### PR TITLE
Skyfang Brigade Training Fix

### DIFF
--- a/script/c100408026.lua
+++ b/script/c100408026.lua
@@ -34,7 +34,7 @@ function c100408026.initial_effect(c)
 end
 function c100408026.spfilter1(c,e,tp)
 	local lv=c:GetLevel()
-	return (c:IsReason(REASON_BATTLE) or (rp~=tp and c:IsReason(REASON_EFFECT))
+	return (c:IsReason(REASON_BATTLE) or (rp~=tp and c:IsReason(REASON_EFFECT)))
 		and c:IsPreviousSetCard(0x214) and c:IsType(TYPE_MONSTER)
 		and c:IsPreviousLocation(LOCATION_MZONE) and c:GetPreviousControler()==tp
 		and c:IsLocation(LOCATION_GRAVE+LOCATION_REMOVED) and c:IsCanBeEffectTarget(e)


### PR DESCRIPTION
Fixed a missing ")" preventing the card activation