### PR TITLE
Ruling Update + cleanup

### DIFF
--- a/script/c11961740.lua
+++ b/script/c11961740.lua
@@ -1,0 +1,54 @@
+--タイムカプセル
+function c11961740.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c11961740.target)
+	e1:SetOperation(c11961740.activate)
+	c:RegisterEffect(e1)
+end
+function c11961740.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,nil,1,tp,LOCATION_DECK)
+end
+function c11961740.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and not c:IsStatus(STATUS_LEAVE_CONFIRMED) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+		local g=Duel.SelectMatchingCard(tp,Card.IsAbleToRemove,tp,LOCATION_DECK,0,1,1,nil)
+		local tc=g:GetFirst()
+		if tc and Duel.Remove(tc,POS_FACEDOWN,REASON_EFFECT)~=0 and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+			tc:RegisterFlagEffect(11961740,RESET_EVENT+0x1fe0000,0,1)
+			local e1=Effect.CreateEffect(c)
+			e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+			e1:SetRange(LOCATION_SZONE)
+			e1:SetCode(EVENT_PHASE+PHASE_STANDBY)
+			e1:SetCountLimit(1)
+			e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_STANDBY+RESET_SELF_TURN,2)
+			e1:SetCondition(c11961740.thcon)
+			e1:SetOperation(c11961740.thop)
+			e1:SetLabel(0)
+			e1:SetLabelObject(tc)
+			c:RegisterEffect(e1)
+		else
+			c:CancelToGrave(false)
+		end
+	end
+end
+function c11961740.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp
+end
+function c11961740.thop(e,tp,eg,ep,ev,re,r,rp)
+	local ct=e:GetLabel()
+	e:GetHandler():SetTurnCounter(ct+1)
+	if ct==1 then
+		Duel.Destroy(e:GetHandler(),REASON_RULE)
+		local tc=e:GetLabelObject()
+		if tc:GetFlagEffect(11961740)~=0 then
+			Duel.SendtoHand(tc,nil,REASON_EFFECT)
+		end
+	else e:SetLabel(1) end
+end

--- a/script/c13317419.lua
+++ b/script/c13317419.lua
@@ -1,0 +1,105 @@
+--ロケットハンド
+function c13317419.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCountLimit(1,13317419)
+	e1:SetCondition(c13317419.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c13317419.target)
+	e1:SetOperation(c13317419.operation)
+	c:RegisterEffect(e1)
+	--destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_DESTROY+CATEGORY_ATKCHANGE)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCountLimit(1,13317419)
+	e2:SetCondition(c13317419.descon)
+	e2:SetCost(c13317419.descost)
+	e2:SetTarget(c13317419.destg)
+	e2:SetOperation(c13317419.desop)
+	c:RegisterEffect(e2)
+end
+function c13317419.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c13317419.filter(c)
+	return c:IsPosition(POS_FACEUP_ATTACK) and c:IsAttackAbove(800)
+end
+function c13317419.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c13317419.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) 
+		and Duel.IsExistingTarget(c13317419.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c13317419.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c13317419.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) then
+		Duel.Equip(tp,c,tc)
+		--Atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(800)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(1)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c13317419.descon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetEquipTarget()
+end
+function c13317419.descost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
+	e:SetLabelObject(e:GetHandler():GetEquipTarget())
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
+end
+function c13317419.desfilter(c)
+	return c:IsFaceup()
+end
+function c13317419.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and c13317419.desfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c13317419.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c13317419.desfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c13317419.desop(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetLabelObject()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)~=0
+		and ec and ec:IsFaceup() and ec:IsLocation(LOCATION_MZONE) then
+		Duel.BreakEffect()
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+		e1:SetValue(0)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		ec:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(e:GetHandler())
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_CANNOT_CHANGE_POSITION)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		ec:RegisterEffect(e2)
+	end
+end

--- a/script/c15684835.lua
+++ b/script/c15684835.lua
@@ -1,0 +1,80 @@
+--イービル・ブラスト
+function c15684835.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c15684835.target)
+	e1:SetOperation(c15684835.operation)
+	c:RegisterEffect(e1)
+end
+function c15684835.filter(c,e,tp)
+	return c:IsFaceup() and c:IsControler(1-tp) and c:IsCanBeEffectTarget(e)
+end
+function c15684835.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return eg:IsContains(chkc) and c15684835.filter(chkc,e,tp) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and eg:IsExists(c15684835.filter,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=eg:FilterSelect(tp,c15684835.filter,1,1,nil,e,tp)
+	Duel.SetTargetCard(g)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c15684835.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--damage
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(15684835,0))
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e1:SetCode(EVENT_PHASE+PHASE_STANDBY)
+		e1:SetRange(LOCATION_SZONE)
+		e1:SetCountLimit(1)
+		e1:SetCondition(c15684835.damcon)
+		e1:SetTarget(c15684835.damtg)
+		e1:SetOperation(c15684835.damop)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Atkup
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetValue(500)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(c15684835.eqlimit)
+		e3:SetLabelObject(tc)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c15684835.eqlimit(e,c)
+	return c==e:GetLabelObject()
+end
+function c15684835.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp
+end
+function c15684835.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(500)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,500)
+end
+function c15684835.damop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/script/c18096222.lua
+++ b/script/c18096222.lua
@@ -1,0 +1,88 @@
+--デュアル・ブースター
+function c18096222.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c18096222.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c18096222.target)
+	e1:SetOperation(c18096222.operation)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(18096222,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCondition(c18096222.dacon)
+	e2:SetTarget(c18096222.datg)
+	e2:SetOperation(c18096222.daop)
+	c:RegisterEffect(e2)
+end
+function c18096222.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c18096222.filter(c)
+	return c:IsFaceup() and c:IsType(TYPE_DUAL)
+end
+function c18096222.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c18096222.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c18096222.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c18096222.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c18096222.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--Atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(700)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(c18096222.eqlimit)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c18096222.eqlimit(e,c)
+	return c:GetControler()==e:GetOwnerPlayer() and c:IsType(TYPE_DUAL)
+end
+function c18096222.dacon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local ec=c:GetEquipTarget()
+	if c:IsReason(REASON_LOST_TARGET) then
+		ec=c:GetPreviousEquipTarget()
+	end
+	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_DESTROY) and ec~=nil
+end
+function c18096222.dafilter(c)
+	return c:IsFaceup() and c:IsType(TYPE_DUAL) and not c:IsDualState()
+end
+function c18096222.datg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c18096222.dafilter(chkc) end
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c18096222.dafilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+end
+function c18096222.daop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and c18096222.dafilter(tc) then
+		tc:EnableDualState()
+	end
+end

--- a/script/c18446701.lua
+++ b/script/c18446701.lua
@@ -1,0 +1,52 @@
+--ガガガシールド
+function c18446701.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c18446701.target)
+	e1:SetOperation(c18446701.operation)
+	c:RegisterEffect(e1)
+end
+function c18446701.filter(c)
+	return c:IsFaceup() and c:IsRace(RACE_SPELLCASTER)
+end
+function c18446701.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c18446701.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c18446701.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c18446701.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c18446701.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(c:GetControler()) then
+		Duel.Equip(tp,c,tc)
+		--draw
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_INDESTRUCTABLE_COUNT)
+		e1:SetCountLimit(2)
+		e1:SetValue(1)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(c18446701.eqlimit)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c18446701.eqlimit(e,c)
+	return c:GetControler()==e:GetOwnerPlayer() and c:IsRace(RACE_SPELLCASTER)
+end

--- a/script/c20007374.lua
+++ b/script/c20007374.lua
@@ -1,0 +1,132 @@
+--集いし願い
+function c20007374.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c20007374.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c20007374.target)
+	e1:SetOperation(c20007374.activate)
+	c:RegisterEffect(e1)
+	--atk up
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetValue(c20007374.atkval)
+	c:RegisterEffect(e2)
+	--chain attack
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(20007374,0))
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_BATTLE_DESTROYING)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCondition(c20007374.cacon)
+	e4:SetCost(c20007374.cacost)
+	e4:SetTarget(c20007374.catg)
+	e4:SetOperation(c20007374.caop)
+	c:RegisterEffect(e4)
+end
+function c20007374.cfilter(c)
+	return c:IsType(TYPE_SYNCHRO) and c:IsRace(RACE_DRAGON)
+end
+function c20007374.condition(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c20007374.cfilter,tp,LOCATION_GRAVE,0,nil)
+	return g:GetClassCount(Card.GetCode)>=5
+end
+function c20007374.filter(c,e,tp)
+	return c:IsCode(44508094) and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_SYNCHRO,tp,false,false)
+end
+function c20007374.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCountFromEx(tp)>0
+		and Duel.IsExistingMatchingCard(c20007374.filter,tp,LOCATION_EXTRA,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_EXTRA)
+end
+function c20007374.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if Duel.GetLocationCountFromEx(tp)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c20007374.filter,tp,LOCATION_EXTRA,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc and Duel.SpecialSummonStep(tc,SUMMON_TYPE_SYNCHRO,tp,tp,false,false,POS_FACEUP) then
+		if c:IsRelateToEffect(e) and not c:IsStatus(STATUS_LEAVE_CONFIRMED) then
+			Duel.Equip(tp,c,tc)
+			--Add Equip limit
+			local e1=Effect.CreateEffect(tc)
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_EQUIP_LIMIT)
+			e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			e1:SetValue(c20007374.eqlimit)
+			c:RegisterEffect(e1)
+		end
+		local fid=c:GetFieldID()
+		tc:RegisterFlagEffect(20007374,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1,fid)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e2:SetCode(EVENT_PHASE+PHASE_END)
+		e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+		e2:SetCountLimit(1)
+		e2:SetLabel(fid)
+		e2:SetLabelObject(tc)
+		e2:SetCondition(c20007374.rmcon)
+		e2:SetOperation(c20007374.rmop)
+		Duel.RegisterEffect(e2,tp)
+		Duel.SpecialSummonComplete()
+		tc:CompleteProcedure()
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c20007374.eqlimit(e,c)
+	return e:GetOwner()==c
+end
+function c20007374.rmcon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	if tc:GetFlagEffectLabel(20007374)~=e:GetLabel() then
+		e:Reset()
+		return false
+	else return true end
+end
+function c20007374.rmop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)
+end
+function c20007374.atkfilter(c)
+	return c20007374.cfilter(c) and c:GetAttack()>0
+end
+function c20007374.atkval(e,c)
+	local g=Duel.GetMatchingGroup(c20007374.atkfilter,e:GetHandlerPlayer(),LOCATION_GRAVE,0,nil)
+	return g:GetSum(Card.GetAttack)
+end
+function c20007374.cacon(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetHandler():GetEquipTarget()
+	return ec and eg:IsContains(ec)
+end
+function c20007374.cafilter(c)
+	return c20007374.cfilter(c) and c:IsAbleToRemoveAsCost() and aux.SpElimFilter(c,true)
+end
+function c20007374.cacost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c20007374.cafilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,e:GetHandler():GetEquipTarget()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c20007374.cafilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,1,e:GetHandler():GetEquipTarget())
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function c20007374.catg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	local ec=c:GetEquipTarget()
+	if chk==0 then return ec:IsChainAttackable(0,true) end
+end
+function c20007374.caop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local ec=c:GetEquipTarget()
+	if not ec or not ec:IsRelateToBattle() then return end
+	Duel.ChainAttack()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_CANNOT_DIRECT_ATTACK)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_BATTLE+PHASE_DAMAGE_CAL)
+	ec:RegisterEffect(e1)
+end

