### PR TITLE
Fix Double Snare code-wise/ruling-wise

### DIFF
--- a/script/c10248389.lua
+++ b/script/c10248389.lua
@@ -1,0 +1,54 @@
+--サイバー・ブレイダー
+function c10248389.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcMix(c,false,false,97023549,11460577)
+	--indes
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e1:SetCondition(c10248389.con)
+	e1:SetLabel(1)
+	e1:SetValue(1)
+	c:RegisterEffect(e1)
+	--atkup
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCode(EFFECT_SET_ATTACK_FINAL)
+	e2:SetLabel(2)
+	e2:SetCondition(c10248389.con)
+	e2:SetValue(c10248389.atkval)
+	c:RegisterEffect(e2)
+	--disable effect
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_CHAIN_SOLVING)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetLabel(3)
+	e4:SetCondition(c10248389.con)
+	e4:SetOperation(c10248389.disop)
+	c:RegisterEffect(e4)
+	--Double Snare
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetLabel(3)
+	e5:SetCondition(c10248389.con)
+	e5:SetCode(3682106)
+	c:RegisterEffect(e5)
+end
+c10248389.material_setcode=0x93
+function c10248389.con(e)
+	return Duel.GetFieldGroupCount(e:GetHandlerPlayer(),0,LOCATION_MZONE)==e:GetLabel()
+end
+function c10248389.atkval(e,c)
+	return c:GetAttack()*2
+end
+function c10248389.disop(e,tp,eg,ep,ev,re,r,rp)
+	if rp~=tp then
+		Duel.NegateEffect(ev)
+	end
+end

--- a/script/c13758665.lua
+++ b/script/c13758665.lua
@@ -1,0 +1,37 @@
+--魔術師の左手
+function c13758665.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--negate
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c13758665.negcon)
+	e2:SetOperation(c13758665.negop)
+	c:RegisterEffect(e2)
+	--Double Snare
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCode(3682106)
+	c:RegisterEffect(e3)
+end
+function c13758665.cfilter(c)
+	return c:IsFaceup() and c:IsRace(RACE_SPELLCASTER)
+end
+function c13758665.negcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(c13758665.cfilter,tp,LOCATION_MZONE,0,1,nil)
+		and rp~=tp and re:IsActiveType(TYPE_TRAP) and Duel.IsChainDisablable(ev) 
+end
+function c13758665.negop(e,tp,eg,ep,ev,re,r,rp)
+	local rc=re:GetHandler()
+	if Duel.NegateEffect(ev) and rc:IsRelateToEffect(re) then
+		Duel.Destroy(rc,REASON_EFFECT)
+	end
+end

--- a/script/c19312169.lua
+++ b/script/c19312169.lua
@@ -1,0 +1,71 @@
+--罠封印の呪符
+function c19312169.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c19312169.actcon)
+	c:RegisterEffect(e1)
+	--destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EFFECT_SELF_DESTROY)
+	e2:SetCondition(c19312169.descon)
+	c:RegisterEffect(e2)
+	--cannot trigger
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_CANNOT_TRIGGER)
+	e3:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetTargetRange(0xa,0xa)
+	e3:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
+	c:RegisterEffect(e3)
+	--disable
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetCode(EFFECT_DISABLE)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e4:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
+	c:RegisterEffect(e4)
+	--disable effect
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e5:SetCode(EVENT_CHAIN_SOLVING)
+	e5:SetRange(LOCATION_SZONE)
+	e5:SetOperation(c19312169.disop)
+	c:RegisterEffect(e5)
+	--disable trap monster
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_FIELD)
+	e6:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+	e6:SetRange(LOCATION_SZONE)
+	e6:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e6:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
+	c:RegisterEffect(e6)
+	--Double Snare
+	local e7=Effect.CreateEffect(c)
+	e7:SetType(EFFECT_TYPE_SINGLE)
+	e7:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e7:SetRange(LOCATION_SZONE)
+	e7:SetCode(3682106)
+	c:RegisterEffect(e7)
+end
+function c19312169.filter(c)
+	return c:IsFaceup() and c:IsCode(2468169)
+end
+function c19312169.actcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(c19312169.filter,tp,LOCATION_MZONE,0,1,nil)
+end
+function c19312169.descon(e)
+	return not Duel.IsExistingMatchingCard(c19312169.filter,e:GetHandlerPlayer(),LOCATION_MZONE,0,1,nil)
+end
+function c19312169.disop(e,tp,eg,ep,ev,re,r,rp)
+	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	if tl==LOCATION_SZONE and re:IsActiveType(TYPE_TRAP) then
+		Duel.NegateEffect(ev)
+	end
+end

--- a/script/c1953925.lua
+++ b/script/c1953925.lua
@@ -1,0 +1,89 @@
+--古代の機械工兵
+function c1953925.initial_effect(c)
+	--disable&destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e1:SetTarget(c1953925.distg)
+	c:RegisterEffect(e1)
+	local e2=e1:Clone()
+	e2:SetCode(EFFECT_SELF_DESTROY)
+	c:RegisterEffect(e2)
+	--disable effect
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_CHAIN_SOLVING)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetOperation(c1953925.disop)
+	c:RegisterEffect(e3)
+	--actlimit
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetTargetRange(0,1)
+	e4:SetValue(c1953925.aclimit)
+	e4:SetCondition(c1953925.actcon)
+	c:RegisterEffect(e4)
+	--destroy
+	local e5=Effect.CreateEffect(c)
+	e5:SetDescription(aux.Stringid(1953925,0))
+	e5:SetCategory(CATEGORY_DESTROY)
+	e5:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e5:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e5:SetCode(EVENT_DAMAGE_STEP_END)
+	e5:SetCondition(c1953925.descon)
+	e5:SetTarget(c1953925.destg)
+	e5:SetOperation(c1953925.desop)
+	c:RegisterEffect(e5)
+	--Double Snare
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_SINGLE)
+	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e6:SetRange(LOCATION_MZONE)
+	e6:SetCode(3682106)
+	c:RegisterEffect(e6)
+end
+function c1953925.distg(e,c)
+	if not c:IsType(TYPE_TRAP) or c:GetCardTargetCount()==0 then return false end
+	return c:GetCardTarget():IsContains(e:GetHandler())
+end
+function c1953925.disop(e,tp,eg,ep,ev,re,r,rp)
+	local rc=re:GetHandler()
+	if not rc:IsType(TYPE_TRAP) then return end
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	if g and g:IsContains(e:GetHandler()) then
+		if Duel.NegateEffect(ev) and rc:IsRelateToEffect(re) then
+			Duel.Destroy(rc,REASON_EFFECT)
+		end
+	end
+end
+function c1953925.aclimit(e,re,tp)
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE)
+end
+function c1953925.actcon(e)
+	return Duel.GetAttacker()==e:GetHandler()
+end
+function c1953925.descon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler()==Duel.GetAttacker()
+end
+function c1953925.filter(c)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function c1953925.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(1-tp) and chkc:IsOnField() and c1953925.filter(chkc) end
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c1953925.filter,tp,0,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c1953925.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end

--- a/script/c19596712.lua
+++ b/script/c19596712.lua
@@ -1,0 +1,34 @@
+--アビスケイル－ケートス
+function c19596712.initial_effect(c)
+	aux.AddEquipProcedure(c,nil,aux.FilterBoolFunction(Card.IsSetCard,0x74))
+	--Atk up
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetValue(800)
+	c:RegisterEffect(e2)
+	--negate
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_CHAIN_SOLVING)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCondition(c19596712.negcon)
+	e4:SetOperation(c19596712.negop)
+	c:RegisterEffect(e4)
+	--Double Snare
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCode(3682106)
+	c:RegisterEffect(e3)
+end
+function c19596712.negcon(e,tp,eg,ep,ev,re,r,rp)
+	return rp~=tp and Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)==LOCATION_SZONE
+		and re:IsActiveType(TYPE_TRAP) and Duel.IsChainDisablable(ev) 
+end
+function c19596712.negop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.NegateEffect(ev) then
+		Duel.SendtoGrave(e:GetHandler(),REASON_EFFECT)
+	end
+end

