### PR TITLE
Fix 'Gabrion, the Timelord'

### DIFF
--- a/script/c100227024.lua
+++ b/script/c100227024.lua
@@ -75,9 +75,10 @@ function c100227024.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c100227024.tdop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetMatchingGroup(Card.IsAbleToDeck,tp,0,LOCATION_ONFIELD,nil)
-	if g:GetCount()>0 and Duel.SendtoDeck(g,nil,2,REASON_EFFECT)>0 then
+	if g:GetCount()>0 and Duel.SendtoDeck(g,nil,0,REASON_EFFECT)>0 then
 		local tg=Duel.GetOperatedGroup():Filter(Card.IsLocation,nil,LOCATION_DECK)
 		if tg:IsExists(Card.IsControler,1,nil,1-tp) then Duel.ShuffleDeck(1-tp) end
+		if tg:IsExists(Card.IsControler,1,nil,tp) then Duel.ShuffleDeck(tp) end
 		Duel.BreakEffect()
 		Duel.Draw(1-tp,tg:FilterCount(Card.IsControler,nil,1-tp),REASON_EFFECT)
 	end

--- a/script/c100227024.lua
+++ b/script/c100227024.lua
@@ -67,22 +67,19 @@ end
 function c100227024.tdcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetBattledGroupCount()>0 or e:GetHandler():GetAttackedCount()>0
 end
-function c100227024.tdfilter(c)
-	return c:IsAbleToDeck()
-end
 function c100227024.tdtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
-	local g=Duel.GetMatchingGroup(c100227024.tdfilter,tp,0,LOCATION_ONFIELD,nil)
+	local g=Duel.GetMatchingGroup(Card.IsAbleToDeck,tp,0,LOCATION_ONFIELD,nil)
 	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,1-tp,g:GetCount())
 end
 function c100227024.tdop(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(c100227024.tdfilter,tp,0,LOCATION_ONFIELD,nil)
-	if g:GetCount()>0 then
-		Duel.SendtoDeck(g,nil,0,REASON_EFFECT)
-		Duel.ShuffleDeck(1-tp)
+	local g=Duel.GetMatchingGroup(Card.IsAbleToDeck,tp,0,LOCATION_ONFIELD,nil)
+	if g:GetCount()>0 and Duel.SendtoDeck(g,nil,2,REASON_EFFECT)>0 then
+		local tg=Duel.GetOperatedGroup():Filter(Card.IsLocation,nil,LOCATION_DECK)
+		if tg:IsExists(Card.IsControler,1,nil,1-tp) then Duel.ShuffleDeck(1-tp) end
 		Duel.BreakEffect()
-		Duel.Draw(1-tp,g:FilterCount(Card.IsLocation,nil,LOCATION_DECK),REASON_EFFECT)
+		Duel.Draw(1-tp,tg:FilterCount(Card.IsControler,nil,1-tp),REASON_EFFECT)
 	end
 end
 function c100227024.rtdcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Fixed interactions with Gabrion's shuffle effect with cards you own
- If you shuffle a card you own into your Deck, it is then shuffled/ If only your cards are shuffled into your Deck then your opponent's deck is not shuffled, but only yours is
- If you shuffle both cards you own and your opponent owns into their owner's Decks, your opponent will only draw cards equal to the number of their cards shuffled into their Deck (as intended).