--- a/script/c21350571.lua
+++ b/script/c21350571.lua
@@ -1,0 +1,86 @@
+--幻獣の角
+function c21350571.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c21350571.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c21350571.target)
+	e1:SetOperation(c21350571.operation)
+	c:RegisterEffect(e1)
+end
+function c21350571.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c21350571.filter(c)
+	return c:IsFaceup() and c:IsRace(RACE_BEAST+RACE_BEASTWARRIOR)
+end
+function c21350571.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c21350571.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c21350571.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c21350571.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c21350571.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--draw
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+		e1:SetCategory(CATEGORY_DRAW)
+		e1:SetDescription(aux.Stringid(21350571,0))
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e1:SetCode(EVENT_BATTLE_DESTROYED)
+		e1:SetRange(LOCATION_SZONE)
+		e1:SetCondition(c21350571.drcon)
+		e1:SetTarget(c21350571.drtg)
+		e1:SetOperation(c21350571.drop)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Atkup
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetValue(800)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(c21350571.eqlimit)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c21350571.eqlimit(e,c)
+	return c:IsRace(RACE_BEAST+RACE_BEASTWARRIOR)
+end
+function c21350571.drfilter(c,rc)
+	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:GetReasonCard()==rc
+end
+function c21350571.drcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c21350571.drfilter,1,nil,e:GetHandler():GetEquipTarget())
+end
+function c21350571.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c21350571.drop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
+end

--- a/script/c23122036.lua
+++ b/script/c23122036.lua
@@ -1,0 +1,64 @@
+--陰謀の盾
+function c23122036.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c23122036.target)
+	e1:SetOperation(c23122036.operation)
+	c:RegisterEffect(e1)
+end
+function c23122036.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c23122036.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:GetControler()==c:GetControler() then
+		Duel.Equip(tp,c,tc)
+		--indes
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_INDESTRUCTABLE_COUNT)
+		e1:SetCountLimit(1)
+		e1:SetValue(c23122036.valcon)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e2:SetCode(EVENT_PRE_BATTLE_DAMAGE)
+		e2:SetRange(LOCATION_SZONE)
+		e2:SetCondition(c23122036.damcon)
+		e2:SetOperation(c23122036.damop)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(1)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c23122036.valcon(e,re,r,rp)
+	return r&REASON_BATTLE~=0 and e:GetHandler():GetEquipTarget():IsPosition(POS_FACEUP_ATTACK)
+end
+function c23122036.damcon(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetHandler():GetEquipTarget()
+	return ec and ep==tp and (Duel.GetAttacker()==ec or Duel.GetAttackTarget()==ec)
+end
+function c23122036.damop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChangeBattleDamage(tp,0)
+end

--- a/script/c2542230.lua
+++ b/script/c2542230.lua
@@ -1,0 +1,99 @@
+--スカーレッド・コクーン
+function c2542230.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c2542230.target)
+	e1:SetOperation(c2542230.activate)
+	c:RegisterEffect(e1)
+	--to grave
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetOperation(c2542230.regop)
+	c:RegisterEffect(e2)
+end
+function c2542230.filter(c)
+	return c:IsFaceup() and c:IsRace(RACE_DRAGON) and c:IsType(TYPE_SYNCHRO)
+end
+function c2542230.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c2542230.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) 
+		and Duel.IsExistingTarget(c2542230.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c2542230.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c2542230.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_EQUIP_LIMIT)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetValue(c2542230.eqlimit)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_FIELD)
+		e2:SetCode(EFFECT_DISABLE)
+		e2:SetRange(LOCATION_SZONE)
+		e2:SetTargetRange(0,LOCATION_MZONE)
+		e2:SetCondition(c2542230.discon)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c2542230.eqlimit(e,c)
+	return c:GetControler()==e:GetHandlerPlayer() or e:GetHandler():GetEquipTarget()==c
+end
+function c2542230.discon(e)
+	local ec=e:GetHandler():GetEquipTarget()
+	return Duel.GetAttacker()==ec or Duel.GetAttackTarget()==ec
+end
+function c2542230.regop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(2542230,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetRange(LOCATION_GRAVE)
+	e1:SetHintTiming(TIMING_END_PHASE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c2542230.spcon)
+	e1:SetTarget(c2542230.sptg)
+	e1:SetOperation(c2542230.spop)
+	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+	c:RegisterEffect(e1)
+end
+function c2542230.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()==PHASE_END
+end
+function c2542230.spfilter(c,e,tp)
+	return c:IsCode(70902743) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c2542230.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c2542230.spfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c2542230.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c2542230.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c2542230.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/script/c259314.lua
+++ b/script/c259314.lua
@@ -1,0 +1,66 @@
+--甲虫装機の手甲
+function c259314.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c259314.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c259314.target)
+	e1:SetOperation(c259314.operation)
+	c:RegisterEffect(e1)
+end
+function c259314.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c259314.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x56)
+end
+function c259314.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c259314.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) 
+		and Duel.IsExistingTarget(c259314.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c259314.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c259314.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--Atk/def
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_UPDATE_DEFENSE)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		e1:SetValue(1000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(c259314.eqlimit)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_EQUIP)
+		e3:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		e3:SetValue(c259314.efilter)
+		c:RegisterEffect(e3,true)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c259314.eqlimit(e,c)
+	return c:IsSetCard(0x56)
+end
+function c259314.efilter(e,re,rp)
+	return e:GetHandlerPlayer()~=rp
+end

--- a/script/c26647858.lua
+++ b/script/c26647858.lua
@@ -1,0 +1,55 @@
+--ヒーロー・ヘイロー
+function c26647858.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMING_BATTLE_START)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c26647858.target)
+	e1:SetOperation(c26647858.operation)
+	c:RegisterEffect(e1)
+end
+function c26647858.filter(c)
+	return c:IsFaceup() and c:IsAttackBelow(1500) and c:IsRace(RACE_WARRIOR)
+end
+function c26647858.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c26647858.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c26647858.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c26647858.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c26647858.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--Atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_CANNOT_BE_BATTLE_TARGET)
+		e1:SetValue(c26647858.atval)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(c26647858.eqlimit)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c26647858.eqlimit(e,c)
+	return c:IsAttackBelow(1500) and c:IsRace(RACE_WARRIOR)
+end
+function c26647858.atval(e,c)
+	return c:IsAttackAbove(1900) and not c:IsImmuneToEffect(e)
+end

--- a/script/c30155789.lua
+++ b/script/c30155789.lua
@@ -1,0 +1,67 @@
+--サディスティック・ポーション
+function c30155789.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c30155789.target)
+	e1:SetOperation(c30155789.operation)
+	c:RegisterEffect(e1)
+end
+function c30155789.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+		and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c30155789.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) and not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--draw
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_DAMAGE)
+		e1:SetRange(LOCATION_SZONE)
+		e1:SetOperation(c30155789.damop)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Atkup
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetValue(1000)
+		e2:SetCondition(c30155789.atkcon)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(c30155789.eqlimit)
+		e3:SetLabelObject(tc)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c30155789.eqlimit(e,c)
+	return c==e:GetLabelObject()
+end
+function c30155789.atkcon(e)
+	return e:GetHandler():GetFlagEffect(30155789)~=0
+end
+function c30155789.damop(e,tp,eg,ep,ev,re,r,rp)
+	if r&REASON_EFFECT~=0 and ep~=tp and rp==tp then
+		e:GetHandler():RegisterFlagEffect(30155789,RESET_EVENT+0x1ff0000+RESET_PHASE+PHASE_END,0,1)
+	end
+end

--- a/script/c35146019.lua
+++ b/script/c35146019.lua
@@ -1,6 +1,5 @@
 --オルターガイスト・マテリアリゼーション
 --Altergeist Materialization
---Scripted by Eerie Code
 function c35146019.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -47,11 +46,11 @@ function c35146019.eqlimit(e,c)
 end
 function c35146019.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
 	local tc=Duel.GetFirstTarget()
-	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) then
+	if tc and tc:IsRelateToEffect(e) then
 		if Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_ATTACK)==0 then return end
 		Duel.Equip(tp,c,tc)
-		c:CancelToGrave()
 		--Add Equip limit
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
@@ -61,6 +60,8 @@ function c35146019.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetValue(c35146019.eqlimit)
 		e1:SetLabelObject(tc)
 		c:RegisterEffect(e1)
+	else
+		c:CancelToGrave(false)
 	end
 end
 function c35146019.desop(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c37390589.lua
+++ b/script/c37390589.lua
@@ -1,0 +1,94 @@
+--鎖付きブーメラン
+function c37390589.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c37390589.condition)
+	e1:SetCost(c37390589.cost)
+	e1:SetTarget(c37390589.target)
+	e1:SetOperation(c37390589.operation)
+	c:RegisterEffect(e1)
+end
+function c37390589.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c37390589.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	e:SetLabel(1)
+end
+function c37390589.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then
+		if e:GetLabel()==0 then
+			return false
+		elseif e:GetLabel()==1 then
+			return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup()
+		else return false end
+	end
+	local b1=Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE) and Duel.GetTurnPlayer()~=tp
+		and Duel.GetAttacker():IsLocation(LOCATION_MZONE) and Duel.GetAttacker():IsAttackPos()
+		and Duel.GetAttacker():IsCanChangePosition() and Duel.GetAttacker():IsCanBeEffectTarget(e)
+	local b2=e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil)
+	if chk==0 then return b1 or b2 end
+	local opt=0
+	if b1 and b2 then
+		opt=Duel.SelectOption(tp,aux.Stringid(37390589,0),aux.Stringid(37390589,1),aux.Stringid(37390589,2))
+	elseif b1 then
+		opt=Duel.SelectOption(tp,aux.Stringid(37390589,0))
+	else
+		opt=Duel.SelectOption(tp,aux.Stringid(37390589,1))+1
+	end
+	Duel.SetTargetParam(opt)
+	if opt==0 or opt==2 then
+		Duel.SetTargetCard(Duel.GetAttacker())
+	end
+	if opt==1 or opt==2 then
+		if e:GetLabel()==1 then
+			aux.RemainFieldCost(e,tp,eg,ep,ev,re,r,rp,1)
+		end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+		Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+		Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+	end
+	e:SetLabel(0)
+end
+function c37390589.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local opt=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
+	if opt==0 or opt==2 then
+		local tc=Duel.GetAttacker()
+		if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED) then
+			Duel.ChangePosition(tc,POS_FACEUP_DEFENSE)
+		end
+	end
+	if opt==1 or opt==2 then
+		local tc=Duel.GetFirstTarget()
+		if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+		if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+			Duel.Equip(tp,c,tc)
+			--Atkup
+			local e1=Effect.CreateEffect(c)
+			e1:SetType(EFFECT_TYPE_EQUIP)
+			e1:SetCode(EFFECT_UPDATE_ATTACK)
+			e1:SetValue(500)
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			c:RegisterEffect(e1)
+			--Equip limit
+			local e2=Effect.CreateEffect(c)
+			e2:SetType(EFFECT_TYPE_SINGLE)
+			e2:SetCode(EFFECT_EQUIP_LIMIT)
+			e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e2:SetValue(c37390589.eqlimit)
+			e2:SetReset(RESET_EVENT+0x1fe0000)
+			c:RegisterEffect(e2)
+		else
+			c:CancelToGrave(false)
+		end
+	end
+end
+function c37390589.eqlimit(e,c)
+	return c:GetControler()==e:GetOwnerPlayer()
+end

