### PR TITLE
Fixes

### DIFF
--- a/script/c2930675.lua
+++ b/script/c2930675.lua
@@ -1,6 +1,5 @@
 --星遺物へと至る鍵
 --Key to World Legacy
---Script by nekrozar
 function c2930675.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -16,6 +15,13 @@ function c2930675.initial_effect(c)
 	e2:SetCondition(c2930675.discon)
 	e2:SetOperation(c2930675.disop)
 	c:RegisterEffect(e2)
+	--Double Snare
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCode(3682106)
+	c:RegisterEffect(e3)
 end
 function c2930675.thfilter(c)
 	return ((c:IsSetCard(0x10c) and c:IsType(TYPE_MONSTER)) or c:IsSetCard(0xfe)) and c:IsFaceup() and c:IsAbleToHand()
@@ -40,15 +46,25 @@ end
 function c2930675.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not e:GetHandler():IsRelateToEffect(e) then return end
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) then
+	if tc and tc:IsRelateToEffect(e) then
 		Duel.SendtoHand(tc,nil,REASON_EFFECT)
 	end
 end
-function c2930675.cfilter(c,tp)
-	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:IsSetCard(0x10c)
+function c2930675.cfilter(c,seq,p)
+	return c:IsFaceup() and c:IsSetCard(0x10c) and c:IsColumn(seq,p,LOCATION_SZONE)
 end
 function c2930675.discon(e,tp,eg,ep,ev,re,r,rp)
-	return rp~=tp and re:IsActiveType(TYPE_TRAP) and re:GetHandler():GetColumnGroup():FilterCount(c2930675.cfilter,nil,tp)>0
+	if rp==tp or not re:IsActiveType(TYPE_TRAP) then return false end
+	local rc=re:GetHandler()
+	local p,loc,seq=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CONTROLER,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_SEQUENCE)
+	if loc&LOCATION_SZONE==0 or rc:IsControler(1-p) then
+		if rc:IsLocation(LOCATION_SZONE) and rc:IsControler(p) then
+			seq=rc:GetSequence()
+		else
+			seq=rc:GetPreviousSequence()
+		end
+	end
+	return Duel.IsExistingMatchingCard(c2930675.cfilter,tp,LOCATION_MZONE,0,1,nil,seq,p)
 end
 function c2930675.disop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.NegateEffect(ev)

--- a/script/c3113667.lua
+++ b/script/c3113667.lua
@@ -1,6 +1,5 @@
 --鋼鉄の襲撃者
 --Heavy Metal Raiders
---Script by nekrozar
 --Effect is not fully implemented
 function c3113667.initial_effect(c)
 	--Activate
@@ -25,7 +24,7 @@ function c3113667.initial_effect(c)
 	e3:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
 	e3:SetCode(EVENT_BATTLE_DESTROYED)
 	e3:SetRange(LOCATION_FZONE)
-	e3:SetCountLimit(1)
+	e3:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
 	e3:SetCondition(c3113667.spcon1)
 	e3:SetTarget(c3113667.sptg)
 	e3:SetOperation(c3113667.spop)

--- a/script/c4259068.lua
+++ b/script/c4259068.lua
@@ -1,0 +1,24 @@
+--魔力倹約術
+function c4259068.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--Cost Change
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_LPCOST_CHANGE)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetTargetRange(1,0)
+	e2:SetValue(c4259068.costchange)
+	c:RegisterEffect(e2)
+end
+function c4259068.costchange(e,re,rp,val)
+	if re and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():IsType(TYPE_SPELL) and not mustpay then
+		return 0
+	else
+		return val
+	end
+end

