### PR TITLE
Fixes for Elemental Lords and Krawlers

### DIFF
--- a/script/c10698416.lua
+++ b/script/c10698416.lua
@@ -1,0 +1,83 @@
+--クローラー・ランヴィエ
+function c10698416.initial_effect(c)
+	--flip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(10698416,0))
+	e1:SetCategory(CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_FLIP+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e1:SetCountLimit(1,10698416)
+	e1:SetTarget(c10698416.target)
+	e1:SetOperation(c10698416.operation)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(10698416,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCountLimit(1,10698417)
+	e2:SetCondition(c10698416.spcon)
+	e2:SetTarget(c10698416.sptg)
+	e2:SetOperation(c10698416.spop)
+	c:RegisterEffect(e2)
+end
+function c10698416.filter(c)
+	return c:IsSetCard(0x104) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+end
+function c10698416.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c10698416.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c10698416.filter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectTarget(tp,c10698416.filter,tp,LOCATION_GRAVE,0,1,2,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+end
+function c10698416.operation(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+	end
+end
+function c10698416.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousPosition(POS_FACEUP) and c:GetLocation()~=LOCATION_DECK
+		and c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp and c:GetPreviousControler()==tp
+end
+function c10698416.filter1(c,e,tp)
+	return c:IsSetCard(0x104) and not c:IsCode(10698416) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c10698416.filter2(c,g)
+	return g:IsExists(c10698416.filter3,1,c,c:GetCode())
+end
+function c10698416.filter3(c,code)
+	return not c:IsCode(code)
+end
+function c10698416.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if Duel.IsPlayerAffectedByEffect(tp,59822133) then return false end
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return false end
+		local g=Duel.GetMatchingGroup(c10698416.filter1,tp,LOCATION_DECK,0,nil,e,tp)
+		return g:IsExists(c10698416.filter2,1,nil,g)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_DECK)
+end
+function c10698416.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
+	local g=Duel.GetMatchingGroup(c10698416.filter1,tp,LOCATION_DECK,0,nil,e,tp)
+	local dg=g:Filter(c10698416.filter2,nil,g)
+	if dg:GetCount()>=1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=dg:Select(tp,1,1,nil)
+		local tc1=sg:GetFirst()
+		dg:Remove(Card.IsCode,nil,tc1:GetCode())
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tc2=dg:Select(tp,1,1,nil):GetFirst()
+		Duel.SpecialSummonStep(tc1,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.SpecialSummonStep(tc2,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.SpecialSummonComplete()
+		local g=Group.FromCards(tc1,tc2)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c13959634.lua
+++ b/script/c13959634.lua
@@ -1,0 +1,68 @@
+--氷霊神ムーラングレイス
+function c13959634.initial_effect(c)
+	c:EnableReviveLimit()
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c13959634.spcon)
+	c:RegisterEffect(e2)
+	--handes
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(13959634,0))
+	e3:SetCategory(CATEGORY_HANDES)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetCountLimit(1,13959634)
+	e3:SetTarget(c13959634.hdtg)
+	e3:SetOperation(c13959634.hdop)
+	c:RegisterEffect(e3)
+	--leave
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_LEAVE_FIELD_P)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_CANNOT_NEGATE)
+	e4:SetOperation(c13959634.leaveop)
+	c:RegisterEffect(e4)
+end
+function c13959634.spcon(e,c)
+	if c==nil then return true end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0 and
+		Duel.GetMatchingGroupCount(Card.IsAttribute,c:GetControler(),LOCATION_GRAVE,0,nil,ATTRIBUTE_WATER)==5
+end
+function c13959634.hdtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,1-tp,2)
+end
+function c13959634.hdop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetFieldGroup(tp,0,LOCATION_HAND):RandomSelect(tp,2)
+	Duel.SendtoGrave(g,REASON_EFFECT+REASON_DISCARD)
+end
+function c13959634.leaveop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsFacedown() then return end
+	local effp=e:GetHandler():GetControler()
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SKIP_BP)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	if Duel.GetTurnPlayer()==effp then
+		e1:SetLabel(Duel.GetTurnCount())
+		e1:SetCondition(c13959634.skipcon)
+		e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN,2)
+	else
+		e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN,1)
+	end
+	Duel.RegisterEffect(e1,effp)
+end
+function c13959634.skipcon(e)
+	return Duel.GetTurnCount()~=e:GetLabel()
+end