--- a/script/c38643567.lua
+++ b/script/c38643567.lua
@@ -1,0 +1,94 @@
+--甲虫装機の宝珠
+function c38643567.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c38643567.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c38643567.target)
+	e1:SetOperation(c38643567.operation)
+	c:RegisterEffect(e1)
+end
+function c38643567.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c38643567.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x56)
+end
+function c38643567.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c38643567.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c38643567.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c38643567.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c38643567.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--Atk/def
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(500)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetCode(EFFECT_UPDATE_DEFENSE)
+		e2:SetValue(500)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(c38643567.eqlimit)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+		--negate
+		local e4=Effect.CreateEffect(c)
+		e4:SetDescription(aux.Stringid(38643567,0))
+		e4:SetType(EFFECT_TYPE_QUICK_O)
+		e4:SetCategory(CATEGORY_DISABLE)
+		e4:SetCode(EVENT_CHAINING)
+		e4:SetRange(LOCATION_SZONE)
+		e4:SetCondition(c38643567.ngcon)
+		e4:SetCost(c38643567.ngcost)
+		e4:SetTarget(c38643567.ngtg)
+		e4:SetOperation(c38643567.ngop)
+		e4:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e4)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c38643567.eqlimit(e,c)
+	return c:IsSetCard(0x56)
+end
+function c38643567.ngcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return end
+	local loc,tg=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TARGET_CARDS)
+	local tc=tg:GetFirst()
+	if tg:GetCount()~=1 or not tc:IsLocation(LOCATION_MZONE) or not tc:IsSetCard(0x56) then return false end
+	return Duel.IsChainDisablable(ev) and loc~=LOCATION_DECK
+end
+function c38643567.ngcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
+end
+function c38643567.ngtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+end
+function c38643567.ngop(e,tp,eg,ep,ev,re,r,rp,chk)
+	Duel.NegateEffect(ev)
+end

--- a/script/c43405287.lua
+++ b/script/c43405287.lua
@@ -1,0 +1,86 @@
+--D－チェーン
+function c43405287.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c43405287.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c43405287.target)
+	e1:SetOperation(c43405287.operation)
+	c:RegisterEffect(e1)
+end
+function c43405287.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c43405287.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0xc008)
+end
+function c43405287.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c43405287.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c43405287.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c43405287.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c43405287.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--draw
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(43405287,0))
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+		e1:SetCategory(CATEGORY_DAMAGE)
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e1:SetCode(EVENT_BATTLE_DESTROYED)
+		e1:SetRange(LOCATION_SZONE)
+		e1:SetCondition(c43405287.damcon)
+		e1:SetTarget(c43405287.damtg)
+		e1:SetOperation(c43405287.damop)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Atkup
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetValue(500)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(c43405287.eqlimit)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c43405287.eqlimit(e,c)
+	return c:GetControler()==e:GetOwnerPlayer() and c:IsSetCard(0xc008)
+end
+function c43405287.damfilter(c,rc)
+	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:GetReasonCard()==rc
+end
+function c43405287.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c43405287.damfilter,1,nil,e:GetHandler():GetEquipTarget())
+end
+function c43405287.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(500)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,500)
+end
+function c43405287.damop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/script/c47819246.lua
+++ b/script/c47819246.lua
@@ -1,0 +1,98 @@
+--超量機神剣－マグナスレイヤー
+function c47819246.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c47819246.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c47819246.target)
+	e1:SetOperation(c47819246.operation)
+	c:RegisterEffect(e1)
+	--atk up
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetValue(c47819246.atkval)
+	c:RegisterEffect(e2)
+	--pierce
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_EQUIP)
+	e3:SetCode(EFFECT_PIERCE)
+	c:RegisterEffect(e3)
+	--multi attack
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(47819246,0))
+	e4:SetType(EFFECT_TYPE_QUICK_O)
+	e4:SetCode(EVENT_FREE_CHAIN)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCondition(c47819246.mtcon)
+	e4:SetCost(c47819246.mtcost)
+	e4:SetTarget(c47819246.mttg)
+	e4:SetOperation(c47819246.mtop)
+	c:RegisterEffect(e4)
+end
+function c47819246.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c47819246.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0xdc) and c:IsType(TYPE_XYZ)
+end
+function c47819246.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c47819246.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c47819246.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c47819246.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c47819246.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:GetControler()==c:GetControler() then
+		Duel.Equip(tp,c,tc)
+		--Equip limit
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_EQUIP_LIMIT)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetValue(c47819246.eqlimit)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c47819246.eqlimit(e,c)
+	return c:GetControler()==e:GetOwnerPlayer() and c:IsSetCard(0xdc) and c:IsType(TYPE_XYZ)
+end
+function c47819246.atkval(e,c)
+	return c:GetRank()*100
+end
+function c47819246.mtcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsType(TYPE_EQUIP) and Duel.GetTurnPlayer()==tp and (Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<=PHASE_BATTLE)
+end
+function c47819246.mtcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToGraveAsCost() end
+	Duel.SetTargetCard(c:GetEquipTarget())
+	Duel.SendtoGrave(c,REASON_COST)
+end
+function c47819246.mttg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ec=e:GetHandler():GetEquipTarget()
+	if chk==0 then return ec and not ec:IsHasEffect(EFFECT_EXTRA_ATTACK) end
+end
+function c47819246.mtop(e,tp,eg,ep,ev,re,r,rp)
+	local ec=Duel.GetFirstTarget()
+	if ec and ec:IsLocation(LOCATION_MZONE) and ec:IsFaceup() and ec:IsRelateToEffect(e) then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_EXTRA_ATTACK)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetValue(2)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		ec:RegisterEffect(e1)
+	end
+end

--- a/script/c48497555.lua
+++ b/script/c48497555.lua
@@ -1,0 +1,69 @@
+--くず鉄の像
+function c48497555.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetCountLimit(1,48497555)
+	e1:SetCondition(c48497555.condition)
+	e1:SetCost(c48497555.cost)
+	e1:SetTarget(c48497555.target)
+	e1:SetOperation(c48497555.activate)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e2:SetCountLimit(1,48497556)
+	e2:SetTarget(c48497555.sptg)
+	e2:SetOperation(c48497555.spop)
+	c:RegisterEffect(e2)
+end
+function c48497555.condition(e,tp,eg,ep,ev,re,r,rp)
+	local rc=re:GetHandler()
+	return rc:IsOnField() and rc:IsControler(1-tp) and re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and not re:IsHasType(EFFECT_TYPE_ACTIVATE)
+end
+function c48497555.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+		aux.RemainFieldCost(e,tp,eg,ep,ev,re,r,rp,1)
+	end
+end
+function c48497555.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+end
+function c48497555.activate(e,tp,eg,ep,ev,re,r,rp)
+	if re:GetHandler():IsRelateToEffect(re) then
+		Duel.Destroy(eg,REASON_EFFECT)
+	end
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	if c:IsCanTurnSet() and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+		Duel.BreakEffect()
+		Duel.ChangePosition(c,POS_FACEDOWN)
+		Duel.RaiseEvent(c,EVENT_SSET,e,REASON_EFFECT,tp,tp,0)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c48497555.spfilter(c,e,tp)
+	return c:IsSetCard(0x43) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE)
+end
+function c48497555.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c48497555.spfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c48497555.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c48497555.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c48497555.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
+	end
+end

--- a/script/c49551909.lua
+++ b/script/c49551909.lua
@@ -1,0 +1,88 @@
+--ヒロイック・リベンジ・ソード
+function c49551909.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_BATTLE_PHASE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c49551909.target)
+	e1:SetOperation(c49551909.operation)
+	c:RegisterEffect(e1)
+end
+function c49551909.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x6f)
+end
+function c49551909.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c49551909.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c49551909.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c49551909.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c49551909.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--destroy
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+		e1:SetCategory(CATEGORY_DESTROY)
+		e1:SetDescription(aux.Stringid(49551909,0))
+		e1:SetCode(EVENT_BATTLED)
+		e1:SetRange(LOCATION_SZONE)
+		e1:SetCondition(c49551909.descon)
+		e1:SetTarget(c49551909.destg)
+		e1:SetOperation(c49551909.desop)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--damage
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e2:SetCode(EVENT_PRE_BATTLE_DAMAGE)
+		e2:SetRange(LOCATION_SZONE)
+		e2:SetCondition(c49551909.damcon)
+		e2:SetOperation(c49551909.damop)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(c49551909.eqlimit)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c49551909.eqlimit(e,c)
+	return c:GetControler()==e:GetOwnerPlayer() and c:IsSetCard(0x6f)
+end
+function c49551909.descon(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetHandler():GetEquipTarget()
+	return Duel.GetAttackTarget()==ec or (Duel.GetAttacker()==ec and Duel.GetAttackTarget())
+end
+function c49551909.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,e:GetHandler():GetEquipTarget():GetBattleTarget(),1,0,0)
+end
+function c49551909.desop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local bc=e:GetHandler():GetEquipTarget():GetBattleTarget()
+	if bc and bc:IsRelateToBattle() then
+		Duel.Destroy(bc,REASON_EFFECT)
+	end
+end
+function c49551909.damcon(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetHandler():GetEquipTarget()
+	return ec and ep==tp and (Duel.GetAttacker()==ec or Duel.GetAttackTarget()==ec)
+end
+function c49551909.damop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChangeBattleDamage(1-tp,Duel.GetBattleDamage(tp),false)
+end

--- a/script/c53656677.lua
+++ b/script/c53656677.lua
@@ -1,0 +1,55 @@
+--パワー・フレーム
+function c53656677.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_BE_BATTLE_TARGET)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c53656677.target)
+	e1:SetOperation(c53656677.operation)
+	c:RegisterEffect(e1)
+end
+function c53656677.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc==Duel.GetAttackTarget() end
+	local a=Duel.GetAttacker()
+	local d=Duel.GetAttackTarget()
+	if chk==0 then return d and d:IsControler(tp) and d:IsFaceup() and d:IsCanBeEffectTarget(e)
+		and d:GetAttack()<a:GetAttack() and e:IsHasType(EFFECT_TYPE_ACTIVATE) end
+	Duel.SetTargetCard(d)
+end
+function c53656677.operation(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateAttack()
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		local a=Duel.GetAttacker()
+		local d=Duel.GetAttackTarget()
+		local atk=a:GetAttack()-d:GetAttack()
+		if atk<0 then atk=0 end
+		--Atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(atk)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(c53656677.eqlimit)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		e2:SetLabelObject(tc)
+		c:RegisterEffect(e2)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c53656677.eqlimit(e,c)
+	return c==e:GetLabelObject()
+end

--- a/script/c54451023.lua
+++ b/script/c54451023.lua
@@ -1,0 +1,87 @@
+--植物連鎖
+function c54451023.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c54451023.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c54451023.target)
+	e1:SetOperation(c54451023.operation)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(54451023,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCondition(c54451023.spcon)
+	e2:SetTarget(c54451023.sptg)
+	e2:SetOperation(c54451023.spop)
+	c:RegisterEffect(e2)
+end
+function c54451023.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c54451023.filter(c)
+	return c:IsFaceup() and c:IsRace(RACE_PLANT)
+end
+function c54451023.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c54451023.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c54451023.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c54451023.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c54451023.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--Atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(500)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(c54451023.eqlimit)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c54451023.eqlimit(e,c)
+	return c:GetControler()==e:GetOwnerPlayer() and c:IsRace(RACE_PLANT)
+end
+function c54451023.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetReason()&0x41==0x41 and e:GetHandler():GetEquipTarget()
+end
+function c54451023.spfilter(c,e,tp)
+	return c:IsRace(RACE_PLANT) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c54451023.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c54451023.spfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(c54451023.spfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c54451023.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c54451023.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/script/c57135971.lua
+++ b/script/c57135971.lua
@@ -1,0 +1,115 @@
+--鎖付き真紅眼牙
+function c57135971.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c57135971.target)
+	e1:SetOperation(c57135971.operation)
+	c:RegisterEffect(e1)
+	--sand to grave and equip
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_EQUIP)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetHintTiming(TIMING_DAMAGE_STEP)
+	e2:SetCondition(c57135971.descon)
+	e2:SetCost(c57135971.descost)
+	e2:SetTarget(c57135971.destg)
+	e2:SetOperation(c57135971.desop)
+	c:RegisterEffect(e2)
+end
+function c57135971.filter(c)
+	return c:IsSetCard(0x3b) and c:IsFaceup()
+end
+function c57135971.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return c57135971.filter(chkc) and chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) end
+	if chk==0 then return Duel.IsExistingTarget(c57135971.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c57135971.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c57135971.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_EXTRA_ATTACK_MONSTER)
+		e1:SetValue(1)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(c57135971.eqlimit)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c57135971.eqlimit(e,c)
+	return c:IsSetCard(0x3b)
+end
+function c57135971.descon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetEquipTarget() and (Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated())
+end
+function c57135971.descost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
+	e:SetLabelObject(e:GetHandler():GetEquipTarget())
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
+end
+function c57135971.desfilter(c)
+	return c:IsFaceup() and c:IsType(TYPE_EFFECT)
+end
+function c57135971.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tc=e:GetLabelObject()
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c57135971.desfilter(chkc) and chkc~=tc end
+	if chk==0 then return Duel.IsExistingTarget(c57135971.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,e:GetHandler():GetEquipTarget()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
+	local g=Duel.SelectTarget(tp,c57135971.desfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,tc)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c57135971.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	local c=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and tc and tc:IsLocation(LOCATION_MZONE) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--Atk
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_SET_ATTACK)
+		e1:SetValue(c:GetAttack())
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Def
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetCode(EFFECT_SET_DEFENSE)
+		e2:SetValue(c:GetDefense())
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(c57135971.eqlimit2)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		e3:SetLabelObject(tc)
+		c:RegisterEffect(e3)
+	end
+end
+function c57135971.eqlimit2(e,c)
+	return c==e:GetLabelObject()
+end

