### PR TITLE
Same fix as Cyberdark Edge

### DIFF
--- a/script/c52977572.lua
+++ b/script/c52977572.lua
@@ -1,0 +1,79 @@
+--Dragunity Pilum
+--ドラグニティ－ピルム
+function c52977572.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(52977572,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetTarget(c52977572.sptg)
+	e1:SetOperation(c52977572.spop)
+	c:RegisterEffect(e1)
+	--direct attack
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_DIRECT_ATTACK)
+	c:RegisterEffect(e2)
+	--damage reduce
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_FIELD)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetCode(EVENT_PRE_BATTLE_DAMAGE)
+	e3:SetCondition(c52977572.rdcon)
+	e3:SetOperation(c52977572.rdop)
+	c:RegisterEffect(e3)
+end
+function c52977572.filter(c,e,tp)
+	return c:IsSetCard(0x29) and c:IsRace(RACE_WINDBEAST) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c52977572.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingMatchingCard(c52977572.filter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,e:GetHandler(),1,0,0)
+end
+function c52977572.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,c52977572.filter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if not tc then return end
+	Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	local c=e:GetHandler()
+	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsControler(1-tp) 
+		or Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 then return end
+	Duel.BreakEffect()
+	if not Duel.Equip(tp,c,tc,false) then return end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_EQUIP_LIMIT)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
+	e1:SetValue(c52977572.eqlimit)
+	e1:SetLabelObject(tc)
+	c:RegisterEffect(e1)
+end
+function c52977572.eqlimit(e,c)
+	return e:GetLabelObject()==c
+end
+function c52977572.rdcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler():GetEquipTarget()
+	return ep~=tp and c==Duel.GetAttacker() and Duel.GetAttackTarget()==nil
+		and c:IsHasEffect(EFFECT_DIRECT_ATTACK)
+		and Duel.IsExistingMatchingCard(aux.NOT(Card.IsHasEffect),tp,0,LOCATION_MZONE,1,nil,EFFECT_IGNORE_BATTLE_TARGET)
+end
+function c52977572.rdop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=c:GetEquipTarget()
+	local effs={tc:GetCardEffect(EFFECT_DIRECT_ATTACK)}
+	local eg=Group.CreateGroup()
+	for _,eff in ipairs(effs) do
+		eg:AddCard(eff:GetOwner())
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EFFECT)
+	local ec = #eg==1 and eg:GetFirst() or eg:Select(tp,1,1,nil):GetFirst()
+	if c==ec then
+		Duel.ChangeBattleDamage(ep,ev/2)
+	end
+end

--- a/script/c53701457.lua
+++ b/script/c53701457.lua
@@ -1,0 +1,73 @@
+--No.28 タイタニック・モス
+--Number 28: Titanic Moth
+function c53701457.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,nil,7,2)
+	c:EnableReviveLimit()
+	--direct attack
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_DIRECT_ATTACK)
+	e1:SetCondition(c53701457.dircon)
+	c:RegisterEffect(e1)
+	--damage reduce
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_PRE_BATTLE_DAMAGE)
+	e2:SetCondition(c53701457.rdcon)
+	e2:SetOperation(c53701457.rdop)
+	c:RegisterEffect(e2)
+	--damage
+	local e3=Effect.CreateEffect(c)
+	e3:SetCategory(CATEGORY_DAMAGE)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e3:SetCode(EVENT_BATTLE_DAMAGE)
+	e3:SetCondition(c53701457.damcon)
+	e3:SetCost(c53701457.damcost)
+	e3:SetTarget(c53701457.damtg)
+	e3:SetOperation(c53701457.damop)
+	c:RegisterEffect(e3,false,1)
+end
+c53701457.xyz_number=28
+function c53701457.dircon(e)
+	return Duel.GetFieldGroupCount(e:GetHandlerPlayer(),LOCATION_MZONE,0)<=1
+end
+function c53701457.rdcon(e,tp,eg,ep,ev,re,r,rp)
+	return ep~=tp and Duel.GetAttackTarget()==nil
+		and e:GetHandler():IsHasEffect(EFFECT_DIRECT_ATTACK)
+		and Duel.IsExistingMatchingCard(aux.NOT(Card.IsHasEffect),tp,0,LOCATION_MZONE,1,nil,EFFECT_IGNORE_BATTLE_TARGET)
+end
+function c53701457.rdop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local effs={c:GetCardEffect(EFFECT_DIRECT_ATTACK)}
+	local eg=Group.CreateGroup()
+	for _,eff in ipairs(effs) do
+		eg:AddCard(eff:GetOwner())
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EFFECT)
+	local ec = #eg==1 and eg:GetFirst() or eg:Select(tp,1,1,nil):GetFirst()
+	if c==ec then
+		Duel.ChangeBattleDamage(ep,ev/2)
+	end
+end
+function c53701457.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return ep~=tp
+end
+function c53701457.damcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
+	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
+end
+function c53701457.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ct=Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)
+	if chk==0 then return ct>0 end
+	Duel.SetTargetPlayer(1-tp)
+	local dam=ct*500
+	Duel.SetTargetParam(dam)
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
+end
+function c53701457.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
+	local dam=Duel.GetFieldGroupCount(p,LOCATION_HAND,0)*500
+	Duel.Damage(p,dam,REASON_EFFECT)
+end

