### PR TITLE
Another fix for 2018.1 F/L Lists

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -292,7 +292,7 @@
 6602300 1 --重爆撃禽 ボム・フェネクス  Blaze Fenix, The Burning Bombardment Bird
 1561110 1 --ABC-Dragon Buster
 65536818 1 --Denglong, First of the Yang Zing
-5043011 1 --Firewall Dragon
+5043010 1 --Firewall Dragon
 33782437 1 --一時休戦 One Day of peace										SPELLS CARDS
 66957584 1 --インフェルニティガン Infernity launcer
 81439173 1 --おろかな埋葬 Foolish Burial
@@ -330,7 +330,6 @@
 #semi limited OCG
 423585 2 --召喚僧サモンプリースト Summoner Monk
 43722862 2 --Windwitch – Ice Bell
-15341821 2 --ダンディライオン Dandylion
 10028593 2 --輪廻天狗 Reborn Tengu
 33184167 2 --同族感染ウィルス Tribe-Infecting Virus
 75732622 2 --Grinder Golem
@@ -500,7 +499,7 @@
 52687916 1 --Trishula, Dragon of the Ice Barrier
 90953320 1 --T.G. Hyper Librarian
 27552504 1 --Beatrice, Lady of Eternal
-5043011 1 --Firewall Dragon
+5043010 1 --Firewall Dragon
 77565204 1 --Future Fusion 									SPELLS CARDS
 14087893 1 --Book of Moon 								
 11110587 1 --That Grass Looks Greener


### PR DESCRIPTION
-"Firewall Dragon"'s limitation was not corrected applied previously due to multiples artworks and alias usage.
--Removed extra entry that caused "Dandylion" incorrectly to be at 2