--- a/script/c50584941.lua
+++ b/script/c50584941.lua
@@ -1,0 +1,54 @@
+--レッド・スプレマシー
+function c50584941.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCost(c50584941.cost)
+	e1:SetTarget(c50584941.target)
+	e1:SetOperation(c50584941.activate)
+	c:RegisterEffect(e1)
+end
+function c50584941.cfilter(c,tp)
+	local code=c:GetOriginalCode()
+	return c:IsSetCard(0x1045) and c:IsType(TYPE_SYNCHRO) and c:IsAbleToRemoveAsCost() and aux.SpElimFilter(c,true) 
+		and Duel.IsExistingTarget(c50584941.filter,tp,LOCATION_MZONE,0,1,c,code)
+end
+function c50584941.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	c50584941.check=false
+	return true
+end
+function c50584941.filter(c,code)
+	return c:IsFaceup() and c:IsSetCard(0x1045) and c:IsType(TYPE_SYNCHRO) and (not c:IsCode(code) or c:GetOriginalCode()~=code)
+end
+function c50584941.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c50584941.filter(chkc,e:GetLabel()) end
+	if chk==0 then
+		if not c50584941.check then return false end
+		c50584941.check=false
+		return Duel.IsExistingMatchingCard(c50584941.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,nil,tp)
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c50584941.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,1,nil,tp)
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+	local code=g:GetFirst():GetOriginalCode()
+	e:SetLabel(code)	
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c50584941.filter,tp,LOCATION_MZONE,0,1,1,nil,code)
+end
+function c50584941.activate(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	local code=e:GetLabel()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_CHANGE_CODE)
+		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+		e1:SetValue(code)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		tc:RegisterEffect(e1)
+		tc:ReplaceEffect(code,RESET_EVENT+0x1fe0000)
+	end
+end

--- a/script/c62530723.lua
+++ b/script/c62530723.lua
@@ -1,6 +1,5 @@
 --星遺物の囁き
 --Whisper of the World Legacy
---Script by nekrozar
 function c62530723.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -59,11 +58,21 @@ function c62530723.activate(e,tp,eg,ep,ev,re,r,rp)
 		tc:RegisterEffect(e2)
 	end
 end
-function c62530723.cfilter(c,tp)
-	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:IsSetCard(0x10c)
+function c62530723.cfilter(c,seq,p)
+	return c:IsFaceup() and c:IsSetCard(0x10c) and c:IsColumn(seq,p,LOCATION_SZONE)
 end
 function c62530723.discon(e,tp,eg,ep,ev,re,r,rp)
-	return rp~=tp and re:IsActiveType(TYPE_SPELL) and re:GetHandler():GetColumnGroup():FilterCount(c62530723.cfilter,nil,tp)>0
+	if rp==tp or not re:IsActiveType(TYPE_SPELL) then return false end
+	local rc=re:GetHandler()
+	local p,loc,seq=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_CONTROLER,CHAININFO_TRIGGERING_LOCATION,CHAININFO_TRIGGERING_SEQUENCE)
+	if loc&LOCATION_SZONE==0 or rc:IsControler(1-p) then
+		if rc:IsLocation(LOCATION_SZONE) and rc:IsControler(p) then
+			seq=rc:GetSequence()
+		else
+			seq=rc:GetPreviousSequence()
+		end
+	end
+	return Duel.IsExistingMatchingCard(c62530723.cfilter,tp,LOCATION_MZONE,0,1,nil,seq,p)
 end
 function c62530723.disop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.NegateEffect(ev)