--- a/script/c15710054.lua
+++ b/script/c15710054.lua
@@ -1,0 +1,80 @@
+--クローラー・アクソン
+function c15710054.initial_effect(c)
+	--flip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(15710054,0))
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_FLIP+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e1:SetCountLimit(1,15710054)
+	e1:SetTarget(c15710054.target)
+	e1:SetOperation(c15710054.operation)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(15710054,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCountLimit(1,15710055)
+	e2:SetCondition(c15710054.spcon)
+	e2:SetTarget(c15710054.sptg)
+	e2:SetOperation(c15710054.spop)
+	c:RegisterEffect(e2)
+end
+function c15710054.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsOnField() and chkc:IsType(TYPE_SPELL+TYPE_TRAP) end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsType,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,nil,TYPE_SPELL+TYPE_TRAP) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,Card.IsType,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,1,1,nil,TYPE_SPELL+TYPE_TRAP)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c15710054.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end
+function c15710054.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousPosition(POS_FACEUP) and c:GetLocation()~=LOCATION_DECK
+		and c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp and c:GetPreviousControler()==tp
+end
+function c15710054.filter1(c,e,tp)
+	return c:IsSetCard(0x104) and not c:IsCode(15710054) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c15710054.filter2(c,g)
+	return g:IsExists(c15710054.filter3,1,c,c:GetCode())
+end
+function c15710054.filter3(c,code)
+	return not c:IsCode(code)
+end
+function c15710054.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if Duel.IsPlayerAffectedByEffect(tp,59822133) then return false end
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return false end
+		local g=Duel.GetMatchingGroup(c15710054.filter1,tp,LOCATION_DECK,0,nil,e,tp)
+		return g:IsExists(c15710054.filter2,1,nil,g)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_DECK)
+end
+function c15710054.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
+	local g=Duel.GetMatchingGroup(c15710054.filter1,tp,LOCATION_DECK,0,nil,e,tp)
+	local dg=g:Filter(c15710054.filter2,nil,g)
+	if dg:GetCount()>=1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=dg:Select(tp,1,1,nil)
+		local tc1=sg:GetFirst()
+		dg:Remove(Card.IsCode,nil,tc1:GetCode())
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tc2=dg:Select(tp,1,1,nil):GetFirst()
+		Duel.SpecialSummonStep(tc1,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.SpecialSummonStep(tc2,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.SpecialSummonComplete()
+		local g=Group.FromCards(tc1,tc2)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c35842855.lua
+++ b/script/c35842855.lua
@@ -1,0 +1,80 @@
+--炎霊神パイロレクス
+function c35842855.initial_effect(c)
+	c:EnableReviveLimit()
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c35842855.spcon)
+	c:RegisterEffect(e2)
+	--destroy
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(35842855,0))
+	e3:SetCategory(CATEGORY_DESTROY+CATEGORY_DAMAGE)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetCountLimit(1,35842855)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetTarget(c35842855.destg)
+	e3:SetOperation(c35842855.desop)
+	c:RegisterEffect(e3)
+	--leave
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_LEAVE_FIELD_P)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_CANNOT_NEGATE)
+	e4:SetOperation(c35842855.leaveop)
+	c:RegisterEffect(e4)
+end
+function c35842855.spcon(e,c)
+	if c==nil then return true end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0 and
+		Duel.GetMatchingGroupCount(Card.IsAttribute,c:GetControler(),LOCATION_GRAVE,0,nil,ATTRIBUTE_FIRE)==5
+end
+function c35842855.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) end
+	if chk==0 then return Duel.IsExistingTarget(aux.TRUE,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,aux.TRUE,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,PLAYER_ALL,0)
+end
+function c35842855.desop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.Destroy(tc,REASON_EFFECT)==1 then
+		local atk=tc:GetTextAttack()/2
+		if atk>0 then
+			Duel.Damage(tp,atk,REASON_EFFECT,true)
+			Duel.Damage(1-tp,atk,REASON_EFFECT,true)
+			Duel.RDComplete()
+		end
+	end
+end
+function c35842855.leaveop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsFacedown() then return end
+	local effp=e:GetHandler():GetControler()
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SKIP_BP)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	if Duel.GetTurnPlayer()==effp then
+		e1:SetLabel(Duel.GetTurnCount())
+		e1:SetCondition(c35842855.skipcon)
+		e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN,2)
+	else
+		e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN,1)
+	end
+	Duel.RegisterEffect(e1,effp)
+end
+function c35842855.skipcon(e)
+	return Duel.GetTurnCount()~=e:GetLabel()
+end

