### PR TITLE
Reverted changes with Metaphys monsters

### DIFF
--- a/script/c18743376.lua
+++ b/script/c18743376.lua
@@ -23,7 +23,7 @@ function c18743376.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c18743376.regcon(e,tp,eg,ep,ev,re,r,rp)
-	return re and re:GetHandler():IsType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
+	return re and re:IsType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
 end
 function c18743376.regop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/script/c18743376.lua
+++ b/script/c18743376.lua
@@ -23,7 +23,7 @@ function c18743376.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c18743376.regcon(e,tp,eg,ep,ev,re,r,rp)
-	return re and re:IsType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
+	return re and re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
 end
 function c18743376.regop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()

--- a/script/c45960523.lua
+++ b/script/c45960523.lua
@@ -26,7 +26,7 @@ function c45960523.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c45960523.rmcon(e,tp,eg,ep,ev,re,r,rp)
-	return re and re:GetHandler():IsType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
+	return re and re:IsType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
 end
 function c45960523.rmfilter(c)
 	return c:IsSummonType(SUMMON_TYPE_SPECIAL) and c:IsAbleToRemove() and c:IsFaceup()

--- a/script/c45960523.lua
+++ b/script/c45960523.lua
@@ -26,7 +26,7 @@ function c45960523.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c45960523.rmcon(e,tp,eg,ep,ev,re,r,rp)
-	return re and re:IsType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
+	return re and re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
 end
 function c45960523.rmfilter(c)
 	return c:IsSummonType(SUMMON_TYPE_SPECIAL) and c:IsAbleToRemove() and c:IsFaceup()

--- a/script/c72355272.lua
+++ b/script/c72355272.lua
@@ -26,7 +26,7 @@ function c72355272.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c72355272.rmcon(e,tp,eg,ep,ev,re,r,rp)
-	return re and re:IsType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
+	return re and re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
 end
 function c72355272.rmfilter(c)
 	return c:IsFacedown() and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToRemove()

--- a/script/c72355272.lua
+++ b/script/c72355272.lua
@@ -26,7 +26,7 @@ function c72355272.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 function c72355272.rmcon(e,tp,eg,ep,ev,re,r,rp)
-	return re and re:GetHandler():IsType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
+	return re and re:IsType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0x105)
 end
 function c72355272.rmfilter(c)
 	return c:IsFacedown() and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToRemove()


### PR DESCRIPTION
A reversal of the previous ruling now says that the monsters should NOT work with the pendulum effect of "Metaphys Decoy Dragon"