--- a/script/c57470761.lua
+++ b/script/c57470761.lua
@@ -1,0 +1,115 @@
+--タイラント・ウィング
+function c57470761.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c57470761.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c57470761.target)
+	e1:SetOperation(c57470761.activate)
+	c:RegisterEffect(e1)
+end
+function c57470761.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c57470761.filter(c)
+	return c:IsFaceup() and c:IsRace(RACE_DRAGON)
+end
+function c57470761.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c57470761.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c57470761.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c57470761.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c57470761.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_EQUIP_LIMIT)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetValue(c57470761.eqlimit)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetValue(400)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		local e3=e2:Clone()
+		e3:SetCode(EFFECT_UPDATE_DEFENSE)
+		c:RegisterEffect(e3)
+		local e4=Effect.CreateEffect(c)
+		e4:SetType(EFFECT_TYPE_EQUIP)
+		e4:SetCode(EFFECT_EXTRA_ATTACK_MONSTER)
+		e4:SetValue(1)
+		e4:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e4)
+		local e7=Effect.CreateEffect(c)
+		e7:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e7:SetCode(EVENT_BATTLE_START)
+		e7:SetRange(LOCATION_SZONE)
+		e7:SetOperation(c57470761.regop)
+		e7:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e7)
+		local e8=Effect.CreateEffect(c)
+		e8:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e8:SetCode(EVENT_EQUIP)
+		e8:SetRange(LOCATION_SZONE)
+		e8:SetOperation(c57470761.resetop)
+		e8:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e8)
+		local e9=Effect.CreateEffect(c)
+		e9:SetCategory(CATEGORY_DESTROY)
+		e9:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+		e9:SetCode(EVENT_PHASE+PHASE_END)
+		e9:SetRange(LOCATION_SZONE)
+		e9:SetCountLimit(1)
+		e9:SetCondition(c57470761.descon)
+		e9:SetTarget(c57470761.destg)
+		e9:SetOperation(c57470761.desop)
+		e9:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e9)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c57470761.eqlimit(e,c)
+	return c:IsRace(RACE_DRAGON)
+end
+function c57470761.regop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local ec=c:GetEquipTarget()
+	if not ec:IsRelateToBattle() then return end
+	local bc=ec:GetBattleTarget()
+	if bc and bc:IsControler(1-tp) and Duel.GetAttacker()==ec then
+		c:RegisterFlagEffect(57470761,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+	end
+end
+function c57470761.resetop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if eg:IsContains(c) then
+		c:ResetFlagEffect(57470761)
+	end
+end
+function c57470761.descon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetFlagEffect(57470761)~=0
+end
+function c57470761.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,e:GetHandler(),1,0,0)
+end
+function c57470761.desop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsRelateToEffect(e) then
+		Duel.Destroy(e:GetHandler(),REASON_EFFECT)
+	end
+end

--- a/script/c58272005.lua
+++ b/script/c58272005.lua
@@ -1,0 +1,84 @@
+--生存競争
+function c58272005.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c58272005.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c58272005.target)
+	e1:SetOperation(c58272005.operation)
+	c:RegisterEffect(e1)
+end
+function c58272005.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c58272005.filter(c)
+	return c:IsFaceup() and c:IsRace(RACE_DINOSAUR)
+end
+function c58272005.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c58272005.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c58272005.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c58272005.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c58272005.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--Atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(1000)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(c58272005.eqlimit)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		--chain attack
+		local e3=Effect.CreateEffect(c)
+		e3:SetDescription(aux.Stringid(58272005,0))
+		e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+		e3:SetRange(LOCATION_SZONE)
+		e3:SetCode(EVENT_BATTLE_DESTROYING)
+		e3:SetCondition(c58272005.atcon)
+		e3:SetOperation(c58272005.atop)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c58272005.eqlimit(e,c)
+	return c:IsRace(RACE_DINOSAUR)
+end
+function c58272005.atcon(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetHandler():GetEquipTarget()
+	if not eg:IsContains(ec) then return false end
+	local bc=ec:GetBattleTarget()
+	return bc:IsLocation(LOCATION_GRAVE) and bc:IsType(TYPE_MONSTER) and ec:IsChainAttackable(2,true) and ec:IsStatus(STATUS_OPPO_BATTLE)
+end
+function c58272005.atop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local ec=c:GetEquipTarget()
+	if not ec:IsRelateToBattle() then return end
+	Duel.ChainAttack()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_CANNOT_DIRECT_ATTACK)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_BATTLE)
+	ec:RegisterEffect(e1)
+end

--- a/script/c6112401.lua
+++ b/script/c6112401.lua
@@ -1,0 +1,82 @@
+--身剣一体
+function c6112401.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c6112401.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c6112401.target)
+	e1:SetOperation(c6112401.operation)
+	c:RegisterEffect(e1)
+end
+function c6112401.condition(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetCurrentPhase()==PHASE_DAMAGE and Duel.IsDamageCalculated() then return false end
+	local g=Duel.GetFieldGroup(tp,LOCATION_MZONE,0)
+	local tc=g:GetFirst()
+	e:SetLabelObject(tc)
+	return g:GetCount()==1 and tc:IsFaceup() and tc:IsSetCard(0x100d)
+end
+function c6112401.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and e:GetLabelObject():IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(e:GetLabelObject())
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c6112401.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=e:GetLabelObject()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--draw
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+		e1:SetCategory(CATEGORY_DRAW)
+		e1:SetDescription(aux.Stringid(6112401,0))
+		e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+		e1:SetCode(EVENT_BATTLE_DESTROYING)
+		e1:SetRange(LOCATION_SZONE)
+		e1:SetCondition(c6112401.drcon)
+		e1:SetTarget(c6112401.drtg)
+		e1:SetOperation(c6112401.drop)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Atkup
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		e2:SetValue(800)
+		c:RegisterEffect(e2)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(c6112401.eqlimit)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c6112401.eqlimit(e,c)
+	return c:IsSetCard(0x100d)
+end
+function c6112401.drcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsContains(e:GetHandler():GetEquipTarget())
+end
+function c6112401.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c6112401.drop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
+end

--- a/script/c62753201.lua
+++ b/script/c62753201.lua
@@ -1,6 +1,5 @@
 --ヴァレル・レフリジェレーション
 --Borrel Refrigeration
---Scripted by Eerie Code
 function c62753201.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -20,6 +19,7 @@ function c62753201.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,c62753201.cfilter,1,nil) end
 	local rg=Duel.SelectReleaseGroup(tp,c62753201.cfilter,1,1,nil)
 	Duel.Release(rg,REASON_COST)
+	aux.RemainFieldCost(e,tp,eg,ep,ev,re,r,rp,1)
 end
 function c62753201.filter(c)
 	return c:IsFaceup() and c:IsType(TYPE_LINK) and (c:IsCode(31833038) or c:IsSetCard(0x10f))
@@ -36,11 +36,10 @@ function c62753201.eqlimit(e,c)
 end
 function c62753201.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsLocation(LOCATION_SZONE) then return end
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
 	local tc=Duel.GetFirstTarget()
-	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		Duel.Equip(tp,c,tc)
-		c:CancelToGrave()
 		--
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
@@ -67,6 +66,8 @@ function c62753201.activate(e,tp,eg,ep,ev,re,r,rp)
 		e3:SetTarget(c62753201.eftg)
 		e3:SetLabelObject(e2)
 		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
 	end
 end
 function c62753201.eftg(e,c)
@@ -80,7 +81,7 @@ function c62753201.indtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c62753201.indop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
@@ -92,4 +93,3 @@ function c62753201.indop(e,tp,eg,ep,ev,re,r,rp)
 		tc:RegisterEffect(e2)
 	end
 end
-

--- a/script/c62868900.lua
+++ b/script/c62868900.lua
@@ -1,0 +1,54 @@
+--D－シールド
+function c62868900.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_BE_BATTLE_TARGET)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCondition(c62868900.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c62868900.target)
+	e1:SetOperation(c62868900.operation)
+	c:RegisterEffect(e1)
+end
+function c62868900.condition(e,tp,eg,ep,ev,re,r,rp)
+	local tc=eg:GetFirst()
+	return tc:IsControler(tp) and tc:IsPosition(POS_FACEUP_ATTACK) and tc:IsCanChangePosition() and tc:IsSetCard(0xc008)
+end
+function c62868900.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc==eg:GetFirst() end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and eg:GetFirst():IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(eg)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c62868900.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.ChangePosition(tc,POS_FACEUP_DEFENSE)
+		Duel.Equip(tp,c,tc)
+		--Atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+		e1:SetValue(1)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(c62868900.eqlimit)
+		e2:SetLabelObject(tc)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c62868900.eqlimit(e,c)
+	return c==e:GetLabelObject()
+end