--- a/script/c20529766.lua
+++ b/script/c20529766.lua
@@ -1,0 +1,77 @@
+--超電磁稼動ボルテック・ドラゴン
+function c20529766.initial_effect(c)
+	--summon success
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetCondition(c20529766.condition)
+	e1:SetOperation(c20529766.operation)
+	c:RegisterEffect(e1)
+	--tribute check
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_MATERIAL_CHECK)
+	e2:SetValue(c20529766.valcheck)
+	e2:SetLabelObject(e1)
+	c:RegisterEffect(e2)
+end
+function c20529766.valcheck(e,c)
+	local g=c:GetMaterial()
+	local flag=0
+	local tc=g:GetFirst()
+	while tc do
+		local code=tc:GetCode()
+		if code==55401221 then flag=flag|0x1
+		elseif code==19733961 then flag=flag|0x2
+		elseif code==63142001 then flag=flag|0x4
+		end
+		tc=g:GetNext()
+	end
+	e:GetLabelObject():SetLabel(flag)
+end
+function c20529766.condition(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsSummonType(SUMMON_TYPE_ADVANCE) and e:GetLabel()~=0
+end
+function c20529766.operation(e,tp,eg,ep,ev,re,r,rp)
+	local flag=e:GetLabel()
+	local c=e:GetHandler()
+	if flag&0x1~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e1:SetCode(EVENT_CHAIN_SOLVING)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetOperation(c20529766.disop)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
+		c:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+		e2:SetRange(LOCATION_MZONE)
+		e2:SetCode(3682106)
+		e2:SetReset(RESET_EVENT+0x1ff0000)
+		c:RegisterEffect(e2)
+	end
+	if flag&0x2~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_PIERCE)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
+		c:RegisterEffect(e1)
+	end
+	if flag&0x4~=0 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetValue(1000)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
+		c:RegisterEffect(e1)
+	end
+end
+function c20529766.disop(e,tp,eg,ep,ev,re,r,rp)
+	if re:IsActiveType(TYPE_MONSTER) or not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	if g:GetCount()==1 and g:GetFirst()==e:GetHandler() then
+		Duel.NegateEffect(ev)
+	end
+end

--- a/script/c2930675.lua
+++ b/script/c2930675.lua
@@ -1,6 +1,5 @@
 --星遺物へと至る鍵
 --Key to World Legacy
---Script by nekrozar
 function c2930675.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -16,6 +15,13 @@ function c2930675.initial_effect(c)
 	e2:SetCondition(c2930675.discon)
 	e2:SetOperation(c2930675.disop)
 	c:RegisterEffect(e2)
+	--Double Snare
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCode(3682106)
+	c:RegisterEffect(e3)
 end
 function c2930675.thfilter(c)
 	return ((c:IsSetCard(0x10c) and c:IsType(TYPE_MONSTER)) or c:IsSetCard(0xfe)) and c:IsFaceup() and c:IsAbleToHand()
@@ -40,7 +46,7 @@ end
 function c2930675.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc and tc:IsRelateToEffect(e) then
 		Duel.SendtoHand(tc,nil,REASON_EFFECT)
 	end
 end

--- a/script/c29353756.lua
+++ b/script/c29353756.lua
@@ -1,0 +1,93 @@
+--ZW－荒鷲激神爪
+function c29353756.initial_effect(c)
+	c:SetUniqueOnField(1,0,29353756)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c29353756.spcon)
+	c:RegisterEffect(e1)
+	--equip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(29353756,0))
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCategory(CATEGORY_EQUIP)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c29353756.eqcon)
+	e2:SetTarget(c29353756.eqtg)
+	e2:SetOperation(c29353756.eqop)
+	c:RegisterEffect(e2)
+	--negate
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_CHAIN_SOLVING)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCountLimit(1)
+	e3:SetCondition(c29353756.negcon)
+	e3:SetOperation(c29353756.negop)
+	c:RegisterEffect(e3)
+	--Double Snare
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCode(3682106)
+	c:RegisterEffect(e4)
+end
+function c29353756.spcon(e,c)
+	if c==nil then return true end
+	local tp=c:GetControler()
+	return Duel.GetLP(tp)<=Duel.GetLP(1-tp)-2000
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+end
+function c29353756.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():CheckUniqueOnField(tp)
+end
+function c29353756.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x107f)
+end
+function c29353756.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c29353756.filter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c29353756.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	Duel.SelectTarget(tp,c29353756.filter,tp,LOCATION_MZONE,0,1,1,nil)
+end
+function c29353756.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
+	local tc=Duel.GetFirstTarget()
+	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 or not tc or tc:GetControler()~=tp or tc:IsFacedown() or not tc:IsRelateToEffect(e) or not c:CheckUniqueOnField(tp) then
+		Duel.SendtoGrave(c,REASON_EFFECT)
+		return
+	end
+	Duel.Equip(tp,c,tc,true)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_EQUIP_LIMIT)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
+	e1:SetValue(c29353756.eqlimit)
+	e1:SetLabelObject(tc)
+	c:RegisterEffect(e1)
+	--atkup
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetValue(2000)
+	e2:SetReset(RESET_EVENT+0x1fe0000)
+	c:RegisterEffect(e2)
+end
+function c29353756.eqlimit(e,c)
+	return c==e:GetLabelObject()
+end
+function c29353756.negcon(e,tp,eg,ep,ev,re,r,rp)
+	return rp~=tp and Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)==LOCATION_SZONE
+		and re:IsActiveType(TYPE_TRAP) and Duel.IsChainDisablable(ev) 
+end
+function c29353756.negop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_CARD,0,29353756)
+	Duel.NegateEffect(ev)
+end

