### PR TITLE
Fixes

### DIFF
--- a/script/c10000080.lua
+++ b/script/c10000080.lua
@@ -1,0 +1,155 @@
+--ラーの翼神竜－球体形
+function c10000080.initial_effect(c)
+	--summon with 3 tribute
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(10000080,0))
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_LIMIT_SUMMON_PROC)
+	e1:SetCondition(c10000080.ttcon1)
+	e1:SetOperation(c10000080.ttop1)
+	e1:SetValue(SUMMON_TYPE_ADVANCE)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(10000080,1))
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SPSUM_PARAM)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_LIMIT_SUMMON_PROC)
+	e2:SetTargetRange(POS_FACEUP_ATTACK,1)
+	e2:SetCondition(c10000080.ttcon2)
+	e2:SetOperation(c10000080.ttop2)
+	e2:SetValue(SUMMON_TYPE_ADVANCE)
+	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_LIMIT_SET_PROC)
+	e3:SetCondition(c10000080.setcon)
+	c:RegisterEffect(e3)
+	--cannot special summon
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	c:RegisterEffect(e4)
+	--control return
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e5:SetCode(EVENT_SUMMON_SUCCESS)
+	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e5:SetOperation(c10000080.retreg)
+	c:RegisterEffect(e5)
+	--attack limit
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_SINGLE)
+	e6:SetCode(EFFECT_CANNOT_ATTACK)
+	c:RegisterEffect(e6)
+	--cannot be target
+	local e7=Effect.CreateEffect(c)
+	e7:SetType(EFFECT_TYPE_SINGLE)
+	e7:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e7:SetCode(EFFECT_CANNOT_BE_BATTLE_TARGET)
+	e7:SetRange(LOCATION_MZONE)
+	e7:SetValue(aux.imval1)
+	c:RegisterEffect(e7)
+	local e8=e7:Clone()
+	e8:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
+	e8:SetValue(aux.tgoval)
+	c:RegisterEffect(e8)
+	--spsummon
+	local e9=Effect.CreateEffect(c)
+	e9:SetDescription(aux.Stringid(10000080,2))
+	e9:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e9:SetType(EFFECT_TYPE_IGNITION)
+	e9:SetRange(LOCATION_MZONE)
+	e9:SetCost(c10000080.spcost)
+	e9:SetTarget(c10000080.sptg)
+	e9:SetOperation(c10000080.spop)
+	c:RegisterEffect(e9)
+end
+function c10000080.ttcon1(e,c,minc)
+	if c==nil then return true end
+	return minc<=3 and Duel.CheckTribute(c,3)
+end
+function c10000080.ttop1(e,tp,eg,ep,ev,re,r,rp,c)
+	local g=Duel.SelectTribute(tp,c,3,3)
+	c:SetMaterial(g)
+	Duel.Release(g,REASON_SUMMON+REASON_MATERIAL)
+end
+function c10000080.ttcon2(e,c,minc)
+	if c==nil then return true end
+	local tp=c:GetControler()
+	for _,te in ipairs(Duel.GetPlayerEffect(tp,EFFECT_CANNOT_SUMMON)) do
+		local tg=te:GetTarget()
+		if type(tg)~='function' or tg(te,c,tp,SUMMON_TYPE_ADVANCE,POS_FACEUP_ATTACK,1-tp) then return false end
+	end
+	local mg=Duel.GetFieldGroup(tp,0,LOCATION_MZONE)
+	return minc<=3 and Duel.CheckTribute(c,3,3,mg,1-tp)
+end
+function c10000080.ttop2(e,tp,eg,ep,ev,re,r,rp,c)
+	local mg=Duel.GetFieldGroup(tp,0,LOCATION_MZONE)
+	local g=Duel.SelectTribute(tp,c,3,3,mg,1-tp)
+	c:SetMaterial(g)
+	Duel.Release(g,REASON_SUMMON+REASON_MATERIAL)
+end
+function c10000080.setcon(e,c,minc)
+	if not c then return true end
+	return false
+end
+function c10000080.retreg(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	c:RegisterFlagEffect(10000080,RESET_EVENT+0x1fc0000+RESET_PHASE+PHASE_END,0,2)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_PHASE+PHASE_END)
+	e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e1:SetLabel(Duel.GetTurnCount()+1)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c10000080.retcon)
+	e1:SetOperation(c10000080.retop)
+	e1:SetReset(RESET_PHASE+PHASE_END,2)
+	Duel.RegisterEffect(e1,tp)
+end
+function c10000080.retcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnCount()==e:GetLabel() and e:GetOwner():GetFlagEffect(10000080)~=0
+end
+function c10000080.retop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetOwner()
+	c:ResetEffect(EFFECT_SET_CONTROL,RESET_CODE)
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SET_CONTROL)
+	e1:SetValue(c:GetOwner())
+	e1:SetReset(RESET_EVENT+0xec0000)
+	c:RegisterEffect(e1)
+end
+function c10000080.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsReleasable() end
+	Duel.Release(e:GetHandler(),REASON_COST)
+end
+function c10000080.filter(c,e,tp)
+	return c:IsCode(10000010) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+end
+function c10000080.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if e:GetHandler():GetSequence()<5 then ft=ft+1 end
+	if chk==0 then return ft>0 and Duel.IsExistingMatchingCard(c10000080.filter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_DECK)
+end
+function c10000080.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c10000080.filter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc and Duel.SpecialSummonStep(tc,0,tp,tp,true,false,POS_FACEUP) then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_SET_ATTACK)
+		e1:SetValue(4000)
+		e1:SetReset(RESET_EVENT+0x1fe0000)
+		tc:RegisterEffect(e1)
+		local e2=e1:Clone()
+		e2:SetCode(EFFECT_SET_DEFENSE)
+		tc:RegisterEffect(e2)
+		Duel.SpecialSummonComplete()
+	end
+end

