### PR TITLE
Updated "Magical Lab"

### DIFF
--- a/script/c94599451.lua
+++ b/script/c94599451.lua
@@ -37,7 +37,7 @@ function c94599451.initial_effect(c)
     c:RegisterEffect(e4)
 end
 function c94599451.ctfilter(c,tp)
-    return c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP) 
+    return c:IsPreviousPosition(POS_FACEUP) 
         and bit.band(c:GetPreviousTypeOnField(),TYPE_PENDULUM)~=0 and c:IsPreviousSetCard(0x10d) 
         and c:GetPreviousControler()==tp and c:IsReason(REASON_BATTLE+REASON_EFFECT)
 end


### PR DESCRIPTION
Now also adds counters if a "Mythical Beast" Pendulum Monster Card(s) is destroyed in your Pendulum Zone.