--- a/script/c3370104.lua
+++ b/script/c3370104.lua
@@ -1,0 +1,70 @@
+--サイバー・フェニックス
+function c3370104.initial_effect(c)
+	--disable
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e1:SetCondition(c3370104.discon)
+	e1:SetTarget(c3370104.distg)
+	c:RegisterEffect(e1)
+	--disable effect
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetOperation(c3370104.disop)
+	c:RegisterEffect(e2)
+	--draw
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(3370104,0))
+	e3:SetCategory(CATEGORY_DRAW)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e3:SetCode(EVENT_BATTLE_DESTROYED)
+	e3:SetCondition(c3370104.condition)
+	e3:SetTarget(c3370104.target)
+	e3:SetOperation(c3370104.operation)
+	c:RegisterEffect(e3)
+	--Double Snare
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCondition(c3370104.discon)
+	e4:SetCode(3682106)
+	c:RegisterEffect(e4)
+end
+function c3370104.discon(e)
+	return e:GetHandler():IsAttackPos()
+end
+function c3370104.distg(e,c)
+	if c:GetCardTargetCount()~=1 then return false end
+	local tc=c:GetFirstCardTarget()
+	return tc:IsControler(e:GetHandlerPlayer()) and tc:IsFaceup() and tc:IsRace(RACE_MACHINE)
+end
+function c3370104.disop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsAttackPos() or re:IsActiveType(TYPE_MONSTER) then return end
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	if not g or g:GetCount()~=1 then return end
+	local tc=g:GetFirst()
+	if tc:IsControler(tp) and tc:IsLocation(LOCATION_MZONE) and tc:IsFaceup() and tc:IsRace(RACE_MACHINE) then
+		Duel.NegateEffect(ev)
+	end
+end
+function c3370104.condition(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsLocation(LOCATION_GRAVE) and c:IsReason(REASON_BATTLE) and c:IsPreviousPosition(POS_FACEUP)
+end
+function c3370104.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,1) end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
+end
+function c3370104.operation(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Draw(p,d,REASON_EFFECT)
+end

--- a/script/c35803249.lua
+++ b/script/c35803249.lua
@@ -1,0 +1,102 @@
+--人造人間－サイコ・ロード
+function c35803249.initial_effect(c)
+	c:EnableReviveLimit()
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(aux.FALSE)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c35803249.spcon)
+	e2:SetOperation(c35803249.spop)
+	c:RegisterEffect(e2)
+	--cannot trigger
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_CANNOT_TRIGGER)
+	e3:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTargetRange(0xa,0xa)
+	e3:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
+	c:RegisterEffect(e3)
+	--disable
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetCode(EFFECT_DISABLE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e4:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
+	c:RegisterEffect(e4)
+	--disable effect
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e5:SetCode(EVENT_CHAIN_SOLVING)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetOperation(c35803249.disop)
+	c:RegisterEffect(e5)
+	--disable trap monster
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_FIELD)
+	e6:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+	e6:SetRange(LOCATION_MZONE)
+	e6:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e6:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
+	c:RegisterEffect(e6)
+	--destroy
+	local e7=Effect.CreateEffect(c)
+	e7:SetDescription(aux.Stringid(35803249,0))
+	e7:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+	e7:SetType(EFFECT_TYPE_IGNITION)
+	e7:SetRange(LOCATION_MZONE)
+	e7:SetCountLimit(1)
+	e7:SetTarget(c35803249.destg)
+	e7:SetOperation(c35803249.desop)
+	c:RegisterEffect(e7)
+	--Double Snare
+	local e8=Effect.CreateEffect(c)
+	e8:SetType(EFFECT_TYPE_SINGLE)
+	e8:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e8:SetRange(LOCATION_MZONE)
+	e8:SetCode(3682106)
+	c:RegisterEffect(e8)
+end
+function c35803249.disop(e,tp,eg,ep,ev,re,r,rp)
+	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	if tl==LOCATION_SZONE and re:IsActiveType(TYPE_TRAP) then
+		Duel.NegateEffect(ev)
+	end
+end
+function c35803249.spfilter(c,ft,tp)
+	return c:IsFaceup() and c:IsCode(77585513) and (ft>0 or (c:GetSequence()<5 and c:IsControler(tp)))
+end
+function c35803249.spcon(e,c)
+	if c==nil then return true end
+	local tp=c:GetControler()
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	return tp>-1 and Duel.CheckReleaseGroup(tp,c35803249.spfilter,1,nil,ft,tp)
+end
+function c35803249.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	local g=Duel.SelectReleaseGroup(tp,c35803249.spfilter,1,1,nil,Duel.GetLocationCount(tp,LOCATION_MZONE),tp)
+	Duel.Release(g,REASON_COST)
+end
+function c35803249.filter(c)
+	return c:IsFaceup() and c:IsType(TYPE_TRAP)
+end
+function c35803249.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c35803249.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
+	local sg=Duel.GetMatchingGroup(c35803249.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,sg,sg:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,sg:GetCount()*300)
+end
+function c35803249.desop(e,tp,eg,ep,ev,re,r,rp)
+	local sg=Duel.GetMatchingGroup(c35803249.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
+	local ct=Duel.Destroy(sg,REASON_EFFECT)
+	Duel.Damage(1-tp,ct*300,REASON_EFFECT)
+end

--- a/script/c3682106.lua
+++ b/script/c3682106.lua
@@ -1,0 +1,28 @@
+--ダブルトラップ
+function c3682106.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c3682106.target)
+	e1:SetOperation(c3682106.activate)
+	c:RegisterEffect(e1)
+end
+function c3682106.filter(c)
+	return c:IsFaceup() and c:IsHasEffect(3682106)
+end
+function c3682106.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and c3682106.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c3682106.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,c3682106.filter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c3682106.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end

--- a/script/c37209439.lua
+++ b/script/c37209439.lua
@@ -1,0 +1,135 @@
+--誤封の契約書
+function c37209439.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c37209439.target)
+	c:RegisterEffect(e1)
+	--disable
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(37209439,0))
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c37209439.negcon)
+	e2:SetCost(c37209439.negcost)
+	e2:SetOperation(c37209439.negop)
+	c:RegisterEffect(e2)
+	--damage
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(37209439,1))
+	e3:SetCategory(CATEGORY_DAMAGE)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCountLimit(1)
+	e3:SetCondition(c37209439.damcon)
+	e3:SetCost(c37209439.damcost)
+	e3:SetTarget(c37209439.damtg)
+	e3:SetOperation(c37209439.damop)
+	c:RegisterEffect(e3)
+	--Double Snare
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCode(3682106)
+	c:RegisterEffect(e4)
+end
+function c37209439.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local b1=c37209439.negcon(e,tp,eg,ep,ev,re,r,rp)
+	local b2=c37209439.damcon(e,tp,eg,ep,ev,re,r,rp) and Duel.GetCurrentPhase()==PHASE_STANDBY
+	if (b1 or b2) and Duel.SelectYesNo(tp,94) then
+		local c=e:GetHandler()
+		local op=0
+		if b1 and b2 then
+			op=Duel.SelectOption(tp,aux.Stringid(37209439,0),aux.Stringid(37209439,1))
+		elseif b1 then
+			op=Duel.SelectOption(tp,aux.Stringid(37209439,0))
+		else op=Duel.SelectOption(tp,aux.Stringid(37209439,1))+1 end
+		if op==0 then
+			c:RegisterFlagEffect(37209439,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+			e:SetCategory(0)
+			e:SetOperation(c37209439.negop)
+		else
+			c:RegisterFlagEffect(37209440,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+			c37209439.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+			e:SetCategory(CATEGORY_DAMAGE)
+			e:SetOperation(c37209439.damop)
+		end
+	else
+		e:SetCategory(0)
+		e:SetOperation(nil)
+	end
+end
+function c37209439.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0xaf)
+end
+function c37209439.negcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(c37209439.cfilter,tp,LOCATION_MZONE,0,1,nil)
+end
+function c37209439.negcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(37209439)==0 end
+	e:GetHandler():RegisterFlagEffect(37209439,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c37209439.negop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	local fid=c:GetFieldID()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetRange(LOCATION_SZONE)
+	e1:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e1:SetTarget(c37209439.distg)
+	e1:SetLabel(fid)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetOperation(c37209439.disop)
+	e2:SetLabel(fid)
+	e2:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e2,tp)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e3:SetTarget(c37209439.distg)
+	e3:SetLabel(fid)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e3,tp)
+end
+function c37209439.distg(e,c)
+	return c:GetFieldID()~=e:GetLabel() and c:IsType(TYPE_TRAP)
+end
+function c37209439.disop(e,tp,eg,ep,ev,re,r,rp)
+	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	if tl==LOCATION_SZONE and re:IsActiveType(TYPE_TRAP) and re:GetHandler():GetFieldID()~=e:GetLabel() then
+		Duel.NegateEffect(ev)
+	end
+end
+function c37209439.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp
+end
+function c37209439.damcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetFlagEffect(37209440)==0 end
+	e:GetHandler():RegisterFlagEffect(37209440,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END,0,1)
+end
+function c37209439.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(tp)
+	Duel.SetTargetParam(1000)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,0,0,tp,1000)
+end
+function c37209439.damop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/script/c40867519.lua
+++ b/script/c40867519.lua
@@ -1,0 +1,64 @@
+--静寂虫
+function c40867519.initial_effect(c)
+	--to defense
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(40867519,0))
+	e1:SetCategory(CATEGORY_POSITION)
+	e1:SetType(EFFECT_TYPE_TRIGGER_F+EFFECT_TYPE_SINGLE)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetTarget(c40867519.postg)
+	e1:SetOperation(c40867519.posop)
+	c:RegisterEffect(e1)
+	local e2=e1:Clone()
+	e2:SetCode(EVENT_FLIP_SUMMON_SUCCESS)
+	c:RegisterEffect(e2)
+	--disable
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_DISABLE)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e3:SetTarget(c40867519.distarget)
+	c:RegisterEffect(e3)
+	--disable effect
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_CHAIN_SOLVING)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetOperation(c40867519.disop)
+	c:RegisterEffect(e4)
+	--disable trap monster
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_FIELD)
+	e5:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e5:SetTarget(c40867519.distarget)
+	c:RegisterEffect(e5)
+	--Double Snare
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_SINGLE)
+	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e6:SetRange(LOCATION_MZONE)
+	e6:SetCode(3682106)
+	c:RegisterEffect(e6)
+end
+function c40867519.postg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chk==0 then return e:GetHandler():IsAttackPos() end
+	Duel.SetOperationInfo(0,CATEGORY_POSITION,e:GetHandler(),1,0,0)
+end
+function c40867519.posop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsFaceup() and c:IsAttackPos() and c:IsRelateToEffect(e) then
+		Duel.ChangePosition(c,POS_FACEUP_DEFENSE)
+	end
+end
+function c40867519.distarget(e,c)
+	return c~=e:GetHandler() and c:IsType(TYPE_CONTINUOUS)
+end
+function c40867519.disop(e,tp,eg,ep,ev,re,r,rp)
+	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	if tl==LOCATION_SZONE and re:IsActiveType(TYPE_CONTINUOUS) then
+		Duel.NegateEffect(ev)
+	end
+end

