### PR TITLE
Cards that end the Battle Phase ruling update

### DIFF
--- a/script/c15552258.lua
+++ b/script/c15552258.lua
@@ -1,0 +1,37 @@
+--ハーフorストップ
+function c15552258.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetHintTiming(0,TIMING_BATTLE_START)
+	e1:SetCondition(c15552258.condition)
+	e1:SetOperation(c15552258.activate)
+	c:RegisterEffect(e1)
+end
+function c15552258.condition(e,tp,eg,ep,ev,re,r,rp)
+	return tp~=Duel.GetTurnPlayer() and (Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<PHASE_BATTLE)
+end
+function c15552258.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,0,LOCATION_MZONE,nil)
+	local opt=0
+	if g:GetCount()==0 then
+		opt=Duel.SelectOption(1-tp,aux.Stringid(15552258,1))+1
+	else
+		opt=Duel.SelectOption(1-tp,aux.Stringid(15552258,0),aux.Stringid(15552258,1))
+	end
+	if opt==1 then
+		Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
+		return
+	end
+	local tc=g:GetFirst()
+	while tc do
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+		e1:SetValue(tc:GetAttack()/2)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_BATTLE)
+		tc:RegisterEffect(e1)
+		tc=g:GetNext()
+	end
+end

--- a/script/c34710660.lua
+++ b/script/c34710660.lua
@@ -1,0 +1,20 @@
+--超電磁タートル
+function c34710660.initial_effect(c)
+	--end battle phase
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(34710660,0))
+	e1:SetType(EFFECT_TYPE_QUICK_O)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetRange(LOCATION_GRAVE)
+	e1:SetCountLimit(1,34710660+EFFECT_COUNT_CODE_DUEL)
+	e1:SetCondition(c34710660.condition)
+	e1:SetCost(aux.bfgcost)
+	e1:SetOperation(c34710660.operation)
+	c:RegisterEffect(e1)
+end
+function c34710660.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp and (Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<PHASE_BATTLE)
+end
+function c34710660.operation(e,tp,eg,ep,ev,re,r,rp)
+	Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
+end

--- a/script/c67381587.lua
+++ b/script/c67381587.lua
@@ -1,0 +1,51 @@
+--黒猫の睨み
+function c67381587.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c67381587.condition)
+	e1:SetOperation(c67381587.activate)
+	c:RegisterEffect(e1)
+	--position change
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_POSITION)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCost(aux.bfgcost)
+	e2:SetTarget(c67381587.postg)
+	e2:SetOperation(c67381587.posop)
+	c:RegisterEffect(e2)
+end
+function c67381587.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp and (Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<PHASE_BATTLE)
+		and Duel.IsExistingMatchingCard(Card.IsPosition,tp,LOCATION_MZONE,0,2,nil,POS_FACEDOWN_DEFENSE)
+end
+function c67381587.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
+end
+function c67381587.posfilter1(c)
+	return c:IsFaceup() and c:IsSetCard(0xcc) and c:IsCanTurnSet()
+		and Duel.IsExistingTarget(c67381587.posfilter2,0,LOCATION_MZONE,LOCATION_MZONE,1,c)
+end
+function c67381587.posfilter2(c)
+	return c:IsFaceup() and c:IsCanTurnSet()
+end
+function c67381587.postg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
+	if chk==0 then return Duel.IsExistingTarget(c67381587.posfilter1,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_POSCHANGE)
+	local g1=Duel.SelectTarget(tp,c67381587.posfilter1,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_POSCHANGE)
+	local g2=Duel.SelectTarget(tp,c67381587.posfilter2,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,g1:GetFirst())
+	g1:Merge(g2)
+	Duel.SetOperationInfo(0,CATEGORY_POSITION,g1,2,0,0)
+end
+function c67381587.posop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	if g:GetCount()>0 then
+		Duel.ChangePosition(g,POS_FACEDOWN_DEFENSE)
+	end
+end

--- a/script/c79205581.lua
+++ b/script/c79205581.lua
@@ -1,0 +1,51 @@
+--強制終了
+function c79205581.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(c79205581.cost)
+	e1:SetTarget(c79205581.target)
+	c:RegisterEffect(e1)
+	--instant(chain)
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(79205581,0))
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetCondition(c79205581.bpcon)
+	e2:SetTarget(c79205581.bpcost)
+	e2:SetOperation(c79205581.bpop)
+	c:RegisterEffect(e2)
+end
+function c79205581.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	e:SetLabel(1)
+	return true
+end
+function c79205581.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chk==0 then
+		e:SetLabel(0)
+		return true
+	end
+	if c79205581.bpcon(e,tp,eg,ep,ev,re,r,rp) and (e:GetLabel()~=1 or c79205581.bpcost(e,tp,eg,ep,ev,re,r,rp,0)) 
+		and Duel.SelectYesNo(tp,94) then
+		if e:GetLabel()==1 then c79205581.bpcost(e,tp,eg,ep,ev,re,r,rp,1) end
+		e:SetOperation(c79205581.bpop)
+	else
+		e:SetOperation(nil)
+	end
+end
+function c79205581.bpcon(e,tp,eg,ep,ev,re,r,rp)
+	return (Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<PHASE_BATTLE) 
+		and (not e:GetHandler():IsStatus(STATUS_CHAINING) or e:IsHasType(EFFECT_TYPE_ACTIVATE))
+end
+function c79205581.bpcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToGraveAsCost,tp,LOCATION_ONFIELD,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,Card.IsAbleToGraveAsCost,tp,LOCATION_ONFIELD,0,1,1,e:GetHandler())
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c79205581.bpop(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	Duel.SkipPhase(Duel.GetTurnPlayer(),PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
+end

--- a/script/c9852718.lua
+++ b/script/c9852718.lua
@@ -1,0 +1,41 @@
+--決別
+function c9852718.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCondition(c9852718.condition)
+	e1:SetCost(c9852718.cost)
+	e1:SetOperation(c9852718.activate)
+	c:RegisterEffect(e1)
+end
+function c9852718.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp and (Duel.GetCurrentPhase()>=PHASE_BATTLE_START and Duel.GetCurrentPhase()<PHASE_BATTLE)
+end
+function c9852718.cfilter(c)
+	return c:IsType(TYPE_SPELL) and c:IsAbleToGraveAsCost()
+end
+function c9852718.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c9852718.cfilter,tp,LOCATION_HAND,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c9852718.cfilter,tp,LOCATION_HAND,0,1,1,nil)
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c9852718.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.SkipPhase(1-tp,PHASE_BATTLE,RESET_PHASE+PHASE_BATTLE,1)
+	local g=Duel.GetMatchingGroup(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	local tc=g:GetFirst()
+	while tc do
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_DISABLE)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(e:GetHandler())
+		e2:SetType(EFFECT_TYPE_SINGLE)
+		e2:SetCode(EFFECT_DISABLE_EFFECT)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e2)
+		tc=g:GetNext()
+	end
+end


### PR DESCRIPTION
Cards that end the Battle Phase (e.g. Electromagnetic Turtle, Scrubbed Raid, etc.) cannot be applied at the end of the Battle Phase.