--- a/script/c59642500.lua
+++ b/script/c59642500.lua
@@ -1,0 +1,71 @@
+--M・HERO 闇鬼
+--Masked HERO Anki
+function c59642500.initial_effect(c)
+	c:EnableReviveLimit()
+	--spsummon condition
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	c:RegisterEffect(e1)
+	--direct attack
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_DIRECT_ATTACK)
+	c:RegisterEffect(e2)
+	--damage reduce
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_PRE_BATTLE_DAMAGE)
+	e3:SetCondition(c59642500.rdcon)
+	e3:SetOperation(c59642500.rdop)
+	c:RegisterEffect(e3)
+	--search
+	local e4=Effect.CreateEffect(c)
+	e4:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e4:SetCode(EVENT_BATTLE_DESTROYING)
+	e4:SetCountLimit(1,59642500)
+	e4:SetCondition(c59642500.thcon)
+	e4:SetTarget(c59642500.thtg)
+	e4:SetOperation(c59642500.thop)
+	c:RegisterEffect(e4)
+end
+function c59642500.rdcon(e,tp,eg,ep,ev,re,r,rp)
+	return ep~=tp and Duel.GetAttackTarget()==nil
+		and e:GetHandler():IsHasEffect(EFFECT_DIRECT_ATTACK)
+		and Duel.IsExistingMatchingCard(aux.NOT(Card.IsHasEffect),tp,0,LOCATION_MZONE,1,nil,EFFECT_IGNORE_BATTLE_TARGET)
+end
+function c59642500.rdop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local effs={c:GetCardEffect(EFFECT_DIRECT_ATTACK)}
+	local eg=Group.CreateGroup()
+	for _,eff in ipairs(effs) do
+		eg:AddCard(eff:GetOwner())
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EFFECT)
+	local ec = #eg==1 and eg:GetFirst() or eg:Select(tp,1,1,nil):GetFirst()
+	if c==ec then
+		Duel.ChangeBattleDamage(ep,ev/2)
+	end
+end
+function c59642500.thcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local bc=c:GetBattleTarget()
+	return c:IsRelateToBattle() and bc:IsLocation(LOCATION_GRAVE) and bc:IsType(TYPE_MONSTER)
+end
+function c59642500.filter(c)
+	return c:IsSetCard(0xa5) and c:IsType(TYPE_QUICKPLAY) and c:IsAbleToHand()
+end
+function c59642500.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c59642500.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c59642500.thop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c59642500.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c92246806.lua
+++ b/script/c92246806.lua
@@ -1,0 +1,89 @@
+--妖仙獣 鎌弐太刀
+--Yosenju Kama 2
+function c92246806.initial_effect(c)
+	--summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(92246806,0))
+	e1:SetCategory(CATEGORY_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetTarget(c92246806.sumtg)
+	e1:SetOperation(c92246806.sumop)
+	c:RegisterEffect(e1)
+	--direct attack
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_DIRECT_ATTACK)
+	c:RegisterEffect(e2)
+	--damage reduce
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_PRE_BATTLE_DAMAGE)
+	e3:SetCondition(c92246806.rdcon)
+	e3:SetOperation(c92246806.rdop)
+	c:RegisterEffect(e3)
+	--return
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_SUMMON_SUCCESS)
+	e4:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e4:SetOperation(c92246806.regop)
+	c:RegisterEffect(e4)
+end
+function c92246806.filter(c)
+	return c:IsSetCard(0xb3) and not c:IsCode(92246806) and c:IsSummonable(true,nil)
+end
+function c92246806.sumtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c92246806.filter,tp,LOCATION_HAND,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_SUMMON,nil,1,0,0)
+end
+function c92246806.sumop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SUMMON)
+	local g=Duel.SelectMatchingCard(tp,c92246806.filter,tp,LOCATION_HAND,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.Summon(tp,g:GetFirst(),true,nil)
+	end
+end
+function c92246806.rdcon(e,tp,eg,ep,ev,re,r,rp)
+	return ep~=tp and Duel.GetAttackTarget()==nil
+		and e:GetHandler():IsHasEffect(EFFECT_DIRECT_ATTACK)
+		and Duel.IsExistingMatchingCard(aux.NOT(Card.IsHasEffect),tp,0,LOCATION_MZONE,1,nil,EFFECT_IGNORE_BATTLE_TARGET)
+end
+function c92246806.rdop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local effs={c:GetCardEffect(EFFECT_DIRECT_ATTACK)}
+	local eg=Group.CreateGroup()
+	for _,eff in ipairs(effs) do
+		eg:AddCard(eff:GetOwner())
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EFFECT)
+	local ec = #eg==1 and eg:GetFirst() or eg:Select(tp,1,1,nil):GetFirst()
+	if c==ec then
+		Duel.ChangeBattleDamage(ep,ev/2)
+	end
+end
+function c92246806.regop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(92246806,1))
+	e1:SetCategory(CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCode(EVENT_PHASE+PHASE_END)
+	e1:SetTarget(c92246806.rettg)
+	e1:SetOperation(c92246806.retop)
+	e1:SetReset(RESET_EVENT+0x1ec0000+RESET_PHASE+PHASE_END)
+	c:RegisterEffect(e1)
+end
+function c92246806.rettg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,e:GetHandler(),1,0,0)
+end
+function c92246806.retop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.SendtoHand(c,nil,REASON_EFFECT)
+	end
+end

