### PR TITLE
Fix interactions with cards that prevent banishing

### DIFF
--- a/script/c30241314.lua
+++ b/script/c30241314.lua
@@ -1,0 +1,42 @@
+--マクロコスモス
+function c30241314.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c30241314.target)
+	e1:SetOperation(c30241314.activate)
+	c:RegisterEffect(e1)
+	--remove
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetProperty(EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_IGNORE_RANGE+EFFECT_FLAG_IGNORE_IMMUNE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+	e2:SetTargetRange(0xff,0xff)
+	e2:SetValue(LOCATION_REMOVED)
+	e2:SetTarget(c30241314.rmtg)
+	c:RegisterEffect(e2)
+end
+function c30241314.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,0,tp,LOCATION_DECK)
+end
+function c30241314.filter(c,e,sp)
+	return c:IsCode(54493213) and c:IsCanBeSpecialSummoned(e,0,sp,false,false)
+end
+function c30241314.activate(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local cg=Duel.GetMatchingGroup(c30241314.filter,tp,LOCATION_DECK+LOCATION_HAND,0,nil,e,tp)
+	if cg:GetCount()>0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
+		if Duel.SelectYesNo(tp, aux.Stringid(30241314,0)) then
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+			local sg=cg:Select(tp,1,1,nil)
+			Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
+		end
+	end
+end
+function c30241314.rmtg(e,c)
+	return Duel.IsPlayerCanRemove(e:GetHandlerPlayer(),c)
+end

--- a/script/c31849106.lua
+++ b/script/c31849106.lua
@@ -1,0 +1,23 @@
+--異次元グランド
+function c31849106.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetOperation(c31849106.activate)
+	c:RegisterEffect(e1)
+end
+function c31849106.activate(e,tp,eg,ep,ev,re,r,rp)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_IGNORE_RANGE+EFFECT_FLAG_IGNORE_IMMUNE)
+	e1:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+	e1:SetTarget(c31849106.rmtarget)
+	e1:SetTargetRange(0xff,0xff)
+	e1:SetValue(LOCATION_REMOVED)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end
+function c31849106.rmtarget(e,c)
+	return not c:IsLocation(0x80) and not c:IsType(TYPE_SPELL+TYPE_TRAP) and Duel.IsPlayerCanRemove(e:GetHandlerPlayer(),c)
+end

--- a/script/c33776734.lua
+++ b/script/c33776734.lua
@@ -1,0 +1,81 @@
+--ハネクリボー LV9
+function c33776734.initial_effect(c)
+	c:SetUniqueOnField(1,0,33776734)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(33776734,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c33776734.spcon)
+	e1:SetTarget(c33776734.sptg)
+	e1:SetOperation(c33776734.spop)
+	c:RegisterEffect(e1)
+	--remove
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e2:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e2:SetTarget(c33776734.rmtarget)
+	e2:SetValue(LOCATION_REMOVED)
+	c:RegisterEffect(e2)
+	--atk,def
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetCode(EFFECT_SET_ATTACK)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetValue(c33776734.val)
+	c:RegisterEffect(e3)
+	local e4=e3:Clone()
+	e4:SetCode(EFFECT_SET_DEFENSE)
+	c:RegisterEffect(e4)
+	if not c33776734.global_check then
+		c33776734.global_check=true
+		local ge1=Effect.CreateEffect(c)
+		ge1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		ge1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		ge1:SetCode(EVENT_CHAINING)
+		ge1:SetOperation(c33776734.checkop1)
+		Duel.RegisterEffect(ge1,0)
+		local ge2=ge1:Clone()
+		ge2:SetCode(EVENT_CHAIN_NEGATED)
+		ge2:SetOperation(c33776734.checkop2)
+		Duel.RegisterEffect(ge2,0)
+	end
+end
+c33776734.lvupcount=1
+c33776734.lvup={33776734}
+function c33776734.checkop1(e,tp,eg,ep,ev,re,r,rp)
+	if re and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_SPELL) then
+		re:GetHandler():RegisterFlagEffect(33776734,RESET_EVENT+0x1fe0000,0,1)
+	end
+end
+function c33776734.checkop2(e,tp,eg,ep,ev,re,r,rp)
+	if re and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_SPELL) then
+		re:GetHandler():ResetFlagEffect(33776734)
+	end
+end
+function c33776734.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentChain()>=2
+end
+function c33776734.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetFlagEffect(tp,33776734)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+	Duel.RegisterFlagEffect(tp,33776734,RESET_CHAIN,0,0)
+end
+function c33776734.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
+end
+function c33776734.rmtarget(e,c)
+	return c:IsFaceup() and c:GetFlagEffect(33776734)>0 and Duel.IsPlayerCanRemove(e:GetHandlerPlayer(),c)
+end
+function c33776734.val(e,c)
+	return Duel.GetMatchingGroupCount(Card.IsType,c:GetControler(),0,LOCATION_GRAVE,nil,TYPE_SPELL)*500
+end