--- a/script/c65172015.lua
+++ b/script/c65172015.lua
@@ -1,0 +1,98 @@
+--AtoZ−ドラゴン・バスターキャノン
+function c65172015.initial_effect(c)
+	c:EnableReviveLimit()
+	aux.AddFusionProcMix(c,true,true,1561110,91998119)
+	aux.AddContactFusion(c,c65172015.contactfil,c65172015.contactop,aux.FALSE)
+	--negate
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(65172015,0))
+	e2:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_CHAINING)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c65172015.discon)
+	e2:SetCost(c65172015.discost)
+	e2:SetTarget(c65172015.distg)
+	e2:SetOperation(c65172015.disop)
+	c:RegisterEffect(e2)
+	--spsummon
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(65172015,1))
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetType(EFFECT_TYPE_QUICK_O)
+	e3:SetCode(EVENT_FREE_CHAIN)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetHintTiming(0,0x1e0)
+	e3:SetCost(aux.bfgcost)
+	e3:SetTarget(c65172015.sptg)
+	e3:SetOperation(c65172015.spop2)
+	c:RegisterEffect(e3)
+end
+function c65172015.crmfilter(c)
+	local code=c:GetOriginalCode()
+	return (code==1561110 or code==91998119) and c:IsAbleToRemoveAsCost()
+end
+function c65172015.contactfil(tp)
+	return Duel.GetMatchingGroup(c65172015.crmfilter,tp,LOCATION_ONFIELD,0,nil)
+end
+function c65172015.contactop(g)
+	Duel.Remove(g,POS_FACEUP,REASON_COST+REASON_MATERIAL)
+end
+function c65172015.discon(e,tp,eg,ep,ev,re,r,rp)
+	return re:GetHandler()~=e:GetHandler() and not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED)
+		and (re:IsActiveType(TYPE_MONSTER) or re:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(ev)
+end
+function c65172015.discost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,nil) end
+	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
+end
+function c65172015.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	if re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
+end
+function c65172015.disop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
+		Duel.Destroy(eg,REASON_EFFECT)
+	end
+end
+function c65172015.spfilter2(c,e,tp)
+	return c:IsFaceup() and c:IsCode(1561110) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.IsExistingTarget(c65172015.spfilter3,tp,LOCATION_REMOVED,0,1,c,e,tp)
+end
+function c65172015.spfilter3(c,e,tp)
+	return c:IsFaceup() and c:IsCode(91998119) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c65172015.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
+	if chk==0 then
+		local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+		if e:GetHandler():GetSequence()<5 then ft=ft+1 end
+		return ft>1 and not Duel.IsPlayerAffectedByEffect(tp,59822133)
+			and Duel.IsExistingTarget(c65172015.spfilter2,tp,LOCATION_REMOVED,0,1,nil,e,tp)
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g1=Duel.SelectTarget(tp,c65172015.spfilter2,tp,LOCATION_REMOVED,0,1,1,nil,e,tp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g2=Duel.SelectTarget(tp,c65172015.spfilter3,tp,LOCATION_REMOVED,0,1,1,g1:GetFirst(),e,tp)
+	g1:Merge(g2)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g1,2,tp,LOCATION_REMOVED)
+end
+function c65172015.spop2(e,tp,eg,ep,ev,re,r,rp)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	if g:GetCount()==0 or (g:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if g:GetCount()<=ft then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=g:Select(tp,ft,ft,nil)
+		Duel.SpecialSummon(sg,0,tp,tp,false,false,POS_FACEUP)
+		g:Sub(sg)
+		Duel.SendtoGrave(g,REASON_RULE)
+	end
+end

--- a/script/c67196946.lua
+++ b/script/c67196946.lua
@@ -1,0 +1,67 @@
+--スター・ブラスト
+function c67196946.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c67196946.con)
+	e1:SetCost(c67196946.cost)
+	e1:SetTarget(c67196946.tg)
+	e1:SetOperation(c67196946.op)
+	c:RegisterEffect(e1)
+end
+function c67196946.con(e,tp,eg,ep,ev,re,r,rp)
+	for _,te in ipairs({Duel.GetPlayerEffect(tp,EFFECT_LPCOST_CHANGE)}) do
+		local val=te:GetValue()
+		if val(te,e,tp,500)~=500 then return false end
+	end
+	return true
+end
+function c67196946.filter(c,lv)
+	return c:GetLevel()>lv
+end
+function c67196946.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	e:SetLabel(1)
+	if chk==0 then return true end
+end
+function c67196946.tg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if e:GetLabel()~=1 then return false end
+		e:SetLabel(0)
+		return Duel.CheckLPCost(tp,500) and Duel.IsExistingMatchingCard(c67196946.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,1,nil,1)
+	end
+	local lp=Duel.GetLP(tp)
+	local g=Duel.GetMatchingGroup(c67196946.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,1)
+	local tg=g:GetMaxGroup(Card.GetLevel)
+	local maxlv=tg:GetFirst():GetLevel()
+	local t={}
+	local l=1
+	while l<maxlv and l*500<=lp do
+		t[l]=l*500
+		l=l+1
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(67196946,0))
+	local announce=Duel.AnnounceNumber(tp,table.unpack(t))
+	Duel.PayLPCost(tp,announce)
+	Duel.SetTargetParam(announce/500)
+end
+function c67196946.op(e,tp,eg,ep,ev,re,r,rp)
+	local ct=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
+	local g=Duel.GetMatchingGroup(c67196946.filter,tp,LOCATION_HAND+LOCATION_MZONE,0,nil,ct)
+	if g:GetCount()>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(67196946,1))
+		local sg=g:Select(tp,1,1,nil)
+		local tc=sg:GetFirst()
+		if tc:IsLocation(LOCATION_MZONE) then
+			Duel.HintSelection(sg)
+		end
+		Duel.ConfirmCards(1-tp,sg)
+		if tc:IsLocation(LOCATION_HAND) then Duel.ShuffleHand(tp) end
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_LEVEL)
+		e1:SetReset(RESET_EVENT+0xfe0000+RESET_PHASE+PHASE_END)
+		e1:SetValue(-ct)
+		tc:RegisterEffect(e1)
+	end
+end

