### PR TITLE
Fix for 2018.1 Worlds F/L List

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -559,7 +559,6 @@
 74311226 2 --Atlantean Dragoons
 85087012 2 --Card Tropper
 72989439 2 --Black Luster Soldier - Envoy of the Beginning
-14943837 2 --Debris Dragon
 00423585 2 --Summoner Monk
 71564252 2 --Thunder King Rai-Oh
 59297550 2 --Wind-up Magician


### PR DESCRIPTION
Removed semi-limitation applied on "Debris Dragon"