--- a/script/c46502744.lua
+++ b/script/c46502744.lua
@@ -1,0 +1,79 @@
+--応戦するG
+function c46502744.initial_effect(c)
+	--spsummon
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c46502744.spcon)
+	e1:SetCost(c46502744.spcost)
+	e1:SetTarget(c46502744.sptg)
+	e1:SetOperation(c46502744.spop)
+	c:RegisterEffect(e1)
+	--remove
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetProperty(EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_IGNORE_RANGE+EFFECT_FLAG_IGNORE_IMMUNE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+	e2:SetTargetRange(0xff,0xff)
+	e1:SetTarget(c46502744.rmtarget)
+	e2:SetCondition(c46502744.remcon)
+	e2:SetValue(LOCATION_REMOVED)
+	c:RegisterEffect(e2)
+	--to hand
+	local e3=Effect.CreateEffect(c)
+	e3:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetCode(EVENT_TO_GRAVE)
+	e3:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e3:SetCondition(c46502744.thcon)
+	e3:SetTarget(c46502744.thtg)
+	e3:SetOperation(c46502744.thop)
+	c:RegisterEffect(e3)
+end
+function c46502744.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return ep~=tp and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_SPELL) and re:IsHasCategory(CATEGORY_SPECIAL_SUMMON)
+end
+function c46502744.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(46502744)==0 end
+	e:GetHandler():RegisterFlagEffect(46502744,RESET_CHAIN,0,1)
+end
+function c46502744.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c46502744.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummonStep(c,0,tp,tp,false,false,POS_FACEUP)~=0 then
+		c:RegisterFlagEffect(46502745,RESET_EVENT+0xfe0000,0,1)
+		Duel.SpecialSummonComplete()
+	end
+end
+function c46502744.rmtarget(e,c)
+	return Duel.IsPlayerCanRemove(e:GetHandlerPlayer(),c)
+end
+function c46502744.remcon(e)
+	return e:GetHandler():GetFlagEffect(46502745)~=0
+end
+function c46502744.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
+end
+function c46502744.thfilter(c)
+	return c:IsRace(RACE_INSECT) and c:IsAttribute(ATTRIBUTE_EARTH) and c:IsAttackBelow(1500) and not c:IsCode(46502744) and c:IsAbleToHand()
+end
+function c46502744.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c46502744.thfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c46502744.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c46502744.thfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c58481572.lua
+++ b/script/c58481572.lua
@@ -1,0 +1,54 @@
+--M・HERO ダーク・ロウ
+function c58481572.initial_effect(c)
+	c:EnableReviveLimit()
+	--spsummon condition
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--remove
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetProperty(EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_IGNORE_RANGE+EFFECT_FLAG_IGNORE_IMMUNE)
+	e2:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(0,0xff)
+	e2:SetValue(LOCATION_REMOVED)
+	e2:SetTarget(c58481572.rmtg)
+	c:RegisterEffect(e2)
+	--handes
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(58481572,0))
+	e3:SetCategory(CATEGORY_REMOVE)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e3:SetProperty(EFFECT_FLAG_DELAY)
+	e3:SetCode(EVENT_TO_HAND)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCountLimit(1)
+	e3:SetCondition(c58481572.hdcon)
+	e3:SetTarget(c58481572.hdtg)
+	e3:SetOperation(c58481572.hdop)
+	c:RegisterEffect(e3)
+end
+function c58481572.rmtg(e,c)
+	return c:GetOwner()~=e:GetHandlerPlayer() and Duel.IsPlayerCanRemove(e:GetHandlerPlayer(),c)
+end
+function c58481572.cfilter(c,tp)
+	return c:IsControler(tp) and c:IsPreviousLocation(LOCATION_DECK)
+end
+function c58481572.hdcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DRAW and eg:IsExists(c58481572.cfilter,1,nil,1-tp)
+end
+function c58481572.hdtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and e:GetHandler():IsFaceup() 
+		and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_HAND,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,1,tp,LOCATION_HAND)
+end
+function c58481572.hdop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,0,LOCATION_HAND,nil)
+	if g:GetCount()>0 then
+		local sg=g:RandomSelect(tp,1)
+		Duel.Remove(sg,POS_FACEUP,REASON_EFFECT)
+	end
+end

