### PR TITLE
Fixed "Skulldeat, the Chained Dracoserpent" and "Gem-Knight Phantom Core"

### DIFF
--- a/script/c100223016.lua
+++ b/script/c100223016.lua
@@ -102,7 +102,7 @@ function c100223016.spop(e,tp,eg,ep,ev,re,r,rp)
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
 			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,chkf)
 			tc:SetMaterial(mat1)
-			Duel.Remove(mat1,POS_FACEUP,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
+			Duel.SendtoDeck(mat1,nil,2,POS_FACEUP,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else

--- a/script/c74997493.lua
+++ b/script/c74997493.lua
@@ -46,7 +46,9 @@ function c74997493.regop(e,tp,eg,ep,ev,re,r,rp)
 		local e2=e1:Clone()
 		e2:SetCode(EVENT_SPSUMMON_SUCCESS)
 		c:RegisterEffect(e2)
+		if c:GetMaterialCount()==2 then
 		c:RegisterFlagEffect(0,RESET_EVENT+0x1fe0000,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(74997493,3))
+		end
 	end
 	if c:GetMaterialCount()>=3 then
 		local e3=Effect.CreateEffect(c)


### PR DESCRIPTION
Skulldeat: small fix to better handle the hints while summoned with 3 or more materials
Phantom Core: now properly suffles the materials back to the deck