### PR TITLE
Phantom of Chaos vs PSY-Framelord Omega ruling

### DIFF
--- a/script/c74586817.lua
+++ b/script/c74586817.lua
@@ -1,0 +1,145 @@
+--PSYフレームロード・Ω
+function c74586817.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,nil,1,1,aux.NonTuner(nil),1,99)
+	c:EnableReviveLimit()
+	--remove
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(74586817,0))
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,0x1c0+TIMING_MAIN_END)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c74586817.rmcon)
+	e1:SetTarget(c74586817.rmtg)
+	e1:SetOperation(c74586817.rmop)
+	c:RegisterEffect(e1)
+	--to grave
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(74586817,1))
+	e2:SetCategory(CATEGORY_TOGRAVE)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c74586817.tgcon)
+	e2:SetTarget(c74586817.tgtg)
+	e2:SetOperation(c74586817.tgop)
+	c:RegisterEffect(e2)
+	--to deck
+	local e3=Effect.CreateEffect(c)
+	e3:SetCategory(CATEGORY_TODECK)
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetRange(LOCATION_GRAVE)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetTarget(c74586817.tdtg)
+	e3:SetOperation(c74586817.tdop)
+	c:RegisterEffect(e3)
+end
+function c74586817.rmcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2
+end
+function c74586817.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemove()
+		and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_HAND,1,nil) end
+	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,0,LOCATION_HAND,nil)
+	g:AddCard(e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,2,0,0)
+end
+function c74586817.rmop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local g=Duel.GetFieldGroup(1-tp,LOCATION_HAND,0)
+	if g:GetCount()==0 or not c:IsRelateToEffect(e) or not c:IsFaceup() then return end
+	local rs=g:RandomSelect(1-tp,1)
+	local rg=Group.FromCards(c,rs:GetFirst())
+	if Duel.Remove(rg,POS_FACEUP,REASON_EFFECT+REASON_TEMPORARY)~=0 then
+		local fid=c:GetFieldID()
+		local og=Duel.GetOperatedGroup()
+		local oc=og:GetFirst()
+		while oc do
+			if oc~=c or not c:IsStatus(STATUS_COPYING_EFFECT) then
+				if oc:IsControler(tp) then
+					oc:RegisterFlagEffect(74586817,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_STANDBY+RESET_SELF_TURN,0,1,fid)
+				else
+					oc:RegisterFlagEffect(74586817,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_STANDBY+RESET_OPPO_TURN,0,1,fid)
+				end
+			end
+			oc=og:GetNext()
+		end
+		og:KeepAlive()
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+		e1:SetCode(EVENT_PHASE+PHASE_STANDBY)
+		e1:SetCountLimit(1)
+		e1:SetLabel(fid)
+		e1:SetLabelObject(og)
+		e1:SetCondition(c74586817.retcon)
+		e1:SetOperation(c74586817.retop)
+		e1:SetReset(RESET_PHASE+PHASE_STANDBY+RESET_SELF_TURN)
+		Duel.RegisterEffect(e1,tp)
+	end
+end
+function c74586817.tgcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp
+end
+function c74586817.tgtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_REMOVED) end
+	if chk==0 then return Duel.IsExistingTarget(nil,tp,LOCATION_REMOVED,LOCATION_REMOVED,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(74586817,2))
+	local g=Duel.SelectTarget(tp,nil,tp,LOCATION_REMOVED,LOCATION_REMOVED,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,g,1,0,0)
+end
+function c74586817.tgop(e,tp,eg,ep,ev,re,r,rp)
+	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local sg=tg:Filter(Card.IsRelateToEffect,nil,e)
+	if sg:GetCount()>0 then
+		Duel.SendtoGrave(sg,REASON_EFFECT+REASON_RETURN)
+	end
+end
+function c74586817.retfilter(c,fid)
+	return c:GetFlagEffectLabel(74586817)==fid
+end
+function c74586817.retcon(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetTurnPlayer()~=tp then return false end
+	local g=e:GetLabelObject()
+	if not g:IsExists(c74586817.retfilter,1,nil,e:GetLabel()) then
+		g:DeleteGroup()
+		e:Reset()
+		return false
+	else return true end
+end
+function c74586817.retop(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetLabelObject()
+	local sg=g:Filter(c74586817.retfilter,nil,e:GetLabel())
+	g:DeleteGroup()
+	local tc=sg:GetFirst()
+	while tc do
+		if tc==e:GetHandler() then
+			Duel.ReturnToField(tc)
+		else
+			Duel.SendtoHand(tc,tc:GetPreviousControler(),REASON_EFFECT)
+		end
+		tc=sg:GetNext()
+	end
+end
+function c74586817.tdtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsAbleToDeck() and chkc~=e:GetHandler() end
+	if chk==0 then return e:GetHandler():IsAbleToExtra()
+		and Duel.IsExistingTarget(Card.IsAbleToDeck,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
+	local g=Duel.SelectTarget(tp,Card.IsAbleToDeck,tp,LOCATION_GRAVE,LOCATION_GRAVE,1,1,e:GetHandler())
+	g:AddCard(e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,2,0,0)
+end
+function c74586817.tdop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) then
+		local g=Group.FromCards(c,tc)
+		Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
+	end
+end


### PR DESCRIPTION
If Omega is being copied by Phantom of Chaos, using banish effect, Phantom of Chaos would not return to the field, but the banished card from hand will return to opponent's hand