--- a/script/c42868711.lua
+++ b/script/c42868711.lua
@@ -1,0 +1,47 @@
+--幻影のゴラ亀
+function c42868711.initial_effect(c)
+	--disable
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e1:SetTarget(c42868711.distg)
+	c:RegisterEffect(e1)
+	--disable effect
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetOperation(c42868711.disop)
+	c:RegisterEffect(e2)
+	--self destroy
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_SELF_DESTROY)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e3:SetTarget(c42868711.distg)
+	c:RegisterEffect(e3)
+	--Double Snare
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCode(3682106)
+	c:RegisterEffect(e4)
+end
+function c42868711.distg(e,c)
+	return c:IsControler(1-e:GetHandlerPlayer()) and c:IsHasCardTarget(e:GetHandler())
+end
+function c42868711.disop(e,tp,eg,ep,ev,re,r,rp)
+	if rp==tp or not re:IsActiveType(TYPE_SPELL+TYPE_TRAP) then return end
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	if not g or g:GetCount()==0 then return end
+	if g:IsContains(e:GetHandler()) then
+		if Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) then
+			Duel.Destroy(re:GetHandler(),REASON_EFFECT)
+		end
+	end
+end

--- a/script/c44155002.lua
+++ b/script/c44155002.lua
@@ -1,0 +1,27 @@
+--魔轟神獣ユニコール
+function c44155002.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,aux.FilterBoolFunction(Card.IsSetCard,0x35),1,1,aux.NonTuner(nil),1,99)
+	c:EnableReviveLimit()
+	--disable and destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EVENT_CHAIN_SOLVING)
+	e1:SetOperation(c44155002.disop)
+	c:RegisterEffect(e1)
+	--Double Snare
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCode(3682106)
+	c:RegisterEffect(e2)
+end
+function c44155002.disop(e,tp,eg,ep,ev,re,r,rp)
+	if ep==tp or Duel.GetFieldGroupCount(tp,LOCATION_HAND,0)~=Duel.GetFieldGroupCount(tp,0,LOCATION_HAND) then return end
+	local rc=re:GetHandler()
+	if Duel.NegateEffect(ev) and rc:IsRelateToEffect(re) then
+		Duel.Destroy(rc,REASON_EFFECT)
+	end
+end

--- a/script/c44852429.lua
+++ b/script/c44852429.lua
@@ -1,0 +1,92 @@
+--DDD呪血王サイフリート
+function c44852429.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,nil,1,1,aux.NonTuner(Card.IsSetCard,0xaf),1,99)
+	c:EnableReviveLimit()
+	--negate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(44852429,0))
+	e1:SetCategory(CATEGORY_DISABLE)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetHintTiming(0,0x1c0)
+	e1:SetCountLimit(1,44852429)
+	e1:SetTarget(c44852429.negtg)
+	e1:SetOperation(c44852429.negop)
+	c:RegisterEffect(e1)
+	--recover
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(44852429,1))
+	e2:SetCategory(CATEGORY_RECOVER)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetCondition(c44852429.reccon)
+	e2:SetTarget(c44852429.rectg)
+	e2:SetOperation(c44852429.recop)
+	c:RegisterEffect(e2)
+	--Double Snare
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCode(3682106)
+	c:RegisterEffect(e3)
+end
+function c44852429.negfilter(c)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP) and aux.disfilter1(c)
+end
+function c44852429.negtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and c44852429.negfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c44852429.negfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	local g=Duel.SelectTarget(tp,c44852429.negfilter,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,g,1,0,0)
+end
+function c44852429.negop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if ((tc:IsFaceup() and not tc:IsDisabled()) or tc:IsType(TYPE_TRAPMONSTER)) and tc:IsRelateToEffect(e) then
+		Duel.NegateRelatedChain(tc,RESET_TURN_SET)
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetCode(EFFECT_DISABLE)
+		if Duel.GetCurrentPhase()==PHASE_STANDBY then
+			e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_STANDBY,2)
+		else
+			e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_STANDBY)
+		end
+		tc:RegisterEffect(e1)
+		local e2=e1:Clone()
+		e2:SetCode(EFFECT_DISABLE_EFFECT)
+		e2:SetValue(RESET_TURN_SET)
+		tc:RegisterEffect(e2)
+		if tc:IsType(TYPE_TRAPMONSTER) then
+			local e3=e1:Clone()
+			e3:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+			tc:RegisterEffect(e3)
+		end
+	end
+end
+function c44852429.reccon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsReason(REASON_DESTROY) and c:IsReason(REASON_BATTLE+REASON_EFFECT)
+end
+function c44852429.recfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0xae)
+end
+function c44852429.rectg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local ct=Duel.GetMatchingGroupCount(c44852429.recfilter,tp,LOCATION_ONFIELD,0,nil)
+	Duel.SetTargetPlayer(tp)
+	Duel.SetOperationInfo(0,CATEGORY_RECOVER,nil,0,tp,ct*1000)
+end
+function c44852429.recop(e,tp,eg,ep,ev,re,r,rp)
+	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
+	local ct=Duel.GetMatchingGroupCount(c44852429.recfilter,p,LOCATION_ONFIELD,0,nil)
+	if ct>0 then
+		Duel.Recover(p,ct*1000,REASON_EFFECT)
+	end
+end

--- a/script/c49868263.lua
+++ b/script/c49868263.lua
@@ -1,0 +1,78 @@
+--ドラゴン・ウォリアー
+function c49868263.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcMix(c,false,false,75953262,67957315)
+	--negate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(49868263,0))
+	e1:SetCategory(CATEGORY_DISABLE)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(c49868263.discon)
+	e1:SetCost(c49868263.discost)
+	e1:SetTarget(c49868263.distg)
+	e1:SetOperation(c49868263.disop)
+	c:RegisterEffect(e1)
+	--disable effect
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetOperation(c49868263.disop2)
+	c:RegisterEffect(e2)
+	--disable
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_DISABLE)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e3:SetTarget(c49868263.distg2)
+	c:RegisterEffect(e3)
+	--self destroy
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetCode(EFFECT_SELF_DESTROY)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e4:SetTarget(c49868263.distg2)
+	c:RegisterEffect(e4)
+	--Double Snare
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetCode(3682106)
+	c:RegisterEffect(e5)
+end
+function c49868263.discon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsStatus(STATUS_BATTLE_DESTROYED) then return false end
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetActiveType()==TYPE_TRAP and Duel.IsChainDisablable(ev)
+end
+function c49868263.discost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.CheckLPCost(tp,1000) end
+	Duel.PayLPCost(tp,1000)
+end
+function c49868263.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+end
+function c49868263.disop(e,tp,eg,ep,ev,re,r,rp,chk)
+	Duel.NegateEffect(ev)
+end
+function c49868263.disop2(e,tp,eg,ep,ev,re,r,rp)
+	if re:IsActiveType(TYPE_SPELL) and re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then
+		local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+		if g and g:IsContains(e:GetHandler()) then
+			if Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) then
+				Duel.Destroy(re:GetHandler(),REASON_EFFECT)
+			end
+		end
+	end
+end
+function c49868263.distg2(e,c)
+	return c:GetCardTargetCount()>0 and c:IsType(TYPE_SPELL)
+		and c:GetCardTarget():IsContains(e:GetHandler())
+end