--- a/script/c99861526.lua
+++ b/script/c99861526.lua
@@ -1,0 +1,52 @@
+--サブマリンロイド
+--Submarineroid
+function c99861526.initial_effect(c)
+	--direct attack
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_DIRECT_ATTACK)
+	c:RegisterEffect(e1)
+	--damage reduce
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_PRE_BATTLE_DAMAGE)
+	e2:SetCondition(c99861526.rdcon)
+	e2:SetOperation(c99861526.rdop)
+	c:RegisterEffect(e2)
+	--pos
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(99861526,0))
+	e3:SetCategory(CATEGORY_POSITION)
+	e3:SetType(EFFECT_TYPE_TRIGGER_O+EFFECT_TYPE_SINGLE)
+	e3:SetCode(EVENT_DAMAGE_STEP_END)
+	e3:SetCondition(c99861526.poscon)
+	e3:SetOperation(c99861526.posop)
+	c:RegisterEffect(e3)
+end
+function c99861526.rdcon(e,tp,eg,ep,ev,re,r,rp)
+	return ep~=tp and Duel.GetAttackTarget()==nil
+		and e:GetHandler():IsHasEffect(EFFECT_DIRECT_ATTACK)
+		and Duel.IsExistingMatchingCard(aux.NOT(Card.IsHasEffect),tp,0,LOCATION_MZONE,1,nil,EFFECT_IGNORE_BATTLE_TARGET)
+end
+function c99861526.rdop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local effs={c:GetCardEffect(EFFECT_DIRECT_ATTACK)}
+	local eg=Group.CreateGroup()
+	for _,eff in ipairs(effs) do
+		eg:AddCard(eff:GetOwner())
+	end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EFFECT)
+	local ec = #eg==1 and eg:GetFirst() or eg:Select(tp,1,1,nil):GetFirst()
+	if c==ec then
+		Duel.ChangeBattleDamage(ep,c:GetBaseAttack())
+	end
+end
+function c99861526.poscon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:IsRelateToBattle() and c:IsAttackPos()
+end
+function c99861526.posop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsRelateToEffect(e) then
+		Duel.ChangePosition(e:GetHandler(),POS_FACEUP_DEFENSE)
+	end
+end


### PR DESCRIPTION
You are allowed to select which effect you are using to conduct a direct attack when multiple direct attack effects apply on the card.
This is required as if it is due to their own effect, there will be different results if it is due to other effects,