### PR TITLE
"Slash Draw" fix

### DIFF
--- a/script/c100227020.lua
+++ b/script/c100227020.lua
@@ -19,7 +19,7 @@ function c100227020.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function c100227020.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ct=Duel.GetFieldGroupCount(tp,0,LOCATION_ONFIELD)
-	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>ct and Duel.IsPlayerCanDiscardDeck(tp,ct)
+	if chk==0 then return ct>0 and Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>ct and Duel.IsPlayerCanDiscardDeck(tp,ct)
 		and Duel.IsPlayerCanDraw(tp,1) end
 	Duel.SetOperationInfo(0,CATEGORY_DECKDES,nil,0,tp,ct)
 	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,1)
@@ -34,7 +34,7 @@ function c100227020.activate(e,tp,eg,ep,ev,re,r,rp)
 			Duel.ConfirmCards(1-tp,tc)
 			if tc:IsCode(100227020) then
 				if Duel.SendtoGrave(tc,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_GRAVE) then
-					local sg=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,aux.ExceptThisCard(e))
+					local sg=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,e:GetHandler())
 					Duel.Destroy(sg,REASON_EFFECT)
 					local tg=Duel.GetOperatedGroup():Filter(Card.IsLocation,nil,LOCATION_GRAVE)
 					if #tg>0 then
@@ -44,6 +44,7 @@ function c100227020.activate(e,tp,eg,ep,ev,re,r,rp)
 					end
 				end
 			else
+				Duel.ShuffleHand(tp)
 				Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
 				local dg=Duel.SelectMatchingCard(tp,Card.IsAbleToDeck,tp,LOCATION_GRAVE,0,ct2,ct2,nil)
 				if #dg>0 then


### PR DESCRIPTION
Should now destroy all cards on the field and deal damage if you draw another "Slash Draw" from its effect. Also, should now not be able to activate it if your opponent controls no cards and the card you draw from its effect doesn't remain revealed. Thx to andré and Naim for some help fixing.