### PR TITLE
Update hint strings

### DIFF
--- a/strings.conf
+++ b/strings.conf
@@ -77,28 +77,28 @@
 !system 507 Select the card(s) to return to Deck
 !system 508 Select the card to Summon
 !system 509 Select a Monster to Special Summon
-!system 510 Select a card to flip-up
+!system 510 Select a card to Set
 !system 511 Select a card to use as Fusion Material
 !system 512 Select a card to use as Synchro Material
 !system 513 Select a card to use as Xyz Material
-!system 514 Select a card on opponent's side
-!system 515 Select a card on your side
+!system 514 Select a face-up card
+!system 515 Select a face-down card
 !system 516 Select a monster in attack position
 !system 517 Select a monster in defense position
 !system 518 Select a card to equip
 !system 519 Select the Xyz material to detach
 !system 520 Select the monster to change control
 !system 521 Select the card to replace
-!system 522 Select the monsters in attack
-!system 523 Select the monsters in defense
-!system 524 Select attack monster
-!system 525 Select defense monster
+!system 522 Select a monster in face-up attack position
+!system 523 Select a monster in face-up defense position
+!system 524 Select a monster in face-down attack position
+!system 525 Select a monster in face-down defense position
 !system 526 Reveal a card
-!system 527 to select the field you want to place the card
+!system 527 Select a card to move to the field
 !system 528 Select a monster to change its battle position
-!system 529 Select your card
-!system 530 Select opponent card
-!system 531 Select the highest level monsters for tribute:
+!system 529 Select a card on your side
+!system 530 Select a card on opponent's side
+!system 531 Select a monster to Tribute
 !system 532 Select a monster to detach Xyz Material
 !system 533 Select a card to use as Link Material
 !system 549 Select an attack target


### PR DESCRIPTION
I noticed some discrepancies between the content of some of the hint strings, and the name of the corresponding constant in constant.lua, which usually informs when it's used in scripts and hence when it will appear to players. I've updated the following strings accordingly:

String 510 is called "HINTMSG_SET" and is used in cards like Metalfoes that set cards directly from the deck etc., not flipping cards up. 

Strings 514 and 515 are called "HINTMSG_FACEUP" and "HINTMSG_FACEDOWN" respectively, and the former is often used in cards that can target almost any card on the field, nothing to do with the controller of the cards. HINTMSG_SELF and _OPPO exist for that purpose.

Strings 522-525 are called "FACEUPATTACK", "FACEUPDEFENSE", "FACEDOWNATTACK" and "FACEDOWNDEFENSE". As it is, they were clones of "HINTMSG_ATTACK" and "_DEFENSE" with worse wording.

String 527 is called "HINTMSG_TOFIELD", and while the existing string reflects that more accurately than some of these, its grammar is extremely poor. It also seems to be written for zone selection, when HINTMSG_TOZONE serves that purpose.

Strings 529 and 530 are the aforementioned "SELF" and "OPPO", and I simply updated them to the previous contents of 514 and 515.

Finally, String 531 is "HINTMSG_TRIBUTE". I'm admittedly not sure what the purpose of this is when "HINTMSG_RELEASE" exists, but the colon at the end is non-standard and it seemed more specific than the constant name implied.