### PR TITLE
Fix Destrudo the Lost Dragon's Frisson

### DIFF
--- a/script/c5560911.lua
+++ b/script/c5560911.lua
@@ -1,0 +1,56 @@
+--亡龍の戦慄－デストルドー
+function c5560911.initial_effect(c)
+	--special Summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(5560911,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_HAND+LOCATION_GRAVE)
+	e1:SetCountLimit(1,5560911)
+	e1:SetCost(c5560911.cost)
+	e1:SetTarget(c5560911.target)
+	e1:SetOperation(c5560911.operation)
+	c:RegisterEffect(e1)
+end
+function c5560911.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.PayLPCost(tp,math.floor(Duel.GetLP(tp)/2))
+end
+function c5560911.filter(c)
+	return c:IsFaceup() and c:IsLevelBelow(6)
+end
+function c5560911.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	local c=e:GetHandler()
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c5560911.filter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+		and Duel.IsExistingTarget(c5560911.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,c5560911.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
+end
+function c5560911.operation(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if c:IsRelateToEffect(e) then
+		local lv=tc:GetLevel()
+		if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)~=0 then
+			if tc:IsFaceup() then
+				local e1=Effect.CreateEffect(c)
+				e1:SetType(EFFECT_TYPE_SINGLE)
+				e1:SetCode(EFFECT_UPDATE_LEVEL)
+				e1:SetValue(-lv)
+				e1:SetReset(RESET_EVENT+0x1ff0000)
+				c:RegisterEffect(e1)
+			end
+			local e2=Effect.CreateEffect(c)
+			e2:SetType(EFFECT_TYPE_SINGLE)
+			e2:SetCode(EFFECT_LEAVE_FIELD_REDIRECT)
+			e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+			e2:SetReset(RESET_EVENT+0x47e0000)
+			e2:SetValue(LOCATION_DECKBOT)
+			c:RegisterEffect(e2)
+		end
+	end
+end


### PR DESCRIPTION
Previously was unable to be Special Summoned by its own effect if the target turns face-down or leaves the field, when it should be able to according to rulings