--- a/script/c51447164.lua
+++ b/script/c51447164.lua
@@ -1,0 +1,109 @@
+--TG ブレード・ガンナー
+function c51447164.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,aux.FilterBoolFunctionEx(Card.IsType,TYPE_SYNCHRO),1,1,aux.NonTunerEx(Card.IsType,TYPE_SYNCHRO),1,99)
+	c:EnableReviveLimit()
+	--Negate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(51447164,0))
+	e1:SetCategory(CATEGORY_DISABLE)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(c51447164.discon)
+	e1:SetCost(c51447164.discost)
+	e1:SetTarget(c51447164.distg)
+	e1:SetOperation(c51447164.disop)
+	c:RegisterEffect(e1)
+	--Remove
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(51447164,1))
+	e2:SetCategory(CATEGORY_REMOVE)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c51447164.rmcon)
+	e2:SetCost(c51447164.rmcost)
+	e2:SetTarget(c51447164.rmtg)
+	e2:SetOperation(c51447164.rmop)
+	c:RegisterEffect(e2)
+	--Special summon
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(51447164,2))
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e3:SetRange(LOCATION_REMOVED)
+	e3:SetCountLimit(1)
+	e3:SetCondition(c51447164.spcon)
+	e3:SetTarget(c51447164.sptg)
+	e3:SetOperation(c51447164.spop)
+	c:RegisterEffect(e3)
+	--Double Snare
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCode(3682106)
+	c:RegisterEffect(e4)
+end
+function c51447164.discon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsStatus(STATUS_BATTLE_DESTROYED) or not re:IsHasType(EFFECT_TYPE_ACTIVATE) or not Duel.IsChainDisablable(ev) then return false end
+	return re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) and Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS):IsContains(c)
+end
+function c51447164.discost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToGraveAsCost,tp,LOCATION_HAND,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToGraveAsCost,tp,LOCATION_HAND,0,1,1,nil)
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c51447164.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+end
+function c51447164.disop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateEffect(ev)
+end
+function c51447164.rmcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp
+end
+function c51447164.rmfilter(c)
+	return c:IsSetCard(0x27) and c:IsAbleToRemoveAsCost() and aux.SpElimFilter(c,true)
+end
+function c51447164.rmcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c51447164.rmfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c51447164.rmfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,1,e:GetHandler())
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function c51447164.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemove() end
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,e:GetHandler(),1,0,0)
+end
+function c51447164.rmop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and Duel.Remove(c,POS_FACEUP,REASON_EFFECT)~=0 then
+		if Duel.GetCurrentPhase()==PHASE_STANDBY then
+			c:RegisterFlagEffect(51447164,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_STANDBY,0,2,Duel.GetTurnCount())
+		else
+			c:RegisterFlagEffect(51447164,RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_STANDBY,0,1)
+		end
+	end
+end
+function c51447164.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local label=e:GetHandler():GetFlagEffectLabel(51447164)
+	return label and label~=Duel.GetTurnCount()
+end
+function c51447164.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	e:GetHandler():ResetFlagEffect(51447164)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c51447164.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/script/c51452091.lua
+++ b/script/c51452091.lua
@@ -1,0 +1,48 @@
+--王宮のお触れ
+function c51452091.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMING_END_PHASE)
+	c:RegisterEffect(e1)
+	--disable
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_DISABLE)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e2:SetTarget(c51452091.distarget)
+	c:RegisterEffect(e2)
+	--disable effect
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_CHAIN_SOLVING)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetOperation(c51452091.disop)
+	c:RegisterEffect(e3)
+	--disable trap monster
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e4:SetTarget(c51452091.distarget)
+	c:RegisterEffect(e4)
+	--Double Snare
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e5:SetRange(LOCATION_SZONE)
+	e5:SetCode(3682106)
+	c:RegisterEffect(e5)
+end
+function c51452091.distarget(e,c)
+	return c~=e:GetHandler() and c:IsType(TYPE_TRAP)
+end
+function c51452091.disop(e,tp,eg,ep,ev,re,r,rp)
+	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	if tl==LOCATION_SZONE and re:IsActiveType(TYPE_TRAP) and re:GetHandler()~=e:GetHandler() then
+		Duel.NegateEffect(ev)
+	end
+end

--- a/script/c53347303.lua
+++ b/script/c53347303.lua
@@ -1,0 +1,77 @@
+--青眼の光龍
+function c53347303.initial_effect(c)
+	c:EnableReviveLimit()
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(aux.FALSE)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c53347303.spcon)
+	e2:SetOperation(c53347303.spop)
+	c:RegisterEffect(e2)
+	--atkup
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetCode(EFFECT_UPDATE_ATTACK)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetValue(c53347303.val)
+	c:RegisterEffect(e3)
+	--negate
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(53347303,0))
+	e4:SetCategory(CATEGORY_DISABLE)
+	e4:SetType(EFFECT_TYPE_QUICK_O)
+	e4:SetCode(EVENT_CHAINING)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCondition(c53347303.discon)
+	e4:SetTarget(c53347303.distg)
+	e4:SetOperation(c53347303.disop)
+	c:RegisterEffect(e4)
+	--Double Snare
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetCode(3682106)
+	c:RegisterEffect(e5)
+end
+function c53347303.cfilter(c,ft,tp)
+	return c:IsCode(23995346) and (ft>0 or (c:GetSequence()<5 and c:IsControler(tp))) and (c:IsFaceup() or c:IsControler(tp))
+end
+function c53347303.spcon(e,c)
+	if c==nil then return true end
+	local tp=c:GetControler()
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	return ft>-1 and Duel.CheckReleaseGroup(tp,c53347303.cfilter,1,nil,ft,tp)
+end
+function c53347303.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	local g=Duel.SelectReleaseGroup(tp,c53347303.cfilter,1,1,nil,Duel.GetLocationCount(tp,LOCATION_MZONE),tp)
+	Duel.Release(g,REASON_COST)
+end
+function c53347303.val(e,c)
+	return Duel.GetMatchingGroupCount(Card.IsRace,c:GetControler(),LOCATION_GRAVE,0,nil,RACE_DRAGON)*300
+end
+function c53347303.discon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsStatus(STATUS_BATTLE_DESTROYED) then return false end
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return end
+	local loc,tg=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TARGET_CARDS)
+	if not tg or not tg:IsContains(c) then return false end
+	return Duel.IsChainDisablable(ev) and loc~=LOCATION_DECK
+end
+function c53347303.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+end
+function c53347303.disop(e,tp,eg,ep,ev,re,r,rp,chk)
+	Duel.NegateEffect(ev)
+end

--- a/script/c6150044.lua
+++ b/script/c6150044.lua
@@ -1,0 +1,47 @@
+--アルカナ ナイトジョーカー
+function c6150044.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcMix(c,false,false,25652259,90876561,64788463)
+	--negate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(6150044,0))
+	e1:SetCategory(CATEGORY_DISABLE)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c6150044.discon)
+	e1:SetCost(c6150044.discost)
+	e1:SetTarget(c6150044.distg)
+	e1:SetOperation(c6150044.disop)
+	c:RegisterEffect(e1)
+	--Double Snare
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCode(3682106)
+	c:RegisterEffect(e2)
+end
+function c6150044.discon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsStatus(STATUS_BATTLE_DESTROYED) or not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
+	local tg=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	return tg and tg:IsContains(c) and Duel.IsChainDisablable(ev)
+end
+function c6150044.filter(c,tpe)
+	return c:IsType(tpe) and c:IsDiscardable()
+end
+function c6150044.discost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local rtype=bit.band(re:GetActiveType(),0x7)
+	if chk==0 then return Duel.IsExistingMatchingCard(c6150044.filter,tp,LOCATION_HAND,0,1,nil,rtype) end
+	Duel.DiscardHand(tp,c6150044.filter,1,1,REASON_COST+REASON_DISCARD,nil,rtype)
+end
+function c6150044.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+end
+function c6150044.disop(e,tp,eg,ep,ev,re,r,rp,chk)
+	Duel.NegateEffect(ev)
+end