--- a/script/c63049052.lua
+++ b/script/c63049052.lua
@@ -1,0 +1,86 @@
+--璽律する武神
+function c63049052.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c63049052.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c63049052.target)
+	e1:SetOperation(c63049052.operation)
+	c:RegisterEffect(e1)
+end
+function c63049052.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c63049052.filter(c)
+	return c:IsFaceup() and c:IsRank(4)
+end
+function c63049052.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and c63049052.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c63049052.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c63049052.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c63049052.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) then
+		Duel.Equip(tp,c,tc)
+		--Atk up
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(c63049052.atkval)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--material
+		local e2=Effect.CreateEffect(c)
+		e2:SetDescription(aux.Stringid(63049052,0))
+		e2:SetType(EFFECT_TYPE_QUICK_O)
+		e2:SetCode(EVENT_FREE_CHAIN)
+		e2:SetRange(LOCATION_SZONE)
+		e2:SetCountLimit(1)
+		e2:SetTarget(c63049052.mattg)
+		e2:SetOperation(c63049052.matop)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(c63049052.eqlimit)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c63049052.atkval(e,c)
+	return c:GetOverlayCount()*300
+end
+function c63049052.eqlimit(e,c)
+	return c:GetControler()==e:GetOwnerPlayer() and c:IsType(TYPE_XYZ)
+end
+function c63049052.mfilter(c)
+	return c:IsSetCard(0x88) and c:IsType(TYPE_MONSTER)
+end
+function c63049052.mattg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c63049052.mfilter,tp,LOCATION_HAND,0,1,nil) end
+end
+function c63049052.matop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local ec=e:GetHandler():GetEquipTarget()
+	if not ec then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_XMATERIAL)
+	local g=Duel.SelectMatchingCard(tp,c63049052.mfilter,tp,LOCATION_HAND,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.Overlay(ec,g)
+	end
+end

--- a/script/c6691855.lua
+++ b/script/c6691855.lua
@@ -1,0 +1,67 @@
+--鎖付き尖盾
+function c6691855.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c6691855.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c6691855.target)
+	e1:SetOperation(c6691855.operation)
+	c:RegisterEffect(e1)
+end
+function c6691855.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c6691855.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) 
+		and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c6691855.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--Atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(500)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--def
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetCode(EFFECT_UPDATE_DEFENSE)
+		e2:SetCondition(c6691855.defcon)
+		e2:SetValue(c6691855.defval)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(1)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c6691855.defcon(e)
+	if Duel.GetCurrentPhase()~=PHASE_DAMAGE_CAL then return false end
+	local eq=e:GetHandler():GetEquipTarget()
+	return (eq==Duel.GetAttacker() or eq==Duel.GetAttackTarget()) and eq:IsDefensePos()
+end
+function c6691855.defval(e,c)
+	return c:GetAttack()
+end

--- a/script/c68054593.lua
+++ b/script/c68054593.lua
@@ -1,0 +1,64 @@
+--燃える闘志
+function c68054593.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c68054593.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c68054593.target)
+	e1:SetOperation(c68054593.operation)
+	c:RegisterEffect(e1)
+end
+function c68054593.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c68054593.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c68054593.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--Atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_SET_ATTACK)
+		e1:SetCondition(c68054593.atkcon)
+		e1:SetValue(c68054593.atkval)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(c68054593.eqlimit)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c68054593.eqlimit(e,c)
+	return c:GetControler()==e:GetOwnerPlayer()
+end
+function c68054593.atkfilter(c)
+	return c:IsFaceup() and c:GetAttack()>c:GetBaseAttack()
+end
+function c68054593.atkcon(e)
+	return (Duel.GetCurrentPhase()==PHASE_DAMAGE or Duel.GetCurrentPhase()==PHASE_DAMAGE_CAL)
+		and Duel.IsExistingMatchingCard(c68054593.atkfilter,e:GetHandlerPlayer(),0,LOCATION_MZONE,1,nil)
+end
+function c68054593.atkval(e,c)
+	return c:GetBaseAttack()*2
+end

--- a/script/c68540058.lua
+++ b/script/c68540058.lua
@@ -1,0 +1,68 @@
+--メタル化・魔法反射装甲
+function c68540058.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c68540058.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c68540058.target)
+	e1:SetOperation(c68540058.operation)
+	c:RegisterEffect(e1)
+end
+function c68540058.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c68540058.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c68540058.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--Atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(300)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		local e2=e1:Clone()
+		e2:SetCode(EFFECT_UPDATE_DEFENSE)
+		c:RegisterEffect(e2)
+		--Equip limit
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_SINGLE)
+		e3:SetCode(EFFECT_EQUIP_LIMIT)
+		e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e3:SetValue(1)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+		--atk up
+		local e4=Effect.CreateEffect(c)
+		e4:SetType(EFFECT_TYPE_EQUIP)
+		e4:SetCode(EFFECT_UPDATE_ATTACK)
+		e4:SetCondition(c68540058.atkcon)
+		e4:SetValue(c68540058.atkval)
+		e4:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e4)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c68540058.atkcon(e)
+	return Duel.GetCurrentPhase()==PHASE_DAMAGE_CAL
+		and Duel.GetAttacker()==e:GetHandler():GetEquipTarget() and Duel.GetAttackTarget()
+end
+function c68540058.atkval(e,c)
+	return Duel.GetAttackTarget():GetAttack()/2
+end

--- a/script/c74640994.lua
+++ b/script/c74640994.lua
@@ -1,0 +1,131 @@
+--サブテラーの決戦
+--Subterror Final Battle
+function c74640994.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetCondition(c74640994.condition)
+	e1:SetCost(c74640994.cost)
+	e1:SetTarget(c74640994.target)
+	e1:SetOperation(c74640994.activate)
+	c:RegisterEffect(e1)
+end
+function c74640994.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c74640994.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+		aux.RemainFieldCost(e,tp,eg,ep,ev,re,r,rp,1)
+	end
+end
+function c74640994.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0xed)
+end
+function c74640994.fufilter(c)
+	return c:IsFacedown() and c:IsSetCard(0xed)
+end
+function c74640994.fdfilter(c)
+	return c74640994.filter(c) and c:IsCanTurnSet()
+end
+function c74640994.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local b1=Duel.GetCurrentPhase()~=PHASE_DAMAGE and Duel.IsExistingMatchingCard(c74640994.fufilter,tp,LOCATION_MZONE,0,1,nil)
+	local b2=Duel.GetCurrentPhase()~=PHASE_DAMAGE and Duel.IsExistingMatchingCard(c74640994.fdfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil)
+	local b3=Duel.IsExistingMatchingCard(c74640994.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil)
+	local b4=Duel.GetCurrentPhase()~=PHASE_DAMAGE and Duel.GetFlagEffect(tp,74640994)==0
+	if chk==0 then return b1 or b2 or b3 or b4 end
+	local off=1
+	local ops={}
+	local opval={}
+	if b1 then
+		ops[off]=aux.Stringid(74640994,0)
+		opval[off-1]=1
+		off=off+1
+	end
+	if b2 then
+		ops[off]=aux.Stringid(74640994,1)
+		opval[off-1]=2
+		off=off+1
+	end
+	if b3 then
+		ops[off]=aux.Stringid(74640994,2)
+		opval[off-1]=3
+		off=off+1
+	end
+	if b4 then
+		ops[off]=aux.Stringid(74640994,3)
+		opval[off-1]=4
+		off=off+1
+	end
+	local op=Duel.SelectOption(tp,table.unpack(ops))
+	local sel=opval[op]
+	e:SetLabel(sel)
+	if sel==1 or sel==2 then
+		e:SetCategory(CATEGORY_POSITION)
+		Duel.SetOperationInfo(0,CATEGORY_POSITION,nil,1,0,0)
+	elseif sel==3 then
+		e:SetCategory(CATEGORY_ATKCHANGE+CATEGORY_DEFCHANGE)
+	end
+end
+function c74640994.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local sel=e:GetLabel()
+	if sel==1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_POSCHANGE)
+		local g=Duel.SelectMatchingCard(tp,c74640994.fufilter,tp,LOCATION_MZONE,0,1,1,nil)
+		if g:GetCount()>0 then
+			Duel.HintSelection(g)
+			local tc=g:GetFirst()
+			local pos=Duel.SelectPosition(tp,tc,POS_FACEUP_ATTACK+POS_FACEUP_DEFENSE)
+			Duel.ChangePosition(tc,pos)
+		end
+	elseif sel==2 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_POSCHANGE)
+		local g=Duel.SelectMatchingCard(tp,c74640994.fdfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+		if g:GetCount()>0 then
+			Duel.HintSelection(g)
+			Duel.ChangePosition(g,POS_FACEDOWN_DEFENSE)
+		end
+	elseif sel==3 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+		local g=Duel.SelectMatchingCard(tp,c74640994.filter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+		if g:GetCount()>0 then
+			Duel.HintSelection(g)
+			local tc=g:GetFirst()
+			local atk=tc:GetBaseAttack()+tc:GetBaseDefense()
+			local e1=Effect.CreateEffect(c)
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+			e1:SetValue(atk)
+			e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+			tc:RegisterEffect(e1)
+			local e2=e1:Clone()
+			e2:SetCode(EFFECT_SET_DEFENSE_FINAL)
+			tc:RegisterEffect(e2)
+		end
+	else
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_FIELD)
+		e1:SetCode(EFFECT_CANNOT_DISEFFECT)
+		e1:SetValue(c74640994.effectfilter)
+		e1:SetReset(RESET_PHASE+PHASE_END)
+		Duel.RegisterEffect(e1,tp)
+		Duel.RegisterFlagEffect(tp,74640994,RESET_PHASE+PHASE_END,0,1)
+	end
+	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	if c:IsCanTurnSet() and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+		Duel.BreakEffect()
+		Duel.ChangePosition(c,POS_FACEDOWN)
+		Duel.RaiseEvent(c,EVENT_SSET,e,REASON_EFFECT,tp,tp,0)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c74640994.effectfilter(e,ct)
+	local te=Duel.GetChainInfo(ct,CHAININFO_TRIGGERING_EFFECT)
+	local tc=te:GetHandler()
+	return tc:IsSetCard(0xed)
+end

--- a/script/c75361204.lua
+++ b/script/c75361204.lua
@@ -1,0 +1,133 @@
+--グレイドル・スプリット
+function c75361204.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c75361204.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c75361204.target)
+	e1:SetOperation(c75361204.operation)
+	c:RegisterEffect(e1)
+end
+function c75361204.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c75361204.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c75361204.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsControler(tp) then
+		Duel.Equip(tp,c,tc)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(500)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(1)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		local e3=Effect.CreateEffect(c)
+		e3:SetCategory(CATEGORY_DESTROY+CATEGORY_SPECIAL_SUMMON)
+		e3:SetType(EFFECT_TYPE_QUICK_O)
+		e3:SetRange(LOCATION_SZONE)
+		e3:SetCode(EVENT_FREE_CHAIN)
+		e3:SetCountLimit(1,75361204)
+		e3:SetCondition(c75361204.spcon)
+		e3:SetCost(c75361204.spcost)
+		e3:SetTarget(c75361204.sptg)
+		e3:SetOperation(c75361204.spop)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c75361204.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetEquipTarget() and Duel.GetTurnPlayer()==tp
+		and (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
+end
+function c75361204.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
+	e:SetLabelObject(e:GetHandler():GetEquipTarget())
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
+end
+function c75361204.spfilter1(c,e,tp)
+	return c:IsSetCard(0xd1) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.IsExistingMatchingCard(c75361204.spfilter2,tp,LOCATION_DECK,0,1,nil,e,tp,c:GetCode())
+end
+function c75361204.spfilter2(c,e,tp,code)
+	return c:IsSetCard(0xd1) and not c:IsCode(code) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c75361204.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c75361204.spfilter1,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	local ec=e:GetLabelObject()
+	ec:CreateEffectRelation(e)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,ec,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_DECK)
+end
+function c75361204.spop(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetLabelObject()
+	if ec:IsRelateToEffect(e) and ec:IsFaceup() and Duel.Destroy(ec,REASON_EFFECT)~=0
+		and not Duel.IsPlayerAffectedByEffect(tp,59822133)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1 then
+		local fid=e:GetHandler():GetFieldID()
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g1=Duel.SelectMatchingCard(tp,c75361204.spfilter1,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+		local tc1=g1:GetFirst()
+		if not tc1 then return end
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local g2=Duel.SelectMatchingCard(tp,c75361204.spfilter2,tp,LOCATION_DECK,0,1,1,nil,e,tp,tc1:GetCode())
+		local tc2=g2:GetFirst()
+		Duel.SpecialSummonStep(tc1,0,tp,tp,false,false,POS_FACEUP)
+		Duel.SpecialSummonStep(tc2,0,tp,tp,false,false,POS_FACEUP)
+		tc1:RegisterFlagEffect(75361204,RESET_EVENT+0x1fe0000,0,1,fid)
+		tc2:RegisterFlagEffect(75361204,RESET_EVENT+0x1fe0000,0,1,fid)
+		Duel.SpecialSummonComplete()
+		g1:Merge(g2)
+		g1:KeepAlive()
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+		e1:SetCode(EVENT_PHASE+PHASE_END)
+		e1:SetCountLimit(1)
+		e1:SetLabel(fid)
+		e1:SetLabelObject(g1)
+		e1:SetCondition(c75361204.descon)
+		e1:SetOperation(c75361204.desop)
+		Duel.RegisterEffect(e1,tp)
+	end
+end
+function c75361204.desfilter(c,fid)
+	return c:GetFlagEffectLabel(75361204)==fid
+end
+function c75361204.descon(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetLabelObject()
+	if not g:IsExists(c75361204.desfilter,1,nil,e:GetLabel()) then
+		g:DeleteGroup()
+		e:Reset()
+		return false
+	else return true end
+end
+function c75361204.desop(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetLabelObject()
+	local tg=g:Filter(c75361204.desfilter,nil,e:GetLabel())
+	Duel.Destroy(tg,REASON_EFFECT)
+end

--- a/script/c75987257.lua
+++ b/script/c75987257.lua
@@ -1,0 +1,72 @@
+--隷属の鱗粉
+function c75987257.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_POSITION+CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCondition(c75987257.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c75987257.target)
+	e1:SetOperation(c75987257.operation)
+	c:RegisterEffect(e1)
+	--pos
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(75987257,0))
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCategory(CATEGORY_POSITION)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c75987257.poscon)
+	e2:SetOperation(c75987257.posop)
+	c:RegisterEffect(e2)
+end
+function c75987257.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp
+end
+function c75987257.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tc=Duel.GetAttacker()
+	if chkc then return chkc==tc end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and tc:IsLocation(LOCATION_MZONE) and tc:IsAttackPos()
+		and tc:IsCanChangePosition() and tc:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tc)
+end
+function c75987257.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsAttackable() and not tc:IsStatus(STATUS_ATTACK_CANCELED) then
+		Duel.ChangePosition(tc,POS_FACEUP_DEFENSE)
+		if c:IsRelateToEffect(e) and not c:IsStatus(STATUS_LEAVE_CONFIRMED) then
+			Duel.Equip(tp,c,tc)
+			--Equip limit
+			local e1=Effect.CreateEffect(c)
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_EQUIP_LIMIT)
+			e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e1:SetValue(c75987257.eqlimit)
+			e1:SetLabelObject(tc)
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			c:RegisterEffect(e1)
+		end
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c75987257.eqlimit(e,c)
+	return c==e:GetLabelObject()
+end
+function c75987257.poscon(e,tp,eg,ep,ev,re,r,rp)
+	local ph=Duel.GetCurrentPhase()
+	return ph>=PHASE_MAIN1 and ph<=PHASE_MAIN2 and e:GetHandler():GetEquipTarget()
+end
+function c75987257.posop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	local ec=c:GetEquipTarget()
+	if ec then
+		Duel.ChangePosition(ec,POS_FACEUP_DEFENSE,0,POS_FACEUP_ATTACK,0)
+	end
+end

