### PR TITLE
"Borrel Cooling" fix

### DIFF
--- a/script/c62753201.lua
+++ b/script/c62753201.lua
@@ -13,7 +13,7 @@ function c62753201.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function c62753201.cfilter(c)
-	return c:IsLevelBelow(3) and c:IsSetCard(0x102)
+	return c:IsSetCard(0x102)
 end
 function c62753201.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.CheckReleaseGroup(tp,c62753201.cfilter,1,nil) end


### PR DESCRIPTION
Should now be able to Tribute any "Rokket" monster to activate this card (could only Tribute Level 3 or lower before).