### PR TITLE
Fix "Armored Cybern"

### DIFF
--- a/script/c67159705.lua
+++ b/script/c67159705.lua
@@ -1,0 +1,44 @@
+--アーマード・サイバーン
+function c67159705.initial_effect(c)
+	aux.AddUnionProcedure(c,c67159705.unfilter)
+	--destroy
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(67159705,2))
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_SZONE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(aux.IsUnionState)
+	e1:SetTarget(c67159705.destg)
+	e1:SetOperation(c67159705.desop)
+	c:RegisterEffect(e1)
+end
+function c67159705.unfilter(c)
+	return c:IsCode(70095154) or aux.IsMaterialListCode(c,70095154)
+end
+function c67159705.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsFaceup() end
+	if chk==0 then return e:GetHandler():GetEquipTarget():GetAttack()>=1000
+		and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c67159705.desop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	local ec=c:GetEquipTarget()
+	local atk=ec:GetAttack()
+	if atk<1000 then return end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetValue(-1000)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
+	ec:RegisterEffect(e1)
+	local tc=Duel.GetFirstTarget()
+	if atk-ec:GetAttack()==1000 and tc and tc:IsRelateToEffect(e) and tc:IsFaceup() then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end


### PR DESCRIPTION
Registering an effect returns nil, so a check that did so in the previous code did not work. Now checks for changed atk, which also eliminates the need for checking for Reverse Trap and the like. Credit to MLD for bringing the issue to my attention.