### PR TITLE
"Darkness Metal, the Dark Steel Dragon" fix

### DIFF
--- a/script/c100200148.lua
+++ b/script/c100200148.lua
@@ -68,5 +68,5 @@ function c100200148.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.SpecialSummonComplete()
 end
 function c100200148.splimit(e,c,sump,sumtype,sumpos,targetp,se)
-	return not c:IsType(TYPE_LINK)
+	return c:IsType(TYPE_LINK)
 end


### PR DESCRIPTION
Should now prevent you from Special Summoning Link Monsters for the rest of the turn instead of everything except Link Monsters.