--- a/script/c75906310.lua
+++ b/script/c75906310.lua
@@ -1,6 +1,5 @@
 --アームド・ドラゴン・カタパルトキャノン
 --Armed Dragon Catapult Cannon
---Scripted by Eerie Code
 function c75906310.initial_effect(c)
 	--fusion material
 	c:EnableReviveLimit()
@@ -39,14 +38,15 @@ function c75906310.initial_effect(c)
 		Duel.RegisterEffect(ge1,tp)
 	end
 end
-function c75906310.regop(e,tp,eg,ep,ev,re,r,rp)
-	for tc in aux.Next(eg) do
-		if tc:IsCode(84243274) then
-			Duel.RegisterFlagEffect(tc:GetControler(),75906310,0,0,0)
-		elseif tc:IsCode(73879377) then
-			Duel.RegisterFlagEffect(tc:GetControler(),75906311,0,0,0)
-		end
+function c75906310.reg(c)
+	if c:IsCode(84243274) then
+		Duel.RegisterFlagEffect(c:GetControler(),75906310,0,0,0)
+	elseif c:IsCode(73879377) then
+		Duel.RegisterFlagEffect(c:GetControler(),75906311,0,0,0)
 	end
+end
+function c75906310.regop(e,tp,eg,ep,ev,re,r,rp)
+	eg:ForEach(c75906310.reg)
 end
 function c75906310.splimit(e,se,sp,st)
 	return e:GetHandler():GetLocation()~=LOCATION_EXTRA
@@ -64,7 +64,7 @@ function c75906310.acfilter(c,cd)
 	return c:IsFaceup() and c:IsCode(cd)
 end
 function c75906310.aclimit(e,re,tp)
-	return Duel.IsExistingMatchingCard(c75906310.acfilter,e:GetHandlerPlayer(),LOCATION_REMOVED,0,1,nil,re:GetHandler():GetCode())
+	return Duel.IsExistingMatchingCard(c75906310.acfilter,e:GetHandlerPlayer(),LOCATION_REMOVED,LOCATION_REMOVED,1,nil,re:GetHandler():GetCode())
 end
 function c75906310.rmcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp
@@ -75,13 +75,16 @@ function c75906310.rmcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToRemoveAsCost,tp,LOCATION_DECK+LOCATION_EXTRA,0,1,1,nil)
 	Duel.Remove(g,POS_FACEUP,REASON_COST)
 end
+function c75906310.rmfilter(c)
+	return c:IsAbleToRemove() and (c:IsLocation(LOCATION_SZONE) or aux.SpElimFilter(c,false,true))
+end
 function c75906310.rmtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD+LOCATION_GRAVE,nil)
+	local g=Duel.GetMatchingGroup(c75906310.rmfilter,tp,0,LOCATION_ONFIELD+LOCATION_GRAVE,nil)
 	if chk==0 then return g:GetCount()>0 end
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,g:GetCount(),0,0)
 end
 function c75906310.rmop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD+LOCATION_GRAVE,nil)
+	local g=Duel.GetMatchingGroup(c75906310.rmfilter,tp,0,LOCATION_ONFIELD+LOCATION_GRAVE,nil)
 	if g:GetCount()>0 then
 		Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
 	end

