### PR TITLE
"Gouki Trainer" fix

### DIFF
--- a/script/c101005005.lua
+++ b/script/c101005005.lua
@@ -57,7 +57,7 @@ function c101005005.spop(e,tp,eg,ep,ev,re,r,rp)
 			e1:SetCode(EFFECT_UPDATE_ATTACK)
 			e1:SetValue(-500)
 			e1:SetReset(RESET_EVENT+0x1fe0000)
-			bc:RegisterEffect(e1)
+			tc:RegisterEffect(e1)
 			Duel.SpecialSummonComplete()
 		end
 	end


### PR DESCRIPTION
The "Gouki" Link Monster Special Summoned from the Graveyard should now correctly lose 500 ATK.