### PR TITLE
Ancient Fairy Dragon + Solemn Warning (OCG)

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -205,7 +205,7 @@
 21377582 0 --Master Peace, The True Dracoslaying King
 20366274 0 --エルシャドール・ネフィリム El Shaddoll Construct 						EXTRA DECK MONSTERS
 17412721 0 --旧神ノーデン Elder Entity Norden
-25862681 0-- Ancient Fairy Dragon
+25862681 0 --Ancient Fairy Dragon
 34086406 0 --ラヴァルバル・チェイン Lavalval Chain
 18326736 0 --星守の騎士 プトレマイオス Tellarknight Ptolomaeus
 54719828 0 --No.16 色の支配者ショック・ルーラー Number 16: Shock Master
@@ -316,7 +316,6 @@
 5851097 1 --虚無空間 Vanity's Emptiness
 35125879 1 --True King's Return
 61740673 1 --王宮の勅命 Imperial Order
-84749824 1 --神の警告 Solemn Warning
 41420027 1 --神の宣告 Solemn Judgment
 #semi limited OCG
 423585 2 --召喚僧サモンプリースト Summoner Monk
@@ -383,7 +382,7 @@
 40318957 0 --Performapal Skullcrobat Joker
 20366274 0 --El Shaddoll Construct									EXTRA DECK MONSTERS
 17412721 0 --Elder Entity Norden
-25862681 0-- Ancient Fairy Dragon
+25862681 0 --Ancient Fairy Dragon
 65536818 0 --Denglong, First of the Yang Zing	
 46772449 0 --Evilswarm Exciton Knight
 18326736 0 --Tellarknight Ptolomaeus


### PR DESCRIPTION
Solemn Warning was added twice as it was never removed out of the limited section, I have edited this.
Ancient Fairy Dragon changed for World and OCG as not functioning correctly on Pro2 as the space was in the wrong place (instead of before the -- it has been placed after) meaning it did not always show as banned in OCG.