--- a/script/c84899094.lua
+++ b/script/c84899094.lua
@@ -1,0 +1,73 @@
+--星杯の守護竜
+--Star Grail's Protector Dragon
+function c84899094.initial_effect(c)
+	--negate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(84899094,0))
+	e1:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetRange(LOCATION_HAND+LOCATION_MZONE)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e1:SetCondition(c84899094.condition)
+	e1:SetCost(c84899094.cost)
+	e1:SetTarget(c84899094.target)
+	e1:SetOperation(c84899094.operation)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(84899094,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCountLimit(1,84899094)
+	e2:SetCost(aux.bfgcost)
+	e2:SetTarget(c84899094.sptg)
+	e2:SetOperation(c84899094.spop)
+	c:RegisterEffect(e2)
+end
+function c84899094.filter(c,tp)
+	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsLinkState()
+end
+function c84899094.condition(e,tp,eg,ep,ev,re,r,rp)
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) then return false end
+	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
+	return g and g:IsExists(c84899094.filter,1,nil,tp)
+		and Duel.IsChainNegatable(ev)
+end
+function c84899094.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
+end
+function c84899094.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	if re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
+end
+function c84899094.operation(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
+		Duel.Destroy(eg,REASON_EFFECT)
+	end
+end
+function c84899094.spfilter(c,e,tp,zone)
+	return c:IsType(TYPE_NORMAL) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE,tp,zone)
+end
+function c84899094.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local zone=Duel.GetLinkedZone(tp)&0x1f
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and c84899094.spfilter(chkc,e,tp,zone) end
+	if chk==0 then return zone~=0
+		and Duel.IsExistingTarget(c84899094.spfilter,tp,LOCATION_GRAVE,0,1,e:GetHandler(),e,tp,zone) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local tg=Duel.SelectTarget(tp,c84899094.spfilter,tp,LOCATION_GRAVE,0,1,1,e:GetHandler(),e,tp,zone)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tg,1,0,0)
+end
+function c84899094.spop(e,tp,eg,ep,ev,re,r,rp)
+	local zone=Duel.GetLinkedZone(tp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and zone~=0 then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP_DEFENSE,zone)
+	end
+end

