### PR TITLE
Fix Pot of Duality

### DIFF
--- a/script/c98645731.lua
+++ b/script/c98645731.lua
@@ -42,7 +42,7 @@ function c98645731.initial_effect(c)
 	end
 end
 function c98645731.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetActivityCount(tp,ACTIVITY_SPSUMMON)==0 and not c98645731[tp] end
+	if chk==0 then return Duel.GetActivityCount(tp,ACTIVITY_SPSUMMON)==0 end
 	--oath effects
 	local e1=Effect.CreateEffect(e:GetHandler())
 	e1:SetType(EFFECT_TYPE_FIELD)


### PR DESCRIPTION
Previously was unable to be activated if your opponent Special Summons a monster successfully in that turn.