### PR TITLE
Bug-Fixed: Ruthless Drop Off

### DIFF
--- a/script/c47439573.lua
+++ b/script/c47439573.lua
@@ -30,7 +30,7 @@ function c47439573.rmfilter(c,g)
 	return c:IsAbleToRemove() and g:IsExists(Card.IsCode,1,nil,c:GetCode())
 end
 function c47439573.activate(e,tp,eg,ep,ev,re,r,rp)
-	local dg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(c47439573.filter,nil,e,tp)
+	local dg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(c47439573.filter,nil,e,1-tp)
 	local g=Duel.GetFieldGroup(tp,0,LOCATION_HAND)
 	if g:GetCount()>0 then
 		Duel.ConfirmCards(tp,g)


### PR DESCRIPTION
# Descriptions

In the operation (activate function), when filtering to obtain the cards returned to the hand. It was done on the player (tp) and not on the opponent (1-tp). So it has changed.

# Context
In turn 2, storming mirror force bounce monster to hand and <Ruthless Drop Off> is used but nothing is banished
(See replay: https://cdn.discordapp.com/attachments/291708361752313866/411078324681441282/drop_off_bug.yrp)

# Screenshot:
![Alt Text](https://cdn.discordapp.com/attachments/291708361752313866/411099523159425024/2018-02-08_11-01-55.gif)