--- a/script/c62892347.lua
+++ b/script/c62892347.lua
@@ -1,0 +1,102 @@
+--アルカナフォース０－THE FOOL
+function c62892347.initial_effect(c)
+	--battle indestructable
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e1:SetValue(1)
+	c:RegisterEffect(e1)
+	--
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_CANNOT_CHANGE_POSITION)
+	e2:SetCondition(c62892347.poscon)
+	c:RegisterEffect(e2)
+	--coin
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(62892347,0))
+	e3:SetCategory(CATEGORY_COIN)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_SUMMON_SUCCESS)
+	e3:SetTarget(c62892347.cointg)
+	e3:SetOperation(c62892347.coinop)
+	c:RegisterEffect(e3)
+	local e4=e3:Clone()
+	e4:SetCode(EVENT_SPSUMMON_SUCCESS)
+	c:RegisterEffect(e4)
+	local e5=e3:Clone()
+	e5:SetCode(EVENT_FLIP_SUMMON_SUCCESS)
+	c:RegisterEffect(e5)
+end
+c62892347.toss_coin=true
+function c62892347.poscon(e)
+	return e:GetHandler():IsPosition(POS_FACEUP_ATTACK)
+end
+function c62892347.cointg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,tp,1)
+end
+function c62892347.coinop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) or c:IsFacedown() then return end
+	local res=0
+	if c:IsHasEffect(73206827) then
+		res=1-Duel.SelectOption(tp,60,61)
+	else res=Duel.TossCoin(tp,1) end
+	c62892347.arcanareg(c,res)
+end
+function c62892347.arcanareg(c,coin)
+	--disable
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(LOCATION_ONFIELD,LOCATION_ONFIELD)
+	e1:SetTarget(c62892347.distg)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
+	c:RegisterEffect(e1)
+	--disable effect
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetOperation(c62892347.disop)
+	e2:SetReset(RESET_EVENT+0x1fe0000)
+	c:RegisterEffect(e2)
+	--self destroy
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_SELF_DESTROY)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTargetRange(LOCATION_ONFIELD,LOCATION_ONFIELD)
+	e3:SetTarget(c62892347.distg)
+	e3:SetReset(RESET_EVENT+0x1fe0000)
+	c:RegisterEffect(e3)
+	c:RegisterFlagEffect(36690018,RESET_EVENT+0x1fe0000,EFFECT_FLAG_CLIENT_HINT,1,coin,63-coin)
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCode(3682106)
+	e4:SetReset(RESET_EVENT+0x1fe0000)
+	c:RegisterEffect(e4)
+end
+function c62892347.distg(e,c)
+	local ec=e:GetHandler()
+	if c==ec or c:GetCardTargetCount()==0 then return false end
+	local val=ec:GetFlagEffectLabel(36690018)
+	if val==1 then
+		return c:GetControler()==ec:GetControler() and c:GetCardTarget():IsContains(ec)
+	else return c:GetControler()~=ec:GetControler() and c:GetCardTarget():IsContains(ec) end
+end
+function c62892347.disop(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetHandler()
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return end
+	local val=ec:GetFlagEffectLabel(36690018)
+	if (val==1 and rp~=ec:GetControler()) or (val==0 and rp==ec:GetControler()) then return end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	if not g or not g:IsContains(ec) then return end
+	if Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) then
+		Duel.Destroy(re:GetHandler(),REASON_EFFECT)
+	end
+end

--- a/script/c65403020.lua
+++ b/script/c65403020.lua
@@ -1,0 +1,31 @@
+--エンド・オブ・アヌビス
+function c65403020.initial_effect(c)
+	--negate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(EVENT_CHAIN_SOLVING)
+	e1:SetCondition(c65403020.condition)
+	e1:SetOperation(c65403020.operation)
+	c:RegisterEffect(e1)
+	--Double Snare
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCode(3682106)
+	c:RegisterEffect(e2)
+end
+function c65403020.gfilter(c)
+	return c:IsLocation(LOCATION_GRAVE)
+end
+function c65403020.condition(e,tp,eg,ep,ev,re,r,rp)
+	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	if loc==LOCATION_GRAVE then return true end
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	return g and g:IsExists(c65403020.gfilter,1,nil)
+end
+function c65403020.operation(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateEffect(ev)
+end

--- a/script/c66235877.lua
+++ b/script/c66235877.lua
@@ -1,0 +1,45 @@
+--デス・デーモン・ドラゴン
+function c66235877.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcMix(c,false,false,93220472,16475472)
+	--disable
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e1:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_FLIP))
+	c:RegisterEffect(e1)
+	--disable effect
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetOperation(c66235877.disop)
+	c:RegisterEffect(e2)
+	--
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(66235877)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	c:RegisterEffect(e3)
+	--Double Snare
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCode(3682106)
+	c:RegisterEffect(e4)
+end
+c66235877.material_setcode=0x45
+function c66235877.disop(e,tp,eg,ep,ev,re,r,rp)
+	if re:IsActiveType(TYPE_FLIP) then Duel.NegateEffect(ev) end
+	if re:IsActiveType(TYPE_TRAP) and re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then
+		local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+		if g and g:IsContains(e:GetHandler()) then
+			Duel.NegateEffect(ev)
+		end
+	end
+end

--- a/script/c67750322.lua
+++ b/script/c67750322.lua
@@ -1,0 +1,37 @@
+--スカル・マイスター
+function c67750322.initial_effect(c)
+	--Inactivate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(67750322,0))
+	e1:SetCategory(CATEGORY_DISABLE)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c67750322.discon)
+	e1:SetCost(c67750322.discost)
+	e1:SetTarget(c67750322.distg)
+	e1:SetOperation(c67750322.disop)
+	c:RegisterEffect(e1)
+	--Double Snare
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_SINGLE)
+	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e6:SetRange(LOCATION_HAND)
+	e6:SetCode(3682106)
+	c:RegisterEffect(e6)
+end
+function c67750322.discon(e,tp,eg,ep,ev,re,r,rp)
+	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	return ep~=tp and Duel.IsChainDisablable(ev) and loc==LOCATION_GRAVE
+end
+function c67750322.discost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
+end
+function c67750322.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return not re:GetHandler():IsStatus(STATUS_DISABLED) end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+end
+function c67750322.disop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.NegateEffect(ev)
+end

--- a/script/c73551138.lua
+++ b/script/c73551138.lua
@@ -1,0 +1,81 @@
+--リチュア・エミリア
+function c73551138.initial_effect(c)
+	--spirit return
+	aux.EnableSpiritReturn(c,EVENT_SUMMON_SUCCESS,EVENT_FLIP)
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(aux.FALSE)
+	c:RegisterEffect(e1)
+	--negate trap
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(73551138,1))
+	e4:SetCategory(CATEGORY_DISABLE)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e4:SetCode(EVENT_SUMMON_SUCCESS)
+	e4:SetOperation(c73551138.negop)
+	c:RegisterEffect(e4)
+	local e5=e4:Clone()
+	e5:SetCode(EVENT_FLIP)
+	c:RegisterEffect(e5)
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e6:SetCode(EVENT_SUMMON_SUCCESS)
+	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e6:SetOperation(c73551138.regop)
+	c:RegisterEffect(e6)
+	local e7=e6:Clone()
+	e7:SetCode(EVENT_FLIP)
+	c:RegisterEffect(e7)
+end
+function c73551138.filter(c)
+	return c:IsFaceup() and c:IsSetCard(0x3a)
+end
+function c73551138.negop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not Duel.IsExistingMatchingCard(c73551138.filter,tp,LOCATION_MZONE,0,1,c) then return end
+	--disable
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e1:SetTarget(c73551138.distg)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+	--disable effect
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetOperation(c73551138.disop)
+	e2:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e2,tp)
+	--disable trap monster
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+	e3:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e3:SetTarget(c73551138.distg)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e3,tp)
+end
+function c73551138.distg(e,c)
+	return c~=e:GetHandler() and c:IsType(TYPE_TRAP)
+end
+function c73551138.disop(e,tp,eg,ep,ev,re,r,rp)
+	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	if tl==LOCATION_SZONE and re:IsActiveType(TYPE_TRAP) then
+		Duel.NegateEffect(ev)
+	end
+end
+function c73551138.regop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCode(3682106)
+	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+	c:RegisterEffect(e1)
+end