--- a/script/c1322368.lua
+++ b/script/c1322368.lua
@@ -1,0 +1,58 @@
+--SPYRAL－ザ・ダブルヘリックス
+--SPYRAL - The Double Helix
+function c1322368.initial_effect(c)
+	--link summon
+	c:EnableReviveLimit()
+	aux.AddLinkProcedure(c,aux.FilterBoolFunction(Card.IsSetCard,0xee),2,2)
+	--change name
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetCode(EFFECT_CHANGE_CODE)
+	e1:SetRange(LOCATION_MZONE+LOCATION_GRAVE)
+	e1:SetValue(41091257)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(1322368,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1,1322368)
+	e2:SetTarget(c1322368.sptg)
+	e2:SetOperation(c1322368.spop)
+	c:RegisterEffect(e2)
+end
+function c1322368.spfilter(c,e,tp,zone)
+	return c:IsSetCard(0xee) and c:IsType(TYPE_MONSTER) and (c:IsAbleToHand() or (zone~=0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)))
+end
+function c1322368.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local zone=e:GetHandler():GetLinkedZone(tp)
+	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_DECK)>0
+		and Duel.IsExistingMatchingCard(c1322368.spfilter,tp,LOCATION_DECK+LOCATION_GRAVE,0,1,nil,e,tp,zone) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CARDTYPE)
+	e:SetLabel(Duel.SelectOption(tp,70,71,72))
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK+LOCATION_GRAVE)
+end
+function c1322368.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetFieldGroupCount(tp,0,LOCATION_DECK)==0 then return end
+	Duel.ConfirmDecktop(1-tp,1)
+	local g=Duel.GetDecktopGroup(1-tp,1)
+	local tc=g:GetFirst()
+	local opt=e:GetLabel()
+	if (opt==0 and tc:IsType(TYPE_MONSTER)) or (opt==1 and tc:IsType(TYPE_SPELL)) or (opt==2 and tc:IsType(TYPE_TRAP)) then
+		local zone=e:GetHandler():GetLinkedZone(tp)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c1322368.spfilter),tp,LOCATION_DECK+LOCATION_GRAVE,0,1,1,nil,e,tp,zone)
+		local sc=sg:GetFirst()
+		if sc then
+			if zone~=0 and sc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp,zone)
+				and (not sc:IsAbleToHand() or Duel.SelectYesNo(tp,aux.Stringid(1322368,1))) then
+				Duel.SpecialSummon(sc,0,tp,tp,false,false,POS_FACEUP,zone)
+			else
+				Duel.SendtoHand(sc,nil,REASON_EFFECT)
+				Duel.ConfirmCards(1-tp,sc)
+			end
+		end
+	end
+end

--- a/script/c24207889.lua
+++ b/script/c24207889.lua
@@ -1,6 +1,5 @@
 --センサー万別
 --Sensor Differentiation
---Scripted by Eerie Code and edo9300
 function c24207889.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -37,7 +36,7 @@ end
 c24207889[0]=nil
 c24207889[1]=nil
 function c24207889.sumlimit(e,c,sump,sumtype,sumpos,targetp)
-	if sumpos and bit.band(sumpos,POS_FACEDOWN)>0 then return false end
+	if sumpos and sumpos&POS_FACEDOWN>0 then return false end
 	local tp=sump
 	if targetp then tp=targetp end
 	return Duel.IsExistingMatchingCard(c24207889.rmfilter,tp,LOCATION_MZONE,0,1,nil,c:GetRace())
@@ -84,7 +83,7 @@ function c24207889.adjustop(e,tp,eg,ep,ev,re,r,rp)
 		c24207889[1]:Clear()
 	end
 	for p=0,1 do
