### PR TITLE
Another "Ignis Heat, the True Dracowarrior" fix

### DIFF
--- a/script/c22499034.lua
+++ b/script/c22499034.lua
@@ -104,7 +104,7 @@ function c22499034.thcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c22499034.thfilter(c,tp)
 	return c:IsSetCard(0xf9) and c:GetType()==0x20002
-		and (c:IsAbleToHand() or c:GetActivateEffect():IsActivatable(tp))
+		and (c:IsAbleToHand() or (c:GetActivateEffect():IsActivatable(tp) and Duel.GetLocationCount(tp,LOCATION_SZONE)>0))
 end
 function c22499034.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c22499034.thfilter,tp,LOCATION_DECK,0,1,nil,tp) end


### PR DESCRIPTION
Now also includes a check for the scenario where all the 5 Spell/Trap zones are full AND you cannot add cards to the hand (e.g. Deck Lockdown, Mistake)