--- a/script/c9236985.lua
+++ b/script/c9236985.lua
@@ -1,0 +1,39 @@
+--リチュアの写魂鏡
+function c9236985.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c9236985.target)
+	e1:SetOperation(c9236985.activate)
+	c:RegisterEffect(e1)
+end
+function c9236985.filter(c,e,tp,lp)
+	if c:GetType()&0x81~=0x81 or not c:IsSetCard(0x3a) 
+		or not c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_RITUAL,tp,true,false) then return false end
+	return lp>c:GetLevel()*500
+end
+function c9236985.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		local lp=Duel.GetLP(tp)
+		return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+			and Duel.IsExistingMatchingCard(c9236985.filter,tp,LOCATION_HAND,0,1,nil,e,tp,lp)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+end
+function c9236985.activate(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	local lp=Duel.GetLP(tp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local tg=Duel.SelectMatchingCard(tp,c9236985.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp,lp)
+	local tc=tg:GetFirst()
+	if tc then
+		mustpay=true
+		Duel.PayLPCost(tp,tc:GetLevel()*500)
+		mustpay=false
+		tc:SetMaterial(nil)
+		Duel.SpecialSummon(tc,SUMMON_TYPE_RITUAL,tp,tp,true,false,POS_FACEUP)
+		tc:CompleteProcedure()
+	end
+end

--- a/script/c97997309.lua
+++ b/script/c97997309.lua
@@ -1,0 +1,135 @@
+--ゲーテの魔導書
+function c97997309.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(97997309,0))
+	e1:SetCategory(CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMING_END_PHASE)
+	e1:SetCountLimit(1,97997309+EFFECT_COUNT_CODE_OATH)
+	e1:SetCondition(c97997309.condition)
+	e1:SetCost(c97997309.cost)
+	e1:SetTarget(c97997309.target1)
+	e1:SetOperation(c97997309.activate1)
+	e1:SetLabel(1)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(97997309,1))
+	e2:SetCategory(CATEGORY_POSITION)
+	e2:SetType(EFFECT_TYPE_ACTIVATE)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetHintTiming(0,0x1c0+TIMING_BATTLE_PHASE)
+	e2:SetCountLimit(1,97997309+EFFECT_COUNT_CODE_OATH)
+	e2:SetCondition(c97997309.condition)
+	e2:SetCost(c97997309.cost)
+	e2:SetTarget(c97997309.target2)
+	e2:SetOperation(c97997309.activate2)
+	e2:SetLabel(2)
+	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(97997309,2))
+	e3:SetCategory(CATEGORY_REMOVE)
+	e3:SetType(EFFECT_TYPE_ACTIVATE)
+	e3:SetCode(EVENT_FREE_CHAIN)
+	e3:SetHintTiming(0,0x1e0)
+	e3:SetCountLimit(1,97997309+EFFECT_COUNT_CODE_OATH)
+	e3:SetCondition(c97997309.condition)
+	e3:SetCost(c97997309.cost)
+	e3:SetTarget(c97997309.target3)
+	e3:SetOperation(c97997309.activate3)
+	e3:SetLabel(3)
+	c:RegisterEffect(e3)
+end
+c97997309.check=false
+function c97997309.cfilter(c)
+	return c:IsFaceup() and c:IsRace(RACE_SPELLCASTER)
+end
+function c97997309.rfilter(c)
+	return c:IsSetCard(0x106e) and c:IsType(TYPE_SPELL) and c:IsAbleToRemoveAsCost()
+end
+function c97997309.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(c97997309.cfilter,tp,LOCATION_MZONE,0,1,nil)
+end
+function c97997309.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	c97997309.check=true
+	if chk==0 then return true end
+end
+function c97997309.filter1(c)
+	return c:IsFacedown() and c:IsAbleToHand()
+end
+function c97997309.target1(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ct=e:GetLabel()
+	if chk==0 then
+		if not c97997309.check then return false end
+		c97997309.check=false
+		return Duel.IsExistingMatchingCard(c97997309.rfilter,tp,LOCATION_GRAVE,0,ct,nil) 
+			and Duel.IsExistingMatchingCard(c97997309.filter1,tp,LOCATION_SZONE,LOCATION_SZONE,1,e:GetHandler()) end
+	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c97997309.rfilter,tp,LOCATION_GRAVE,0,ct,ct,nil)
+	Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
+	local g=Duel.GetMatchingGroup(c97997309.filter1,tp,LOCATION_SZONE,LOCATION_SZONE,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+end
+function c97997309.activate1(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RTOHAND)
+	local g=Duel.SelectMatchingCard(tp,c97997309.filter1,tp,LOCATION_SZONE,LOCATION_SZONE,1,1,e:GetHandler())
+	if g:GetCount()>0 then
+		Duel.HintSelection(g)
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+	end
+end
+function c97997309.filter2(c)
+	return not c:IsPosition(POS_FACEUP_ATTACK) or c:IsCanTurnSet()
+end
+function c97997309.target2(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ct=e:GetLabel()
+	if chk==0 then
+		if not c97997309.check then return false end
+		c97997309.check=false
+		return Duel.IsExistingMatchingCard(c97997309.rfilter,tp,LOCATION_GRAVE,0,ct,nil) 
+			and Duel.IsExistingMatchingCard(c97997309.filter2,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c97997309.rfilter,tp,LOCATION_GRAVE,0,ct,ct,nil)
+	Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
+	local g=Duel.GetMatchingGroup(c97997309.filter2,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,1,0,0)
+end
+function c97997309.activate2(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_POSCHANGE)
+	local g=Duel.SelectMatchingCard(tp,c97997309.filter2,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.HintSelection(g)
+		if tc:IsPosition(POS_FACEUP_ATTACK) then
+			Duel.ChangePosition(tc,POS_FACEDOWN_DEFENSE)
+		else
+			local pos=Duel.SelectPosition(tp,tc,POS_FACEUP_ATTACK+POS_FACEDOWN_DEFENSE)
+			Duel.ChangePosition(tc,pos)
+		end
+	end
+end
+function c97997309.target3(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ct=e:GetLabel()
+	if chk==0 then
+		if not c97997309.check then return false end
+		c97997309.check=false
+		return Duel.IsExistingMatchingCard(c97997309.rfilter,tp,LOCATION_GRAVE,0,ct,nil) 
+			and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD,1,nil) end
+	Duel.Hint(HINT_OPSELECTED,1-tp,e:GetDescription())
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c97997309.rfilter,tp,LOCATION_GRAVE,0,ct,ct,nil)
+	Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
+	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
+end
+function c97997309.activate3(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.HintSelection(g)
+		Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
+	end
+end


### PR DESCRIPTION
* Red Supremacy interaction with Scarlight/RDA fix
* Remove card name hardcode in Spell Economics
* Remove new hardcoding checking Spell Economics in Star Blast
* Spellbook of Fate checking for cost
* World Chalice Guardragon shouldnt Summon in EMZone
* Armed Dragon Catapult Cannon proper checking of banished cards to prevent activation
* A-to-Z-Dragon Buster Cannon must ignore Fusion Tag
* Heavy Metal Raiders Special Summon effect is OPT
* Key/Whisper to World Legacy column checking fix