--- a/script/c78586116.lua
+++ b/script/c78586116.lua
@@ -1,0 +1,81 @@
+--パワーアップ・コネクター
+function c78586116.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c78586116.target)
+	e1:SetOperation(c78586116.operation)
+	c:RegisterEffect(e1)
+	--attack up
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_ATKCHANGE)
+	e2:SetDescription(aux.Stringid(78586116,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_CUSTOM+78586116)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetTarget(c78586116.attg)
+	e2:SetOperation(c78586116.atop)
+	c:RegisterEffect(e2)
+end
+function c78586116.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x26)
+end
+function c78586116.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c78586116.filter(chkc) end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(c78586116.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c78586116.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c78586116.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--Atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_CANNOT_ATTACK)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(c78586116.eqlimit)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		Duel.RaiseSingleEvent(c,EVENT_CUSTOM+78586116,e,0,0,0,0,0)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c78586116.eqlimit(e,c)
+	return c:IsSetCard(0x26)
+end
+function c78586116.attg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local eq=e:GetHandler():GetEquipTarget()
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() and chkc~=eq end
+	if chk==0 then return eq and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,eq) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,eq)
+end
+function c78586116.atop(e,tp,eg,ep,ev,re,r,rp)
+	local eq=e:GetHandler():GetEquipTarget()
+	if not eq then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(eq:GetAttack())
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		tc:RegisterEffect(e1)
+	end
+end

--- a/script/c80143954.lua
+++ b/script/c80143954.lua
@@ -1,0 +1,89 @@
+--オルターガイスト・カモフラージュ
+function c80143954.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c80143954.target)
+	e1:SetOperation(c80143954.activate)
+	c:RegisterEffect(e1)
+	--destroy replace
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EFFECT_DESTROY_REPLACE)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetTarget(c80143954.reptg)
+	e2:SetValue(c80143954.repval)
+	e2:SetOperation(c80143954.repop)
+	c:RegisterEffect(e2)
+end
+function c80143954.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x103)
+end
+function c80143954.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c80143954.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c80143954.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c80143954.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c80143954.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_EQUIP_LIMIT)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetValue(c80143954.eqlimit)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetCode(EFFECT_IGNORE_BATTLE_TARGET)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+		--negate
+		local e4=Effect.CreateEffect(c)
+		e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e4:SetCode(EVENT_CHAIN_SOLVING)
+		e4:SetRange(LOCATION_SZONE)
+		e4:SetLabelObject(tc)
+		e4:SetCondition(c80143954.negcon)
+		e4:SetOperation(c80143954.negop)
+		e4:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e4)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c80143954.eqlimit(e,c)
+	return c:GetControler()==e:GetHandlerPlayer() or e:GetHandler():GetEquipTarget()==c
+end
+function c80143954.negcon(e,tp,eg,ep,ev,re,r,rp)
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	return rp~=tp and re:IsActiveType(TYPE_MONSTER) and g and g:IsContains(e:GetLabelObject())
+end
+function c80143954.negop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateEffect(ev)
+end
+function c80143954.repfilter(c,tp)
+	return c:IsFaceup() and c:IsSetCard(0x103) and c:IsLocation(LOCATION_ONFIELD) and c:IsControler(tp) 
+		and not c:IsReason(REASON_REPLACE) and c:IsReason(REASON_EFFECT+REASON_BATTLE)
+end
+function c80143954.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(c80143954.repfilter,1,nil,tp) end
+	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+end
+function c80143954.repval(e,c)
+	return c80143954.repfilter(c,e:GetHandlerPlayer())
+end
+function c80143954.repop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+end

--- a/script/c87043568.lua
+++ b/script/c87043568.lua
@@ -1,0 +1,86 @@
+--アサルト・スピリッツ
+function c87043568.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c87043568.target)
+	e1:SetOperation(c87043568.operation)
+	c:RegisterEffect(e1)
+end
+function c87043568.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE)
+		and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c87043568.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(87043568,0))
+		e1:SetCategory(CATEGORY_ATKCHANGE)
+		e1:SetType(EFFECT_TYPE_QUICK_O)
+		e1:SetCode(EVENT_FREE_CHAIN)
+		e1:SetHintTiming(TIMING_DAMAGE_STEP)
+		e1:SetRange(LOCATION_SZONE)
+		e1:SetCountLimit(1)
+		e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+		e1:SetCondition(c87043568.atkcon)
+		e1:SetCost(c87043568.atkcost)
+		e1:SetOperation(c87043568.atkop)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(c87043568.eqlimit)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		e2:SetLabelObject(tc)
+		c:RegisterEffect(e2)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c87043568.eqlimit(e,c)
+	return c:GetControler()==e:GetOwnerPlayer() and c==e:GetLabelObject()
+end
+function c87043568.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	local a=Duel.GetAttacker()
+	local ph=Duel.GetCurrentPhase()
+	return a==e:GetHandler():GetEquipTarget()
+		and ph==PHASE_DAMAGE and not Duel.IsDamageCalculated()
+end
+function c87043568.cfilter(c)
+	return c:IsType(TYPE_MONSTER) and c:IsAttackBelow(1000) and c:IsAbleToGraveAsCost()
+end
+function c87043568.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c87043568.cfilter,tp,LOCATION_HAND,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c87043568.cfilter,tp,LOCATION_HAND,0,1,1,nil)
+	e:SetLabel(g:GetFirst():GetAttack())
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c87043568.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local a=Duel.GetAttacker()
+	if c:IsRelateToEffect(e) and a:IsRelateToBattle() and a:IsFaceup() then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		e1:SetValue(e:GetLabel())
+		a:RegisterEffect(e1)
+	end
+end

--- a/script/c879958.lua
+++ b/script/c879958.lua
@@ -1,6 +1,5 @@
 --パラレルポート・アーマー
 --Parallel Port Armor
---Scripted by Larry126
 function c879958.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -8,6 +7,7 @@ function c879958.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCost(aux.RemainFieldCost)
 	e1:SetTarget(c879958.target)
 	e1:SetOperation(c879958.operation)
 	c:RegisterEffect(e1)
@@ -39,11 +39,10 @@ function c879958.eqlimit(e,c)
 end
 function c879958.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsLocation(LOCATION_SZONE) then return end
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
 	local tc=Duel.GetFirstTarget()