--- a/script/c74593218.lua
+++ b/script/c74593218.lua
@@ -1,0 +1,50 @@
+--H－C クサナギ
+function c74593218.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,aux.FilterBoolFunctionEx(Card.IsRace,RACE_WARRIOR),4,3)
+	c:EnableReviveLimit()
+	--negate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(74593218,0))
+	e1:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY+CATEGORY_ATKCHANGE)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetCondition(c74593218.negcon)
+	e1:SetCost(c74593218.negcost)
+	e1:SetTarget(c74593218.negtg)
+	e1:SetOperation(c74593218.negop)
+	c:RegisterEffect(e1,false,1)
+end
+function c74593218.negcon(e,tp,eg,ep,ev,re,r,rp)
+	return not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED)
+		and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:IsActiveType(TYPE_TRAP) and Duel.IsChainNegatable(ev)
+end
+function c74593218.negcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
+	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
+end
+function c74593218.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	if re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
+end
+function c74593218.negop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)>0 then
+		Duel.BreakEffect()
+		if c:IsRelateToEffect(e) and c:IsFaceup() then
+			local e1=Effect.CreateEffect(c)
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetProperty(EFFECT_FLAG_COPY_INHERIT)
+			e1:SetCode(EFFECT_UPDATE_ATTACK)
+			e1:SetValue(500)
+			e1:SetReset(RESET_EVENT+0x1ff0000)
+			c:RegisterEffect(e1)
+		end
+	end
+end

--- a/script/c74841885.lua
+++ b/script/c74841885.lua
@@ -1,0 +1,96 @@
+--天魔神 インヴィシル
+function c74841885.initial_effect(c)
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--tribute check
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_MATERIAL_CHECK)
+	e2:SetValue(c74841885.valcheck)
+	c:RegisterEffect(e2)
+	--give negate effect only when summon
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_SUMMON_COST)
+	e3:SetOperation(c74841885.facechk)
+	e3:SetLabelObject(e2)
+	c:RegisterEffect(e3)
+end
+function c74841885.chkfilter(c,rac,att)
+	return c:IsRace(rac) and c:IsAttribute(att)
+end
+function c74841885.valcheck(e,c)
+	if e:GetLabel()~=1 then return end
+	e:SetLabel(0)
+	local g=c:GetMaterial()
+	local lbl=0
+	if g:IsExists(c74841885.chkfilter,1,nil,RACE_FAIRY,ATTRIBUTE_LIGHT) then
+		lbl=lbl+TYPE_SPELL
+	end
+	if g:IsExists(c74841885.chkfilter,1,nil,RACE_FIEND,ATTRIBUTE_DARK) then
+		lbl=lbl+TYPE_TRAP
+		local e0=Effect.CreateEffect(c)
+		e0:SetType(EFFECT_TYPE_SINGLE)
+		e0:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+		e0:SetRange(LOCATION_MZONE)
+		e0:SetCode(3682106)
+		e0:SetReset(RESET_EVENT+0xff0000)
+		c:RegisterEffect(e0)
+	end
+	if lbl~=0 then
+		--disable
+		local e1=Effect.CreateEffect(c)
+		if lbl==TYPE_SPELL then
+			e1:SetDescription(aux.Stringid(74841885,0))
+		elseif lbl==TYPE_TRAP then
+			e1:SetDescription(aux.Stringid(74841885,1))
+		else
+			e1:SetDescription(aux.Stringid(74841885,2))
+		end
+		e1:SetProperty(EFFECT_FLAG_CLIENT_HINT)
+		e1:SetType(EFFECT_TYPE_FIELD)
+		e1:SetCode(EFFECT_DISABLE)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+		e1:SetTarget(c74841885.distg)
+		e1:SetLabel(lbl)
+		e1:SetReset(RESET_EVENT+0xff0000)
+		c:RegisterEffect(e1)
+		--disable effect
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e2:SetCode(EVENT_CHAIN_SOLVING)
+		e2:SetRange(LOCATION_MZONE)
+		e2:SetLabel(lbl)
+		e2:SetOperation(c74841885.disop)
+		e2:SetReset(RESET_EVENT+0xff0000)
+		c:RegisterEffect(e2)
+		if lbl&TYPE_TRAP~=0 then
+			local e3=Effect.CreateEffect(c)
+			e3:SetType(EFFECT_TYPE_FIELD)
+			e3:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+			e3:SetRange(LOCATION_MZONE)
+			e3:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+			e3:SetTarget(c74841885.distg)
+			e3:SetLabel(TYPE_TRAP)
+			e3:SetReset(RESET_EVENT+0xff0000)
+			c:RegisterEffect(e3)
+		end
+	end
+end
+function c74841885.distg(e,c)
+	return c:IsType(e:GetLabel())
+end
+function c74841885.disop(e,tp,eg,ep,ev,re,r,rp)
+	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	if tl&LOCATION_SZONE~=0 and re:IsActiveType(e:GetLabel()) then
+		Duel.NegateEffect(ev)
+	end
+end
+function c74841885.facechk(e,tp,eg,ep,ev,re,r,rp)
+	e:GetLabelObject():SetLabel(1)
+end

--- a/script/c77585513.lua
+++ b/script/c77585513.lua
@@ -1,0 +1,48 @@
+--人造人間－サイコ・ショッカー
+function c77585513.initial_effect(c)
+	--cannot trigger
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_TRIGGER)
+	e1:SetProperty(EFFECT_FLAG_SET_AVAILABLE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(0xa,0xa)
+	e1:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
+	c:RegisterEffect(e1)
+	--disable
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_DISABLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e2:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
+	c:RegisterEffect(e2)
+	--disable effect
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_CHAIN_SOLVING)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetOperation(c77585513.disop)
+	c:RegisterEffect(e3)
+	--disable trap monster
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e4:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
+	c:RegisterEffect(e4)
+	--Double Snare
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetCode(3682106)
+	c:RegisterEffect(e5)
+end
+function c77585513.disop(e,tp,eg,ep,ev,re,r,rp)
+	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	if tl==LOCATION_SZONE and re:IsActiveType(TYPE_TRAP) then
+		Duel.NegateEffect(ev)
+	end
+end

--- a/script/c88989706.lua
+++ b/script/c88989706.lua
@@ -1,0 +1,91 @@
+--大神官デ・ザード
+function c88989706.initial_effect(c)
+	--check
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_BATTLE_DESTROYING)
+	e1:SetOperation(c88989706.regop)
+	c:RegisterEffect(e1)
+	--negate
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_DESTROY+CATEGORY_NEGATE)
+	e2:SetType(EFFECT_TYPE_QUICK_F)
+	e2:SetCode(EVENT_CHAINING)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e2:SetCondition(c88989706.discon)
+	e2:SetTarget(c88989706.distg)
+	e2:SetOperation(c88989706.disop)
+	c:RegisterEffect(e2)
+	--special summon
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(88989706,0))
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCondition(c88989706.spcon)
+	e3:SetCost(c88989706.spcost)
+	e3:SetTarget(c88989706.sptg)
+	e3:SetOperation(c88989706.spop)
+	c:RegisterEffect(e3)
+	--Double Snare
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCondition(c88989706.effcon)
+	e4:SetCode(3682106)
+	c:RegisterEffect(e4)
+end
+function c88989706.effcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetFlagEffect(88989707)>0
+end
+function c88989706.regop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToBattle() then
+		c:RegisterFlagEffect(88989707,RESET_EVENT+0x1fe0000,0,0)
+	end
+end
+function c88989706.discon(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():GetFlagEffect(88989707)==0 or not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
+	local tg=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	if not tg or not tg:IsContains(e:GetHandler()) then return false end
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE)
+end
+function c88989706.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	if re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
+end
+function c88989706.disop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetCurrentChain()~=ev+1 then return end
+	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
+		Duel.Destroy(eg,REASON_EFFECT)
+	end
+end
+function c88989706.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetFlagEffect(88989707)>=2
+end
+function c88989706.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsReleasable() end
+	Duel.Release(e:GetHandler(),REASON_COST)
+end
+function c88989706.filter(c,e,tp)
+	return c:IsCode(39711336) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+end
+function c88989706.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if e:GetHandler():GetSequence()<5 then ft=ft+1 end
+	if chk==0 then return ft>0 and Duel.IsExistingMatchingCard(c88989706.filter,tp,LOCATION_DECK+LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,0,tp,LOCATION_DECK+LOCATION_HAND)
+end
+function c88989706.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c88989706.filter,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,e,tp)
+	if g:GetCount()>0 and Duel.SpecialSummon(g,0,tp,tp,true,false,POS_FACEUP)>0 then
+		g:GetFirst():CompleteProcedure()
+	end
+end

