### PR TITLE
Fixed "Dinomight Knight, the True Dracofighter"

### DIFF
--- a/script/c58984738.lua
+++ b/script/c58984738.lua
@@ -104,7 +104,7 @@ function c58984738.thcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function c58984738.thfilter(c,tp)
 	return c:IsSetCard(0xf9) and c:GetType()==0x20004
-		and (c:IsAbleToHand() or c:GetActivateEffect():IsActivatable(tp))
+		and (c:IsAbleToHand() or (c:GetActivateEffect():IsActivatable(tp) and Duel.GetLocationCount(tp,LOCATION_SZONE)>0))
 end
 function c58984738.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(c58984738.thfilter,tp,LOCATION_DECK,0,1,nil,tp) end


### PR DESCRIPTION
Now also includes a check for the scenario where all the 5 Spell/Trap zones are full AND you cannot add cards to the hand (e.g. Deck Lockdown, Mistake)