--- a/script/c39998992.lua
+++ b/script/c39998992.lua
@@ -1,0 +1,81 @@
+--エクスクローラー・シナプシス
+--Excrawler Synapses
+function c39998992.initial_effect(c)
+	--link summon
+	c:EnableReviveLimit()
+	aux.AddLinkProcedure(c,aux.FilterBoolFunctionEx(Card.IsAttribute,ATTRIBUTE_EARTH),2,2)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(39998992,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_LEAVE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e1:SetCondition(c39998992.spcon)
+	e1:SetTarget(c39998992.sptg)
+	e1:SetOperation(c39998992.spop)
+	c:RegisterEffect(e1)
+	--battle indestructable
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e2:SetTarget(c39998992.indtg)
+	e2:SetValue(1)
+	c:RegisterEffect(e2)
+	--stats up
+	local e3=e2:Clone()
+	e3:SetCode(EFFECT_UPDATE_ATTACK)
+	e3:SetValue(300)
+	c:RegisterEffect(e3)
+	local e4=e3:Clone()
+	e4:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e4)
+	--extra attack
+	local e5=e2:Clone()
+	e5:SetCode(EFFECT_EXTRA_ATTACK_MONSTER)
+	c:RegisterEffect(e5)
+end
+function c39998992.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return (c:IsReason(REASON_BATTLE) or (c:GetReasonPlayer()~=tp and c:IsReason(REASON_EFFECT)))
+		and c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousControler()==tp
+end
+function c39998992.spfilter1(c,e,tp)
+	return c:IsSetCard(0x104) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
+		and Duel.IsExistingTarget(c39998992.spfilter2,tp,LOCATION_GRAVE,0,1,c,c:GetCode(),e,tp)
+end
+function c39998992.spfilter2(c,cd,e,tp)
+	return not c:IsCode(cd) and c:IsSetCard(0x104) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
+end
+function c39998992.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1
+		and Duel.IsExistingTarget(c39998992.spfilter1,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g1=Duel.SelectTarget(tp,c39998992.spfilter1,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	local tc1=g1:GetFirst()
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g2=Duel.SelectTarget(tp,c39998992.spfilter2,tp,LOCATION_GRAVE,0,1,1,tc1,tc1:GetCode(),e,tp)
+	g1:Merge(g2)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g1,2,0,0)
+end
+function c39998992.spop(e,tp,eg,ep,ev,re,r,rp)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local g=tg:Filter(Card.IsRelateToEffect,nil,e)
+	if g:GetCount()==0 or ft<=0 or (g:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if ft<g:GetCount() then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		g=g:Select(tp,ft,ft,nil)
+	end
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c39998992.indtg(e,c)
+	return e:GetHandler():GetLinkedGroup():IsContains(c) and c:IsSetCard(0x104)
+end

--- a/script/c46083111.lua
+++ b/script/c46083111.lua
@@ -1,0 +1,81 @@
+--クローラー・デンドライト
+function c46083111.initial_effect(c)
+	--flip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(46083111,0))
+	e1:SetCategory(CATEGORY_TOGRAVE)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_FLIP+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCountLimit(1,46083111)
+	e1:SetTarget(c46083111.tgtg)
+	e1:SetOperation(c46083111.tgop)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(46083111,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCountLimit(1,46083112)
+	e2:SetCondition(c46083111.spcon)
+	e2:SetTarget(c46083111.sptg)
+	e2:SetOperation(c46083111.spop)
+	c:RegisterEffect(e2)
+end
+function c46083111.tgfilter(c)
+	return c:IsType(TYPE_MONSTER) and c:IsAbleToGrave()
+end
+function c46083111.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c46083111.tgfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
+end
+function c46083111.tgop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c46083111.tgfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoGrave(g,REASON_EFFECT)
+	end
+end
+function c46083111.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousControler()==tp and c:GetLocation()~=LOCATION_DECK
+		and c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp and c:GetPreviousControler()==tp
+end
+function c46083111.filter1(c,e,tp)
+	return c:IsSetCard(0x104) and not c:IsCode(46083111) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c46083111.filter2(c,g)
+	return g:IsExists(c46083111.filter3,1,c,c:GetCode())
+end
+function c46083111.filter3(c,code)
+	return not c:IsCode(code)
+end
+function c46083111.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if Duel.IsPlayerAffectedByEffect(tp,59822133) then return false end
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return false end
+		local g=Duel.GetMatchingGroup(c46083111.filter1,tp,LOCATION_DECK,0,nil,e,tp)
+		return g:IsExists(c46083111.filter2,1,nil,g)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_DECK)
+end
+function c46083111.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
+	local g=Duel.GetMatchingGroup(c46083111.filter1,tp,LOCATION_DECK,0,nil,e,tp)
+	local dg=g:Filter(c46083111.filter2,nil,g)
+	if dg:GetCount()>=1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=dg:Select(tp,1,1,nil)
+		local tc1=sg:GetFirst()
+		dg:Remove(Card.IsCode,nil,tc1:GetCode())
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tc2=dg:Select(tp,1,1,nil):GetFirst()
+		Duel.SpecialSummonStep(tc1,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.SpecialSummonStep(tc2,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.SpecialSummonComplete()
+		local g=Group.FromCards(tc1,tc2)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c51205763.lua
+++ b/script/c51205763.lua
@@ -1,0 +1,90 @@
+--クローラー・グリア
+function c51205763.initial_effect(c)
+	--flip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(51205763,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_FLIP+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCountLimit(1,51205763)
+	e1:SetTarget(c51205763.target)
+	e1:SetOperation(c51205763.operation)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(51205763,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCountLimit(1,51205764)
+	e2:SetCondition(c51205763.spcon)
+	e2:SetTarget(c51205763.sptg)
+	e2:SetOperation(c51205763.spop)
+	c:RegisterEffect(e2)
+end
+function c51205763.filter(c,e,tp)
+	return c:IsSetCard(0x104) and not c:IsCode(51205763) and (c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) or c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE))
+end
+function c51205763.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c51205763.filter,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_GRAVE)
+end
+function c51205763.operation(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c51205763.filter),tp,LOCATION_HAND+LOCATION_GRAVE,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if not tc then return end
+	local spos=0
+	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_ATTACK) then spos=spos+POS_FACEUP_ATTACK end
+	if tc:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE) then spos=spos+POS_FACEDOWN_DEFENSE end
+	if spos~=0 and Duel.SpecialSummon(tc,0,tp,tp,false,false,spos)~=0 then
+		if tc:IsFacedown() then
+			Duel.ConfirmCards(1-tp,tc)
+		end
+	end
+end
+function c51205763.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousPosition(POS_FACEUP) and c:GetLocation()~=LOCATION_DECK
+		and c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp and c:GetPreviousControler()==tp
+end
+function c51205763.filter1(c,e,tp)
+	return c:IsSetCard(0x104) and not c:IsCode(51205763) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c51205763.filter2(c,g)
+	return g:IsExists(c51205763.filter3,1,c,c:GetCode())
+end
+function c51205763.filter3(c,code)
+	return not c:IsCode(code)
+end
+function c51205763.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if Duel.IsPlayerAffectedByEffect(tp,59822133) then return false end
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return false end
+		local g=Duel.GetMatchingGroup(c51205763.filter1,tp,LOCATION_DECK,0,nil,e,tp)
+		return g:IsExists(c51205763.filter2,1,nil,g)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_DECK)
+end
+function c51205763.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
+	local g=Duel.GetMatchingGroup(c51205763.filter1,tp,LOCATION_DECK,0,nil,e,tp)
+	local dg=g:Filter(c51205763.filter2,nil,g)
+	if dg:GetCount()>=1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=dg:Select(tp,1,1,nil)
+		local tc1=sg:GetFirst()
+		dg:Remove(Card.IsCode,nil,tc1:GetCode())
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tc2=dg:Select(tp,1,1,nil):GetFirst()
+		Duel.SpecialSummonStep(tc1,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.SpecialSummonStep(tc2,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.SpecialSummonComplete()
+		local g=Group.FromCards(tc1,tc2)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c53027855.lua
+++ b/script/c53027855.lua
@@ -1,0 +1,72 @@
+--風霊神ウィンドローズ
+function c53027855.initial_effect(c)
+	c:EnableReviveLimit()
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c53027855.spcon)
+	c:RegisterEffect(e2)
+	--destroy
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(53027855,0))
+	e3:SetCategory(CATEGORY_DESTROY)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetCountLimit(1,53027855)
+	e3:SetTarget(c53027855.destg)
+	e3:SetOperation(c53027855.desop)
+	c:RegisterEffect(e3)
+	--leave
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_LEAVE_FIELD_P)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_CANNOT_NEGATE)
+	e4:SetOperation(c53027855.leaveop)
+	c:RegisterEffect(e4)
+end
+function c53027855.spcon(e,c)
+	if c==nil then return true end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0 and
+		Duel.GetMatchingGroupCount(Card.IsAttribute,c:GetControler(),LOCATION_GRAVE,0,nil,ATTRIBUTE_WIND)==5
+end
+function c53027855.desfilter(c)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function c53027855.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local g=Duel.GetMatchingGroup(c53027855.desfilter,tp,0,LOCATION_ONFIELD,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,g:GetCount(),0,0)
+end
+function c53027855.desop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(c53027855.desfilter,tp,0,LOCATION_ONFIELD,nil)
+	Duel.Destroy(g,REASON_EFFECT)
+end
+function c53027855.leaveop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsFacedown() then return end
+	local effp=e:GetHandler():GetControler()
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SKIP_BP)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,0)
+	if Duel.GetTurnPlayer()==effp then
+		e1:SetLabel(Duel.GetTurnCount())
+		e1:SetCondition(c53027855.skipcon)
+		e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN,2)
+	else
+		e1:SetReset(RESET_PHASE+PHASE_END+RESET_SELF_TURN,1)
+	end
+	Duel.RegisterEffect(e1,effp)
+end
+function c53027855.skipcon(e)
+	return Duel.GetTurnCount()~=e:GetLabel()
+end