--- a/script/c61528025.lua
+++ b/script/c61528025.lua
@@ -1,0 +1,16 @@
+--光の追放者
+function c61528025.initial_effect(c)
+	--remove
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_IGNORE_RANGE+EFFECT_FLAG_IGNORE_IMMUNE)
+	e1:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(0xff,0xff)
+	e1:SetTarget(c61528025.rmtarget)
+	e1:SetValue(LOCATION_REMOVED)
+	c:RegisterEffect(e1)
+end
+function c61528025.rmtarget(e,c)
+	return Duel.IsPlayerCanRemove(e:GetHandlerPlayer(),c)
+end

--- a/script/c69072185.lua
+++ b/script/c69072185.lua
@@ -1,0 +1,58 @@
+--アモルファージ・イリテュム
+function c69072185.initial_effect(c)
+	--pendulum summon
+	aux.EnablePendulumAttribute(c)
+	--maintain
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetRange(LOCATION_PZONE)
+	e1:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c69072185.descon)
+	e1:SetOperation(c69072185.desop)
+	c:RegisterEffect(e1)
+	--spsummon limit
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetTargetRange(1,1)
+	e2:SetTarget(c69072185.sumlimit)
+	c:RegisterEffect(e2)
+	--remove
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetProperty(EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_IGNORE_RANGE+EFFECT_FLAG_IGNORE_IMMUNE)
+	e3:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+	e3:SetRange(LOCATION_PZONE)
+	e3:SetCondition(c69072185.rmcon)
+	e3:SetTarget(c69072185.rmtarget)
+	e3:SetTargetRange(0xff,0xff)
+	e3:SetValue(LOCATION_REMOVED)
+	c:RegisterEffect(e3)
+end
+function c69072185.descon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp
+end
+function c69072185.desop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	Duel.HintSelection(Group.FromCards(c))
+	if Duel.CheckReleaseGroup(tp,Card.IsReleasableByEffect,1,c) and Duel.SelectYesNo(tp,aux.Stringid(69072185,0)) then
+		local g=Duel.SelectReleaseGroup(tp,Card.IsReleasableByEffect,1,1,c)
+		Duel.Release(g,REASON_COST)
+	else Duel.Destroy(c,REASON_COST) end
+end
+function c69072185.sumlimit(e,c,sump,sumtype,sumpos,targetp,se)
+	return c:IsLocation(LOCATION_EXTRA) and not c:IsSetCard(0xe0)
+end
+function c69072185.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0xe0)
+end
+function c69072185.rmcon(e)
+	return Duel.IsExistingMatchingCard(c69072185.cfilter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,nil)
+end
+function c69072185.rmtarget(e,c)
+	return not c:IsSetCard(0xe0) and Duel.IsPlayerCanRemove(e:GetHandlerPlayer(),c)
+end