-		local pg=c24207889[p]
+		local pg=c24207889[p]:Filter(Card.IsLocation,nil,LOCATION_MZONE)
 		local g=Duel.GetMatchingGroup(Card.IsFaceup,p,LOCATION_MZONE,0,nil)
 		local dg=g:Filter(c24207889.filter,nil,g,pg)
 		if dg:GetCount()==0 or Duel.SendtoGrave(dg,REASON_EFFECT)==0 then
@@ -100,4 +99,3 @@ function c24207889.adjustop(e,tp,eg,ep,ev,re,r,rp)
 		end
 	end
 end
-

--- a/script/c50470982.lua
+++ b/script/c50470982.lua
@@ -1,0 +1,24 @@
+--運命の分かれ道
+function c50470982.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_COIN)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c50470982.target)
+	e1:SetOperation(c50470982.activate)
+	c:RegisterEffect(e1)
+end
+c50470982.toss_coin=true
+function c50470982.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_COIN,nil,0,PLAYER_ALL,2)
+end
+function c50470982.activate(e,tp,eg,ep,ev,re,r,rp)
+	local res=Duel.TossCoin(tp,1)
+	if res==1 then Duel.Recover(tp,2000,REASON_EFFECT)
+	else Duel.Damage(tp,2000,REASON_EFFECT) end
+	res=Duel.TossCoin(1-tp,1)
+	if res==1 then Duel.Recover(1-tp,2000,REASON_EFFECT)
+	else Duel.Damage(1-tp,2000,REASON_EFFECT) end
+end

--- a/script/c92481084.lua
+++ b/script/c92481084.lua
@@ -1,0 +1,35 @@
+--心眼の祭殿
+--Altar of the Mind's Eye
+function c92481084.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	c:RegisterEffect(e1)
+	--battle damage
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e2:SetCode(EVENT_PRE_BATTLE_DAMAGE)
+	e2:SetRange(LOCATION_FZONE)
+	e2:SetOperation(c92481084.dop)
+	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e3:SetCode(92481084)
+	e3:SetRange(LOCATION_FZONE)
+	e3:SetTargetRange(1,1)
+	c:RegisterEffect(e3)
+end
+function c92481084.dop(e,tp,eg,ep,ev,re,r,rp)
+	local eff={Duel.GetPlayerEffect(ep,EFFECT_REVERSE_DAMAGE)}
+	if eff then
+		for _,te in ipairs(eff) do
+			local val=te:GetValue()
+			if type(val)=='function' then
+				if val(e,re,r,rp,rc) then return end
+			else return end
+		end
+	end
+	Duel.ChangeBattleDamage(ep,1000)
+end

--- a/script/c95448692.lua
+++ b/script/c95448692.lua
@@ -1,0 +1,53 @@
+--ダメージ・ダイエット
+function c95448692.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetOperation(c95448692.activate)
+	c:RegisterEffect(e1)
+	--effect damage
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCost(aux.bfgcost)
+	e2:SetOperation(c95448692.activate2)
+	c:RegisterEffect(e2)
+end
+c95448692[0]=0
+c95448692[1]=0
+function c95448692.activate(e,tp,eg,ep,ev,re,r,rp)
+	c95448692[tp]=1
+	if Duel.GetFlagEffect(tp,95448692)~=0 then return end
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CHANGE_DAMAGE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	e1:SetLabel(tp)
+	e1:SetValue(c95448692.val)
+	e1:SetReset(RESET_PHASE+PHASE_END,1)
+	Duel.RegisterEffect(e1,tp)
+	Duel.RegisterFlagEffect(tp,95448692,RESET_PHASE+PHASE_END,0,1)
+end
+function c95448692.activate2(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetFlagEffect(tp,95448692)~=0 then return end
+	c95448692[tp]=0
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CHANGE_DAMAGE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	e1:SetLabel(tp)
+	e1:SetValue(c95448692.val)
+	e1:SetReset(RESET_PHASE+PHASE_END,1)
+	Duel.RegisterEffect(e1,tp)
+	Duel.RegisterFlagEffect(tp,95448692,RESET_PHASE+PHASE_END,0,1)
+end
+function c95448692.val(e,re,dam,r,rp,rc)
+	if r&REASON_BATTLE>0 and Duel.IsPlayerAffectedByEffect(e:GetLabel(),92481084) then return dam end
+	if c95448692[e:GetOwnerPlayer()]==1 or r&REASON_EFFECT~=0 then
+		return dam/2
+	else return dam end
+end


### PR DESCRIPTION
Winged Dragon of Ra - Sphere Mode fix - Proper checking vs Gozen Match/Rivalry of Warlords
The Paths of Destiny fix - Gun Cannon Shot's Graveyard effect should be able to chain to it
Sensor Differentiation bug vs Mask Change
Temple of the Mind's Eye vs Damage Diet ruling - If both effects are applied, the final damage will always be 1000.
SPYRAL Double Helix fix - Bug: When using its effect and its control was changed, it will continue to allow Special Summoning to 1 of your zones.