--- a/script/c61468779.lua
+++ b/script/c61468779.lua
@@ -30,6 +30,7 @@ function c61468779.initial_effect(c)
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 	e4:SetCode(EVENT_LEAVE_FIELD_P)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_CANNOT_NEGATE)
 	e4:SetOperation(c61468779.leaveop)
 	c:RegisterEffect(e4)
 end

--- a/script/c66393507.lua
+++ b/script/c66393507.lua
@@ -1,0 +1,93 @@
+--エクスクローラー・ニューロゴス
+--Excrawler Neurogos
+--Scripted by Eerie Code
+function c66393507.initial_effect(c)
+	--link summon
+	c:EnableReviveLimit()
+	aux.AddLinkProcedure(c,aux.FilterBoolFunctionEx(Card.IsRace,RACE_INSECT),2,2)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(66393507,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_LEAVE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e1:SetCondition(c66393507.spcon)
+	e1:SetTarget(c66393507.sptg)
+	e1:SetOperation(c66393507.spop)
+	c:RegisterEffect(e1)
+	--battle indestructable
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e2:SetTarget(c66393507.indtg)
+	e2:SetValue(1)
+	c:RegisterEffect(e2)
+	--stats up
+	local e3=e2:Clone()
+	e3:SetCode(EFFECT_UPDATE_ATTACK)
+	e3:SetValue(300)
+	c:RegisterEffect(e3)
+	local e4=e3:Clone()
+	e4:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e4)
+	--double damage
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e5:SetCode(EVENT_PRE_BATTLE_DAMAGE)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetCondition(c66393507.damcon)
+	e5:SetOperation(c66393507.damop)
+	c:RegisterEffect(e5)	
+end
+function c66393507.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return (c:IsReason(REASON_BATTLE) or (c:GetReasonPlayer()~=tp and c:IsReason(REASON_EFFECT)))
+		and c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousControler()==tp
+end
+function c66393507.spfilter1(c,e,tp)
+	return c:IsSetCard(0x104) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
+		and Duel.IsExistingTarget(c66393507.spfilter2,tp,LOCATION_GRAVE,0,1,c,c:GetCode(),e,tp)
+end
+function c66393507.spfilter2(c,cd,e,tp)
+	return not c:IsCode(cd) and c:IsSetCard(0x104) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
+end
+function c66393507.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1
+		and Duel.IsExistingTarget(c66393507.spfilter1,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g1=Duel.SelectTarget(tp,c66393507.spfilter1,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	local tc1=g1:GetFirst()
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g2=Duel.SelectTarget(tp,c66393507.spfilter2,tp,LOCATION_GRAVE,0,1,1,tc1,tc1:GetCode(),e,tp)
+	g1:Merge(g2)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g1,2,0,0)
+end
+function c66393507.spop(e,tp,eg,ep,ev,re,r,rp)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local g=tg:Filter(Card.IsRelateToEffect,nil,e)
+	if g:GetCount()==0 or ft<=0 or (g:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if ft<g:GetCount() then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		g=g:Select(tp,ft,ft,nil)
+	end
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c66393507.indtg(e,c)
+	return e:GetHandler():GetLinkedGroup():IsContains(c) and c:IsSetCard(0x104)
+end
+function c66393507.damcon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=eg:GetFirst()
+	return ep~=tp and tc:IsSetCard(0x104) and tc:GetBattleTarget()~=nil and e:GetHandler():GetLinkedGroup():IsContains(tc)
+end
+function c66393507.damop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.ChangeBattleDamage(ep,ev*2)
+end

--- a/script/c8192327.lua
+++ b/script/c8192327.lua
@@ -30,7 +30,7 @@ function c8192327.initial_effect(c)
 	local e4=Effect.CreateEffect(c)
 	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 	e4:SetCode(EVENT_LEAVE_FIELD_P)
-	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_CANNOT_NEGATE)
 	e4:SetOperation(c8192327.leaveop)
 	c:RegisterEffect(e4)
 end

--- a/script/c83293307.lua
+++ b/script/c83293307.lua
@@ -1,0 +1,82 @@
+--クローラー・レセプター
+function c83293307.initial_effect(c)
+	--flip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(83293307,0))
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_FLIP+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCountLimit(1,83293307)
+	e1:SetTarget(c83293307.target)
+	e1:SetOperation(c83293307.operation)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(83293307,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCountLimit(1,83293308)
+	e2:SetCondition(c83293307.spcon)
+	e2:SetTarget(c83293307.sptg)
+	e2:SetOperation(c83293307.spop)
+	c:RegisterEffect(e2)
+end
+function c83293307.filter(c)
+	return c:IsSetCard(0x104) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+end
+function c83293307.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c83293307.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c83293307.operation(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c83293307.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c83293307.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousPosition(POS_FACEUP) and c:GetLocation()~=LOCATION_DECK
+		and c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp and c:GetPreviousControler()==tp
+end
+function c83293307.filter1(c,e,tp)
+	return c:IsSetCard(0x104) and not c:IsCode(83293307) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c83293307.filter2(c,g)
+	return g:IsExists(c83293307.filter3,1,c,c:GetCode())
+end
+function c83293307.filter3(c,code)
+	return not c:IsCode(code)
+end
+function c83293307.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if Duel.IsPlayerAffectedByEffect(tp,59822133) then return false end
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return false end
+		local g=Duel.GetMatchingGroup(c83293307.filter1,tp,LOCATION_DECK,0,nil,e,tp)
+		return g:IsExists(c83293307.filter2,1,nil,g)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_DECK)
+end
+function c83293307.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
+	local g=Duel.GetMatchingGroup(c83293307.filter1,tp,LOCATION_DECK,0,nil,e,tp)
+	local dg=g:Filter(c83293307.filter2,nil,g)
+	if dg:GetCount()>=1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=dg:Select(tp,1,1,nil)
+		local tc1=sg:GetFirst()
+		dg:Remove(Card.IsCode,nil,tc1:GetCode())
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tc2=dg:Select(tp,1,1,nil):GetFirst()
+		Duel.SpecialSummonStep(tc1,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.SpecialSummonStep(tc2,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.SpecialSummonComplete()
+		local g=Group.FromCards(tc1,tc2)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c88316955.lua
+++ b/script/c88316955.lua
@@ -1,0 +1,80 @@
+--クローラー・スパイン
+function c88316955.initial_effect(c)
+	--flip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(88316955,0))
+	e1:SetCategory(CATEGORY_DESTROY)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_FLIP+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e1:SetCountLimit(1,88316955)
+	e1:SetTarget(c88316955.target)
+	e1:SetOperation(c88316955.operation)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(88316955,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
+	e2:SetCode(EVENT_LEAVE_FIELD)
+	e2:SetCountLimit(1,88316956)
+	e2:SetCondition(c88316955.spcon)
+	e2:SetTarget(c88316955.sptg)
+	e2:SetOperation(c88316955.spop)
+	c:RegisterEffect(e2)
+end
+function c88316955.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) end
+	if chk==0 then return Duel.IsExistingTarget(nil,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_DESTROY)
+	local g=Duel.SelectTarget(tp,nil,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
+end
+function c88316955.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.Destroy(tc,REASON_EFFECT)
+	end
+end
+function c88316955.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsPreviousPosition(POS_FACEUP) and c:GetLocation()~=LOCATION_DECK
+		and c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp and c:GetPreviousControler()==tp
+end
+function c88316955.filter1(c,e,tp)
+	return c:IsSetCard(0x104) and not c:IsCode(88316955) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c88316955.filter2(c,g)
+	return g:IsExists(c88316955.filter3,1,c,c:GetCode())
+end
+function c88316955.filter3(c,code)
+	return not c:IsCode(code)
+end
+function c88316955.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then
+		if Duel.IsPlayerAffectedByEffect(tp,59822133) then return false end
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return false end
+		local g=Duel.GetMatchingGroup(c88316955.filter1,tp,LOCATION_DECK,0,nil,e,tp)
+		return g:IsExists(c88316955.filter2,1,nil,g)
+	end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_DECK)
+end
+function c88316955.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsPlayerAffectedByEffect(tp,59822133) then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
+	local g=Duel.GetMatchingGroup(c88316955.filter1,tp,LOCATION_DECK,0,nil,e,tp)
+	local dg=g:Filter(c88316955.filter2,nil,g)
+	if dg:GetCount()>=1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg=dg:Select(tp,1,1,nil)
+		local tc1=sg:GetFirst()
+		dg:Remove(Card.IsCode,nil,tc1:GetCode())
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local tc2=dg:Select(tp,1,1,nil):GetFirst()
+		Duel.SpecialSummonStep(tc1,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.SpecialSummonStep(tc2,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.SpecialSummonComplete()
+		local g=Group.FromCards(tc1,tc2)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c92781606.lua
+++ b/script/c92781606.lua
@@ -1,0 +1,104 @@
+--エクスクローラー・クオリアーク
+--Excrawler Qualiark
+--Scripted by Eerie Code
+function c92781606.initial_effect(c)
+	--link summon
+	c:EnableReviveLimit()
+	aux.AddLinkProcedure(c,aux.FilterBoolFunction(Card.IsSetCard,0x104),2,2)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(92781606,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_LEAVE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e1:SetCondition(c92781606.spcon)
+	e1:SetTarget(c92781606.sptg)
+	e1:SetOperation(c92781606.spop)
+	c:RegisterEffect(e1)
+	--atk up
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(LOCATION_MZONE,0)
+	e2:SetValue(300)
+	e2:SetCondition(c92781606.effcon)
+	e2:SetLabel(2)
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e3)
+	--actlimit
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e4:SetTargetRange(0,1)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetLabel(4)
+	e4:SetCondition(c92781606.actcon)
+	e4:SetValue(c92781606.actlimit)
+	c:RegisterEffect(e4)
+	--direct attack
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_FIELD)
+	e5:SetCode(EFFECT_DIRECT_ATTACK)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetTargetRange(LOCATION_MZONE,0)
+	e5:SetLabel(6)
+	e5:SetCondition(c92781606.effcon)
+	c:RegisterEffect(e5)
+end
+function c92781606.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return (c:IsReason(REASON_BATTLE) or (c:GetReasonPlayer()~=tp and c:IsReason(REASON_EFFECT)))
+		and c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousControler()==tp
+end
+function c92781606.spfilter1(c,e,tp)
+	return c:IsSetCard(0x104) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
+		and Duel.IsExistingTarget(c92781606.spfilter2,tp,LOCATION_GRAVE,0,1,c,c:GetCode(),e,tp)
+end
+function c92781606.spfilter2(c,cd,e,tp)
+	return not c:IsCode(cd) and c:IsSetCard(0x104) and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEDOWN_DEFENSE)
+end
+function c92781606.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1
+		and Duel.IsExistingTarget(c92781606.spfilter1,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g1=Duel.SelectTarget(tp,c92781606.spfilter1,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	local tc1=g1:GetFirst()
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g2=Duel.SelectTarget(tp,c92781606.spfilter2,tp,LOCATION_GRAVE,0,1,1,tc1,tc1:GetCode(),e,tp)
+	g1:Merge(g2)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g1,2,0,0)
+end
+function c92781606.spop(e,tp,eg,ep,ev,re,r,rp)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local g=tg:Filter(Card.IsRelateToEffect,nil,e)
+	if g:GetCount()==0 or ft<=0 or (g:GetCount()>1 and Duel.IsPlayerAffectedByEffect(tp,59822133)) then return end
+	if ft<g:GetCount() then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		g=g:Select(tp,ft,ft,nil)
+	end
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEDOWN_DEFENSE)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function c92781606.effilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x104)
+end
+function c92781606.effcon(e)
+	return Duel.GetMatchingGroupCount(c92781606.effilter,e:GetHandlerPlayer(),LOCATION_MZONE,0,nil)>=e:GetLabel()
+end
+function c92781606.actcon(e)
+	local ph=Duel.GetCurrentPhase()
+	return c92781606.effcon(e) and ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE
+end
+function c92781606.actlimit(e,re,tp)
+	return not re:GetHandler():IsImmuneToEffect(e)
+end


### PR DESCRIPTION
- Krawlers' effects now will not trigger if they are stolen and sent to the GY (e.g. by Borreload Dragon, Big Eye)
- Elemental Lords' Battle Phase skip effect now apply even if they leave the field when their effects are negated on the field