-	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		Duel.Equip(tp,c,tc)
-		c:CancelToGrave()
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
@@ -63,6 +62,8 @@ function c879958.operation(e,tp,eg,ep,ev,re,r,rp)
 		e3:SetValue(c879958.eqlimit)
 		e3:SetReset(RESET_EVENT+0x1fe0000)
 		c:RegisterEffect(e3)
+	else
+		c:CancelToGrave(false)
 	end
 end
 function c879958.atcon(e,tp,eg,ep,ev,re,r,rp)
@@ -90,7 +91,7 @@ function c879958.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c879958.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc and tc:IsRelateToEffect(e) then
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_EXTRA_ATTACK)
@@ -100,4 +101,3 @@ function c879958.atkop(e,tp,eg,ep,ev,re,r,rp)
 		tc:RegisterEffect(e1)
 	end
 end
-

--- a/script/c98239899.lua
+++ b/script/c98239899.lua
@@ -1,0 +1,78 @@
+--鎖付き爆弾
+function c98239899.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(TIMING_DAMAGE_STEP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCondition(c98239899.condition)
+	e1:SetCost(aux.RemainFieldCost)
+	e1:SetTarget(c98239899.target)
+	e1:SetOperation(c98239899.operation)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(98239899,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCondition(c98239899.descon)
+	e2:SetTarget(c98239899.destg)
+	e2:SetOperation(c98239899.desop)
+	c:RegisterEffect(e2)
+end
+function c98239899.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
+end
+function c98239899.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
+	if chk==0 then return e:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c98239899.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsLocation(LOCATION_SZONE) or not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+		--Atkup
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_EQUIP)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(500)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e1)
+		--Equip limit
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_EQUIP_LIMIT)
+		e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e2:SetValue(c98239899.eqlimit)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		c:RegisterEffect(e2)
+	else
+		c:CancelToGrave(false)
+	end
+end
+function c98239899.eqlimit(e,c)
+	return c:GetControler()==e:GetOwnerPlayer()
+end
+function c98239899.descon(e,tp,eg,ep,ev,re,r,rp)
+	return r&0x41==0x41 and e:GetHandler():GetEquipTarget()~=nil
+end
+function c98239899.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() end
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c98239899.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end

--- a/script/c98427577.lua
+++ b/script/c98427577.lua
@@ -1,0 +1,40 @@
+--くず鉄のかかし 
+function c98427577.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e1:SetCondition(c98427577.condition)
+	e1:SetCost(c98427577.cost)
+	e1:SetTarget(c98427577.target)
+	e1:SetOperation(c98427577.activate)
+	c:RegisterEffect(e1)
+end
+function c98427577.condition(e,tp,eg,ep,ev,re,r,rp)
+	return tp~=Duel.GetTurnPlayer()
+end
+function c98427577.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+		aux.RemainFieldCost(e,tp,eg,ep,ev,re,r,rp,1)
+	end
+end
+function c98427577.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local tg=Duel.GetAttacker()
+	if chkc then return chkc==tg end
+	if chk==0 then return tg:IsOnField() and tg:IsCanBeEffectTarget(e) end
+	Duel.SetTargetCard(tg)
+end
+function c98427577.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateAttack()
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	if c:IsCanTurnSet() and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+		Duel.BreakEffect()
+		Duel.ChangePosition(c,POS_FACEDOWN)
+		Duel.RaiseEvent(c,EVENT_SSET,e,REASON_EFFECT,tp,tp,0)
+	else
+		c:CancelToGrave(false)
+	end
+end

--- a/script/proc_equip.lua
+++ b/script/proc_equip.lua
@@ -1,0 +1,75 @@
+
+--add procedure to equip spells equipping by rule
+function Auxiliary.AddEquipProcedure(c,p,f,eqlimit,cost,tg,op,con)
+	--Note: p==0 is check equip spell controler, p==1 for opponent's, PLAYER_ALL for both player's monsters
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(1068)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	if con then
+		e1:SetCondition(con)
+	end
+	if cost~=nil then
+		e1:SetCost(cost)
+	end
+	e1:SetTarget(Auxiliary.EquipTarget(tg,p,f))
+	e1:SetOperation(op)
+	c:RegisterEffect(e1)
+	--Equip limit
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_EQUIP_LIMIT)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	if eqlimit~=nil then
+		e2:SetValue(eqlimit)
+	else
+		e2:SetValue(Auxiliary.EquipLimit(f))
+	end
+	c:RegisterEffect(e2)
+end
+function Auxiliary.EquipLimit(f)
+	return function(e,c)
+				return not f or f(c,e,e:GetHandlerPlayer())
+			end
+end
+function Auxiliary.EquipFilter(c,p,f,e,tp)
+	return (p==PLAYER_ALL or c:IsControler(p)) and c:IsFaceup() and (not f or f(c,e,tp))
+end
+function Auxiliary.EquipTarget(tg,p,f)
+	return	function(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+				local player=nil
+				if p==0 then
+					player=tp
+				elseif p==1 then
+					player=1-tp
+				elseif p==PLAYER_ALL or p==nil then
+					player=PLAYER_ALL
+				end
+				if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() and Auxiliary.EquipFilter(chkc,player,f,e,tp) end
+				if chk==0 then return player~=nil and Duel.IsExistingTarget(Auxiliary.EquipFilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,player,f,e,tp) end
+				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+				local g=Duel.SelectTarget(tp,Auxiliary.EquipFilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,player,f,e,tp)
+				if tg then tg(e,tp,eg,ep,ev,re,r,rp,g:GetFirst()) end
+				local e1=Effect.CreateEffect(e:GetHandler())
+				e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+				e1:SetCode(EVENT_CHAIN_SOLVING)
+				e1:SetReset(RESET_CHAIN)
+				e1:SetLabel(Duel.GetCurrentChain())
+				e1:SetLabelObject(e)
+				e1:SetOperation(Auxiliary.EquipEquip)
+				Duel.RegisterEffect(e1,tp)
+				Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+			end
+end
+function Auxiliary.EquipEquip(e,tp,eg,ep,ev,re,r,rp)
+	if re~=e:GetLabelObject() then return end
+	local c=e:GetHandler()
+	local tc=Duel.GetChainInfo(Duel.GetCurrentChain(),CHAININFO_TARGET_CARDS):GetFirst()
+	if tc and c:IsRelateToEffect(re) and tc:IsRelateToEffect(re) and tc:IsFaceup() then
+		Duel.Equip(tp,c,tc)
+	end
+end
+

--- a/script/proc_persistent.lua
+++ b/script/proc_persistent.lua
@@ -1,0 +1,84 @@
+
+--add procedure to persistent traps
+function Auxiliary.AddPersistentProcedure(c,p,f,category,property,hint1,hint2,con,cost,tg,op,anypos)
+	--Note: p==0 is check persistent trap controler, p==1 for opponent's, PLAYER_ALL for both player's monsters
+	--anypos is check for face-up/any
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(1068)
+	if category then
+		e1:SetCategory(category)
+	end
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	if hint1 or hint2 then
+		if hint1==hint2 then
+			e1:SetHintTiming(hint1)
+		elseif hint1 and not hint2 then
+			e1:SetHintTiming(hint1,0)
+		elseif hint2 and not hint1 then
+			e1:SetHintTiming(0,hint2)
+		else
+			e1:SetHintTiming(hint1,hint2)
+		end
+	end
+	if property then
+		e1:SetProperty(EFFECT_FLAG_CARD_TARGET+property)
+	else
+		e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	end
+	if con then
+		e1:SetCondition(con)
+	end
+	if cost then
+		e1:SetCost(cost)
+	end
+	e1:SetTarget(Auxiliary.PersistentTarget(tg,p,f))
+	e1:SetOperation(op)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_CHAIN_SOLVED)
+	e2:SetLabelObject(e1)
+	e2:SetCondition(Auxiliary.PersistentTgCon)
+	e2:SetOperation(Auxiliary.PersistentTgOp(anypos))
+	c:RegisterEffect(e2)
+end
+function Auxiliary.PersistentFilter(c,p,f,e,tp,tg,eg,ep,ev,re,r,rp)
+	return (p==PLAYER_ALL or c:IsControler(p)) and (not f or f(c,e,tp)) and (not tg or tg(e,tp,eg,ep,ev,re,r,rp,c,0))
+end
+function Auxiliary.PersistentTarget(tg,p,f)
+	return	function(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+				local player=nil
+				if p==0 then
+					player=tp
+				elseif p==1 then
+					player=1-tp
+				elseif p==PLAYER_ALL or p==nil then
+					player=PLAYER_ALL
+				end
+				if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() and Auxiliary.PersistentFilter(chkc,player,f,e,tp) end
+				if chk==0 then return Duel.IsExistingTarget(Auxiliary.PersistentFilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,player,f,e,tp,tg,eg,ep,ev,re,r,rp)
+					and player~=nil end
+				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+				local g=Duel.SelectTarget(tp,Auxiliary.PersistentFilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,player,f,e,tp)
+				if tg then tg(e,tp,eg,ep,ev,re,r,rp,g:GetFirst(),1) end
+			end
+end
+function Auxiliary.PersistentTgCon(e,tp,eg,ep,ev,re,r,rp)
+	return re==e:GetLabelObject()
+end
+function Auxiliary.PersistentTgOp(anypos)
+	return function(e,tp,eg,ep,ev,re,r,rp)
+			local c=e:GetHandler()
+			local tc=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS):GetFirst()
+			if c:IsRelateToEffect(re) and tc and (anypos or tc:IsFaceup()) and tc:IsRelateToEffect(re) then
+				c:SetCardTarget(tc)
+			end
+		end
+end
+function Auxiliary.PersistentTargetFilter(e,c)
+	return e:GetHandler():IsHasCardTarget(c)
+end

--- a/script/utility.lua
+++ b/script/utility.lua
@@ -121,19 +121,27 @@ end
 function Auxiliary.FALSE()
 	return false
 end
-function Auxiliary.AND(f1,f2)
-	return	function(a,b,c)
-				return f1(a,b,c) and f2(a,b,c)
+function Auxiliary.AND(...)
+	local funs={...}
+	return	function(...)
+				for _,f in ipairs(funs) do
+					if not f(...) then return false end
+				end
+				return true
 			end
 end
-function Auxiliary.OR(f1,f2)
-	return	function(a,b,c)
-				return f1(a,b,c) or f2(a,b,c)
+function Auxiliary.OR(...)
+	local funs={...}
+	return	function(...)
+				for _,f in ipairs(funs) do
+					if f(...) then return true end
+				end
+				return false
 			end
 end
 function Auxiliary.NOT(f)
-	return	function(a,b,c)
-				return not f(a,b,c)
+	return	function(...)
+				return not f(...)
 			end
 end
 function Auxiliary.BeginPuzzle(effect)
