### PR TITLE
Fix Ghostrick Scare's number of targets 

### DIFF
--- a/script/c86516889.lua
+++ b/script/c86516889.lua
@@ -1,0 +1,36 @@
+--ゴーストリック・パニック
+function c86516889.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_POSITION)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,0x1e0)
+	e1:SetTarget(c86516889.target)
+	e1:SetOperation(c86516889.activate)
+	c:RegisterEffect(e1)
+end
+function c86516889.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFacedown() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFacedown,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEDOWN)
+	local g=Duel.SelectTarget(tp,Card.IsFacedown,tp,LOCATION_MZONE,0,1,99,nil)
+	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,g:GetCount(),0,0)
+end
+function c86516889.filter(c,e)
+	return c:IsFacedown() and c:IsRelateToEffect(e)
+end
+function c86516889.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(c86516889.filter,nil,e)
+	Duel.ChangePosition(g,POS_FACEUP_DEFENSE)
+	local ct=g:FilterCount(Card.IsSetCard,nil,0x8d)
+	if ct>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_POSCHANGE)
+		local sg=Duel.SelectMatchingCard(tp,Card.IsCanTurnSet,tp,0,LOCATION_MZONE,1,ct,nil)
+		if sg:GetCount()>0 then
+			Duel.HintSelection(sg)
+			Duel.ChangePosition(sg,POS_FACEDOWN_DEFENSE)
+		end
+	end
+end


### PR DESCRIPTION
Now the maximum number of targets is 7 (5 Main Monster Zones and 2 Extra Monster Zones)