--- a/script/c90464188.lua
+++ b/script/c90464188.lua
@@ -1,0 +1,50 @@
+--黒曜岩竜
+function c90464188.initial_effect(c)
+	--disable
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e1:SetTarget(c90464188.distg)
+	c:RegisterEffect(e1)
+	--disable effect
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetOperation(c90464188.disop)
+	c:RegisterEffect(e2)
+	--self destroy
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_SELF_DESTROY)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e3:SetTarget(c90464188.distg)
+	c:RegisterEffect(e3)
+	--Double Snare
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCode(3682106)
+	c:RegisterEffect(e4)
+end
+function c90464188.distg(e,c)
+	if c:GetCardTargetCount()==0 then return false end
+	return c:GetCardTarget():IsExists(c90464188.disfilter,1,nil,e:GetHandlerPlayer())
+end
+function c90464188.disfilter(c,tp)
+	return c:IsControler(tp) and c:IsFaceup() and c:IsLocation(LOCATION_MZONE) and c:IsAttribute(ATTRIBUTE_DARK)
+end
+function c90464188.disop(e,tp,eg,ep,ev,re,r,rp)
+	if not re:IsActiveType(TYPE_SPELL+TYPE_TRAP) or not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	if not g or g:GetCount()==0 then return end
+	if g:IsExists(c90464188.disfilter,1,nil,tp) then
+		if Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) then
+			Duel.Destroy(re:GetHandler(),REASON_EFFECT)
+		end
+	end
+end

--- a/script/c92408984.lua
+++ b/script/c92408984.lua
@@ -1,0 +1,84 @@
+--ドラゴンの宝珠
+function c92408984.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCost(c92408984.cost)
+	e1:SetTarget(c92408984.target)
+	c:RegisterEffect(e1)
+	--instant(chain)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(92408984,0))
+	e2:SetCategory(CATEGORY_DISABLE+CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_CHAINING)
+	e2:SetCondition(c92408984.discon)
+	e2:SetCost(c92408984.discost)
+	e2:SetTarget(c92408984.distg)
+	e2:SetOperation(c92408984.disop)
+	c:RegisterEffect(e2)
+	--Double Snare
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_SINGLE)
+	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e6:SetRange(LOCATION_SZONE)
+	e6:SetCode(3682106)
+	c:RegisterEffect(e6)
+end
+function c92408984.cfilter(c)
+	return c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:IsRace(RACE_DRAGON)
+end
+function c92408984.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	e:SetLabel(1)
+	return true
+end
+function c92408984.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		e:SetLabel(0)
+		return true
+	end
+	local ct=Duel.GetCurrentChain()-1
+	if ct<=0 then return end
+	local pe,p=Duel.GetChainInfo(ct,CHAININFO_TRIGGERING_EFFECT,CHAININFO_TRIGGERING_PLAYER)
+	local g=Group.FromCards(pe:GetHandler())
+	if c92408984.discon(e,tp,g,p,ct,pe,0,p) and (e:GetLabel()~=1 or c92408984.discost(e,tp,g,p,ct,pe,0,p,0)) and c92408984.distg(e,tp,g,p,ct,pe,0,p,0) then
+		e:SetCategory(CATEGORY_DISABLE+CATEGORY_DESTROY)
+		e:SetOperation(c92408984.activate(g,ct,pe))
+		if e:GetLabel()==1 then c92408984.discost(e,tp,g,p,ct,pe,0,p,1) end
+		c92408984.distg(e,tp,g,p,ct,pe,0,p,1)
+	else
+		e:SetCategory(0)
+		e:SetOperation(nil)
+	end
+end
+function c92408984.discon(e,tp,eg,ep,ev,re,r,rp)
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) or not re:GetHandler():IsType(TYPE_TRAP) then return false end
+	local tg=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	return tg and tg:IsExists(c92408984.cfilter,1,nil) and Duel.IsChainDisablable(ev)
+end
+function c92408984.discost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,e:GetHandler()) end
+	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
+end
+function c92408984.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+	if eg:GetFirst():IsOnField() then
+		Duel.SetTargetCard(eg)
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
+end
+function c92408984.activate(teg,tev,tre)
+	return	function(e,tp,eg,ep,ev,re,r,rp)
+				if e:GetHandler():IsRelateToEffect(e) and Duel.NegateEffect(tev) and tre:GetHandler():IsRelateToEffect(tre) then
+					Duel.Destroy(teg,REASON_EFFECT)
+				end
+			end
+end
+function c92408984.disop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsRelateToEffect(e) and Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) then
+		Duel.Destroy(eg,REASON_EFFECT)
+	end
+end

--- a/script/c94568601.lua
+++ b/script/c94568601.lua
@@ -1,0 +1,75 @@
+--タイラント・ドラゴン
+--not fully implemented
+function c94568601.initial_effect(c)
+	--disable
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_DISABLE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e1:SetTarget(c94568601.distg)
+	c:RegisterEffect(e1)
+	--disable effect
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_CHAIN_SOLVING)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetOperation(c94568601.disop)
+	c:RegisterEffect(e2)
+	--self destroy
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_SELF_DESTROY)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e3:SetTarget(c94568601.distg)
+	c:RegisterEffect(e3)
+	--multiatk
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetCode(EFFECT_EXTRA_ATTACK)
+	e4:SetValue(1)
+	e4:SetCondition(c94568601.atkcon)
+	c:RegisterEffect(e4)
+	--spsummon cost
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetCode(EFFECT_SPSUMMON_COST)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e5:SetRange(LOCATION_GRAVE)
+	e5:SetCost(c94568601.spcost)
+	e5:SetOperation(c94568601.spcop)
+	c:RegisterEffect(e5)
+	--Double Snare
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_SINGLE)
+	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e6:SetRange(LOCATION_MZONE)
+	e6:SetCode(3682106)
+	c:RegisterEffect(e6)
+end
+function c94568601.distg(e,c)
+	if not c:IsType(TYPE_TRAP) or c:GetCardTargetCount()==0 then return false end
+	return c:GetCardTarget():IsContains(e:GetHandler())
+end
+function c94568601.disop(e,tp,eg,ep,ev,re,r,rp)
+	if not re:IsActiveType(TYPE_TRAP) then return end
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	if not g or g:GetCount()==0 then return end
+	if g:IsContains(e:GetHandler()) then
+		if Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) then
+			Duel.Destroy(re:GetHandler(),REASON_EFFECT)
+		end
+	end
+end
+function c94568601.atkcon(e)
+	return Duel.GetFieldGroupCount(e:GetHandlerPlayer(),0,LOCATION_MZONE)>0
+end
+function c94568601.spcost(e,c,tp)
+	return Duel.CheckReleaseGroup(tp,Card.IsRace,1,nil,RACE_DRAGON)
+end
+function c94568601.spcop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.SelectReleaseGroup(tp,Card.IsRace,1,1,nil,RACE_DRAGON)
+	Duel.Release(g,REASON_EFFECT)
+end


### PR DESCRIPTION
Removed hardcoding of "listed cards"
Can only destroy those that state "negate effect" not "activation"
Can only destroy specific cards when condition is met. e.g. Cyber Phoenix in Attack Position only, Sky Scourge Invicil when you Tributed a DARK Fiend-Type monster