@@ -238,19 +246,22 @@ function Auxiliary.SpiritReturnOperation(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SendtoHand(c,nil,REASON_EFFECT)
 	end
 end
-function Auxiliary.TargetEqualFunction(f,value,a,b,c)
+function Auxiliary.TargetEqualFunction(f,value,...)
+	local params={...}
 	return	function(effect,target)
-				return f(target,a,b,c)==value
+				return f(target,table.unpack(params))==value
 			end
 end
-function Auxiliary.TargetBoolFunction(f,a,b,c)
+function Auxiliary.TargetBoolFunction(f,...)
+	local params={...}
 	return	function(effect,target)
-				return f(target,a,b,c)
+				return f(target,table.unpack(params))
 			end
 end
-function Auxiliary.FilterEqualFunction(f,value,a,b,c)
+function Auxiliary.FilterEqualFunction(f,value,...)
+	local params={...}
 	return	function(target)
-				return f(target,a,b,c)==value
+				return f(target,table.unpack(params))==value
 			end
 end
 --used for Material Types Filter Bool (works for IsRace, IsAttribute, IsType)
@@ -259,9 +270,10 @@ function Auxiliary.FilterBoolFunctionEx(f,value)
 				return f(target,value,scard,sumtype,tp)
 			end
 end
-function Auxiliary.FilterBoolFunction(f,a,b,c)
+function Auxiliary.FilterBoolFunction(f,...)
+	local params={...}
 	return	function(target)
-				return f(target,a,b,c)
+				return f(target,table.unpack(params))
 			end
 end
 Auxiliary.ProcCancellable=false
@@ -473,7 +485,7 @@ function Auxiliary.AddEREquipLimit(c,con,equipval,equipop,linkedeff,prop,resetfl
 	end
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetProperty(finalprop)
-	e1:SetCode(100407001) --to be changed when official code is released
+	e1:SetCode(89785779) --to be changed when official code is released
 	e1:SetLabelObject(linkedeff)
 	if resetflag and resetcount then
 		e1:SetReset(resetflag,resetcount)
@@ -486,7 +498,7 @@ function Auxiliary.AddEREquipLimit(c,con,equipval,equipop,linkedeff,prop,resetfl
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_SINGLE)
 	e2:SetProperty(finalprop-EFFECT_FLAG_CANNOT_DISABLE)
-	e2:SetCode(100407001+EFFECT_EQUIP_LIMIT) --to be changed when official code is released
+	e2:SetCode(89785779+EFFECT_EQUIP_LIMIT) --to be changed when official code is released
 	if resetflag and resetcount then
 		e2:SetReset(resetflag,resetcount)
 	elseif resetflag then
@@ -498,7 +510,7 @@ end
 
 function Auxiliary.EquipByEffectLimit(e,c)
 	if e:GetOwner()~=c then return false end
-	local eff={c:GetCardEffect(100407001+EFFECT_EQUIP_LIMIT)}
+	local eff={c:GetCardEffect(89785779+EFFECT_EQUIP_LIMIT)}
 	for _,te in ipairs(eff) do
 		if te==e:GetLabelObject() then return true end
 	end
@@ -524,163 +536,6 @@ function Auxiliary.EquipByEffectAndLimitRegister(c,e,tp,tc,code,mustbefaceup)
 	return true
 end
 
---add procedure to equip spells equipping by rule
-function Auxiliary.AddEquipProcedure(c,p,f,eqlimit,cost,tg,op,con)
-	--Note: p==0 is check equip spell controler, p==1 for opponent's, PLAYER_ALL for both player's monsters
-	--Activate
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(1068)
-	e1:SetCategory(CATEGORY_EQUIP)
-	e1:SetType(EFFECT_TYPE_ACTIVATE)
-	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	if con then
-		e1:SetCondition(con)
-	end
-	if cost~=nil then
-		e1:SetCost(cost)
-	end
-	e1:SetTarget(Auxiliary.EquipTarget(tg,p,f))
-	e1:SetOperation(op)
-	c:RegisterEffect(e1)
-	--Equip limit
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_SINGLE)
-	e2:SetCode(EFFECT_EQUIP_LIMIT)
-	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	if eqlimit~=nil then
-		e2:SetValue(eqlimit)
-	else
-		e2:SetValue(Auxiliary.EquipLimit(f))
-	end
-	c:RegisterEffect(e2)
-end
-function Auxiliary.EquipLimit(f)
-	return function(e,c)
-				return not f or f(c,e,e:GetHandlerPlayer())
-			end
-end
-function Auxiliary.EquipFilter(c,p,f,e,tp)
-	return (p==PLAYER_ALL or c:IsControler(p)) and c:IsFaceup() and (not f or f(c,e,tp))
-end
-function Auxiliary.EquipTarget(tg,p,f)
-	return	function(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-				local player=nil
-				if p==0 then
-					player=tp
-				elseif p==1 then
-					player=1-tp
-				elseif p==PLAYER_ALL or p==nil then
-					player=PLAYER_ALL
-				end
-				if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() and Auxiliary.EquipFilter(chkc,player,f,e,tp) end
-				if chk==0 then return player~=nil and Duel.IsExistingTarget(Auxiliary.EquipFilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,player,f,e,tp) end
-				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
-				local g=Duel.SelectTarget(tp,Auxiliary.EquipFilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,player,f,e,tp)
-				if tg then tg(e,tp,eg,ep,ev,re,r,rp,g:GetFirst()) end
-				local e1=Effect.CreateEffect(e:GetHandler())
-				e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-				e1:SetCode(EVENT_CHAIN_SOLVING)
-				e1:SetReset(RESET_CHAIN)
-				e1:SetLabel(Duel.GetCurrentChain())
-				e1:SetLabelObject(e)
-				e1:SetOperation(Auxiliary.EquipEquip)
-				Duel.RegisterEffect(e1,tp)
-				Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
-			end
-end
-function Auxiliary.EquipEquip(e,tp,eg,ep,ev,re,r,rp)
-	if re~=e:GetLabelObject() then return end
-	local c=e:GetHandler()
-	local tc=Duel.GetChainInfo(Duel.GetCurrentChain(),CHAININFO_TARGET_CARDS):GetFirst()
-	if tc and c:IsRelateToEffect(re) and tc:IsRelateToEffect(re) and tc:IsFaceup() then
-		Duel.Equip(tp,c,tc)
-	end
-end
-
---add procedure to persistent traps
-function Auxiliary.AddPersistentProcedure(c,p,f,category,property,hint1,hint2,con,cost,tg,op,anypos)
-	--Note: p==0 is check persistent trap controler, p==1 for opponent's, PLAYER_ALL for both player's monsters
-	--anypos is check for face-up/any
-	--Activate
-	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(1068)
-	if category then
-		e1:SetCategory(category)
-	end
-	e1:SetType(EFFECT_TYPE_ACTIVATE)
-	e1:SetCode(EVENT_FREE_CHAIN)
-	if hint1 or hint2 then
-		if hint1==hint2 then
-			e1:SetHintTiming(hint1)
-		elseif hint1 and not hint2 then
-			e1:SetHintTiming(hint1,0)
-		elseif hint2 and not hint1 then
-			e1:SetHintTiming(0,hint2)
-		else
-			e1:SetHintTiming(hint1,hint2)
-		end
-	end
-	if property then
-		e1:SetProperty(EFFECT_FLAG_CARD_TARGET+property)
-	else
-		e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	end
-	if con then
-		e1:SetCondition(con)
-	end
-	if cost then
-		e1:SetCost(cost)
-	end
-	e1:SetTarget(Auxiliary.PersistentTarget(tg,p,f))
-	e1:SetOperation(op)
-	c:RegisterEffect(e1)
-	local e2=Effect.CreateEffect(c)
-	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-	e2:SetRange(LOCATION_SZONE)
-	e2:SetCode(EVENT_CHAIN_SOLVED)
-	e2:SetLabelObject(e1)
-	e2:SetCondition(Auxiliary.PersistentTgCon)
-	e2:SetOperation(Auxiliary.PersistentTgOp(anypos))
-	c:RegisterEffect(e2)
-end
-function Auxiliary.PersistentFilter(c,p,f,e,tp,tg,eg,ep,ev,re,r,rp)
-	return (p==PLAYER_ALL or c:IsControler(p)) and (not f or f(c,e,tp)) and (not tg or tg(e,tp,eg,ep,ev,re,r,rp,c,0))
-end
-function Auxiliary.PersistentTarget(tg,p,f)
-	return	function(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-				local player=nil
-				if p==0 then
-					player=tp
-				elseif p==1 then
-					player=1-tp
-				elseif p==PLAYER_ALL or p==nil then
-					player=PLAYER_ALL
-				end
-				if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() and Auxiliary.PersistentFilter(chkc,player,f,e,tp) end
-				if chk==0 then return Duel.IsExistingTarget(Auxiliary.PersistentFilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil,player,f,e,tp,tg,eg,ep,ev,re,r,rp)
-					and player~=nil end
-				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-				local g=Duel.SelectTarget(tp,Auxiliary.PersistentFilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil,player,f,e,tp)
-				if tg then tg(e,tp,eg,ep,ev,re,r,rp,g:GetFirst(),1) end
-			end
-end
-function Auxiliary.PersistentTgCon(e,tp,eg,ep,ev,re,r,rp)
-	return re==e:GetLabelObject()
-end
-function Auxiliary.PersistentTgOp(anypos)
-	return function(e,tp,eg,ep,ev,re,r,rp)
-			local c=e:GetHandler()
-			local tc=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS):GetFirst()
-			if c:IsRelateToEffect(re) and tc and (anypos or tc:IsFaceup()) and tc:IsRelateToEffect(re) then
-				c:SetCardTarget(tc)
-			end
-		end
-end
-function Auxiliary.PersistentTargetFilter(e,c)
-	return e:GetHandler():IsHasCardTarget(c)
-end
 --add a anounce digit by digit
 function Auxiliary.ComposeNumberDigitByDigit(tp,min,max)
 	if min>max then min,max=max,min end
@@ -809,6 +664,30 @@ function Auxiliary.ChkfMMZ(sumcount)
 				return sg:FilterCount(Auxiliary.MZFilter,nil,tp)+Duel.GetLocationCount(tp,LOCATION_MZONE)>=sumcount
 			end
 end
+--check for cards that can stay on the field, but not always
+function Auxiliary.RemainFieldCost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local c=e:GetHandler()
+	local cid=Duel.GetChainInfo(0,CHAININFO_CHAIN_ID)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_REMAIN_FIELD)
+	e1:SetProperty(EFFECT_FLAG_OATH)
+	e1:SetReset(RESET_CHAIN)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_CHAIN_DISABLED)
+	e2:SetOperation(Auxiliary.RemainFieldDisabled)
+	e2:SetLabel(cid)
+	e2:SetReset(RESET_CHAIN)
+	Duel.RegisterEffect(e2,tp)
+end
+function Auxiliary.RemainFieldDisabled(e,tp,eg,ep,ev,re,r,rp)
+	local cid=Duel.GetChainInfo(ev,CHAININFO_CHAIN_ID)
+	if cid~=e:GetLabel() then return end
+	e:GetOwner():CancelToGrave(false)
+end
 
 function loadutility(file)
 	local f1 = loadfile("expansions/live2017links/script/"..file)
@@ -828,4 +707,6 @@ loadutility("proc_union.lua")
 loadutility("proc_xyz.lua")
 loadutility("proc_pendulum.lua")
 loadutility("proc_link.lua")
+loadutility("proc_equip.lua")
+loadutility("proc_persistent.lua")
 pcall(dofile,"init.lua")


### PR DESCRIPTION
Ruling: Normal/Quick-Play Spells/ Normal Traps that would stay on the field (e.g. Equip to a monster/Re-Set) can be returned to the hand/Deck/banished by effect/cost.

Also, cleanup separating proc_equip and proc_persistent