### PR TITLE
Fixed many "Vampire" cards

### DIFF
--- a/script/c100408001.lua
+++ b/script/c100408001.lua
@@ -1,5 +1,5 @@
 --ヴァンパイアの使い魔
-
+--Vampire Familiar
 --Script by nekrozar
 function c100408001.initial_effect(c)
 	--tohand

--- a/script/c100408002.lua
+++ b/script/c100408002.lua
@@ -1,5 +1,5 @@
 --ヴァンパイアの眷属
-
+--Vampire Brood
 --Script by nekrozar
 function c100408002.initial_effect(c)
 	--tohand
@@ -20,7 +20,7 @@ function c100408002.initial_effect(c)
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetRange(LOCATION_GRAVE)
-	e2:SetCountLimit(1,100408101)
+	e2:SetCountLimit(1,100408102)
 	e2:SetCost(c100408002.spcost)
 	e2:SetTarget(c100408002.sptg)
 	e2:SetOperation(c100408002.spop)

--- a/script/c100408003.lua
+++ b/script/c100408003.lua
@@ -1,5 +1,5 @@
 --ヴァンパイア・フロイライン
-
+--Vampire Fraulen
 --Script by nekrozar
 function c100408003.initial_effect(c)
 	--special summon
@@ -55,8 +55,10 @@ function c100408003.spop1(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function c100408003.atkcon(e,tp,eg,ep,ev,re,r,rp)
-	return (Duel.GetAttacker():IsControler(tp) and Duel.GetAttacker():IsSetCard(0x8e))
-		or (Duel.GetAttackTarget() and Duel.GetAttackTarget():IsControler(tp) and Duel.GetAttackTarget():IsSetCard(0x8e))
+	if Duel.GetAttackTarget()~=nil then
+		return (Duel.GetAttacker():IsControler(tp) and Duel.GetAttacker():IsRace(RACE_ZOMBIE))
+		or (Duel.GetAttackTarget() and Duel.GetAttackTarget():IsControler(tp) and Duel.GetAttackTarget():IsRace(RACE_ZOMBIE))
+	end
 end
 function c100408003.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():GetFlagEffect(100408003)==0

--- a/script/c100408008.lua
+++ b/script/c100408008.lua
@@ -1,5 +1,5 @@
 --ヴァンパイア・デザイア
-
+--Vampire Desire
 --Script by nekrozar
 function c100408008.initial_effect(c)
 	--Activate
@@ -78,7 +78,7 @@ function c100408008.activate(e,tp,eg,ep,ev,re,r,rp)
 	else
 		local tc=Duel.GetFirstTarget()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
-		local tg=Duel.SelectMatchingCard(tp,c100408008.spfilter1,tp,LOCATION_MZONE,0,1,1,nil,tp)
+		local g=Duel.SelectMatchingCard(tp,c100408008.spfilter1,tp,LOCATION_MZONE,0,1,1,nil,tp)
 		if g:GetCount()>0 and Duel.SendtoGrave(g,REASON_EFFECT)~=0 and g:GetFirst():IsLocation(LOCATION_GRAVE)
 			and tc:IsRelateToEffect(e) then
 			Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)


### PR DESCRIPTION
Fixed:
Summon Limit interaction between Vampire Familiar and Vampire Brood
Vampire Desire second effect: now summons the monster from graveyard
Vampire Fraulein: no longer boost status during direct attacks. Now also boosts non-"Vampire" Zombie-type monsters