--- a/script/c79606837.lua
+++ b/script/c79606837.lua
@@ -1,0 +1,78 @@
+--虹光の宣告者
+function c79606837.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,nil,1,1,aux.NonTuner(nil),1,99)
+	c:EnableReviveLimit()
+	--remove
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
+	e1:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTarget(c79606837.rmtarget)
+	e1:SetTargetRange(LOCATION_HAND+LOCATION_DECK,LOCATION_HAND+LOCATION_DECK)
+	e1:SetValue(LOCATION_REMOVED)
+	c:RegisterEffect(e1)
+	--negate
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(79606837,0))
+	e2:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_CHAINING)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c79606837.discon)
+	e2:SetCost(c79606837.discost)
+	e2:SetTarget(c79606837.distg)
+	e2:SetOperation(c79606837.disop)
+	c:RegisterEffect(e2)
+	--tohand
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(79606837,1))
+	e3:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetCode(EVENT_TO_GRAVE)
+	e3:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e3:SetTarget(c79606837.thtg)
+	e3:SetOperation(c79606837.thop)
+	c:RegisterEffect(e3)
+end
+function c79606837.rmtarget(e,c)
+	return c:IsType(TYPE_MONSTER) and Duel.IsPlayerCanRemove(e:GetHandlerPlayer(),c)
+end
+function c79606837.discon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsStatus(STATUS_BATTLE_DESTROYED) then return false end
+	return (re:IsActiveType(TYPE_MONSTER) or re:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(ev)
+end
+function c79606837.discost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsReleasable() end
+	Duel.Release(e:GetHandler(),REASON_COST)
+end
+function c79606837.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
+end
+function c79606837.disop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
+		Duel.Destroy(eg,REASON_EFFECT)
+	end
+end
+function c79606837.filter(c)
+	return c:IsType(TYPE_RITUAL) and c:IsAbleToHand()
+end
+function c79606837.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c79606837.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c79606837.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c79606837.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c93449450.lua
+++ b/script/c93449450.lua
@@ -1,0 +1,84 @@
+--F.A. Hang On Mach
+function c93449450.initial_effect(c)
+	--atk up
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetValue(c93449450.atkval)
+	c:RegisterEffect(e1)
+	--immune
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_IMMUNE_EFFECT)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetValue(c93449450.immval)
+	c:RegisterEffect(e2)
+	--lv up
+	local e0=Effect.CreateEffect(c)
+	e0:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e0:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e0:SetCode(EVENT_CHAINING)
+	e0:SetRange(LOCATION_MZONE)
+	e0:SetOperation(aux.chainreg)
+	c:RegisterEffect(e0)
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(93449450,0))
+	e3:SetCategory(CATEGORY_LVCHANGE)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e3:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
+	e3:SetCode(EVENT_CHAIN_SOLVING)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCondition(c93449450.lvcon)
+	e3:SetOperation(c93449450.lvop)
+	c:RegisterEffect(e3)
+	--redirect
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetProperty(EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_IGNORE_RANGE+EFFECT_FLAG_IGNORE_IMMUNE)
+	e4:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCondition(c93449450.excon)
+	e4:SetTarget(c93449450.extg)
+	e4:SetTargetRange(0xff,0xff)
+	e4:SetValue(LOCATION_REMOVED)
+	c:RegisterEffect(e4)
+end
+function c93449450.atkval(e,c)
+	return c:GetLevel()*300
+end
+function c93449450.immval(e,te)
+	if te:GetOwner()~=e:GetHandler() and te:IsActiveType(TYPE_MONSTER) and te:IsActivated() then
+		local lv=e:GetHandler():GetLevel()
+		local tc=te:GetHandler()
+		if tc:GetRank()>0 then
+			return tc:GetOriginalRank()<lv
+		elseif tc:GetLevel()>0 then
+			return tc:GetOriginalLevel()<lv
+		else return false end
+	else return false end
+end
+function c93449450.lvcon(e,tp,eg,ep,ev,re,r,rp)
+	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and re:GetHandler():IsSetCard(0x107) and e:GetHandler():GetFlagEffect(1)>0
+end
+function c93449450.lvop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and c:IsFaceup() then
+		local e4=Effect.CreateEffect(c)
+		e4:SetType(EFFECT_TYPE_SINGLE)
+		e4:SetCode(EFFECT_UPDATE_LEVEL)
+		e4:SetValue(1)
+		e4:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+		e4:SetRange(LOCATION_MZONE)
+		e4:SetReset(RESET_EVENT+0x1ff0000)
+		c:RegisterEffect(e4)
+	end
+end
+function c93449450.excon(e)
+	return e:GetHandler():IsLevelAbove(7)
+end
+function c93449450.extg(e,c)
+	return c:GetOwner()~=e:GetHandlerPlayer() and Duel.IsPlayerCanRemove(e:GetHandlerPlayer(),c)
+end

--- a/script/c94853057.lua
+++ b/script/c94853057.lua
@@ -1,0 +1,16 @@
+--閃光の追放者
+function c94853057.initial_effect(c)
+	--remove
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_SET_AVAILABLE+EFFECT_FLAG_IGNORE_RANGE+EFFECT_FLAG_IGNORE_IMMUNE)
+	e1:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(0xff,0xff)
+	e1:SetTarget(c94853057.rmtarget)
+	e1:SetValue(LOCATION_REMOVED)
+	c:RegisterEffect(e1)
+end
+function c94853057.rmtarget(e,c)
+	return Duel.IsPlayerCanRemove(e:GetHandlerPlayer(),c)
+end


### PR DESCRIPTION
Now certain cards should correctly prevent "banished instead" effects, e.g. Chaos Hunter