### PR TITLE
Fixed "Gabrion the Timelord"

### DIFF
--- a/script/c100227024.lua
+++ b/script/c100227024.lua
@@ -79,8 +79,10 @@ end
 function c100227024.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(c100227024.tdfilter,tp,0,LOCATION_ONFIELD,nil)
 	if g:GetCount()>0 then
-		Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
-		Duel.Draw(1-tp,g:GetCount(),REASON_EFFECT)
+		Duel.SendtoDeck(g,nil,0,REASON_EFFECT)
+		Duel.ShuffleDeck(1-tp)
+		Duel.BreakEffect()
+		Duel.Draw(1-tp,g:FilterCount(Card.IsLocation,nil,LOCATION_DECK),REASON_EFFECT)
 	end
 end
 function c100227024.rtdcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Correctly shuffles the deck, avoiding the player from drawing the same cards.
No longer makes the player draw when tokens leave the field due to its effect.
No longer draws for cards returned to the extra deck (until we get rulings for that part)