### PR TITLE
Fix "Superheavy Samurai Gigagloves"

### DIFF
--- a/script/c62017867.lua
+++ b/script/c62017867.lua
@@ -43,19 +43,17 @@ function c62017867.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetDecktopGroup(tp,1)
 	local tc=g:GetFirst()
 	Duel.DisableShuffleCheck()
-	if tc:IsSetCard(0x9a) then
-		if Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 then
-		  	Duel.ShuffleHand(tp)
-		  	local at=Duel.GetAttacker()
-		  	if at:IsFaceup() and at:IsRelateToBattle() then
-			  	local e1=Effect.CreateEffect(e:GetHandler())
-			  	e1:SetType(EFFECT_TYPE_SINGLE)
-			  	e1:SetCode(EFFECT_SET_ATTACK_FINAL)
-			  	e1:SetValue(0)
-			 	e1:SetReset(RESET_EVENT+0x1fe0000)
-				at:RegisterEffect(e1)
-			end
-    	end
+	if tc:IsSetCard(0x9a) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 then
+		Duel.ShuffleHand(tp)
+		local at=Duel.GetAttacker()
+		if at:IsFaceup() and at:IsRelateToBattle() then
+			local e1=Effect.CreateEffect(e:GetHandler())
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+			e1:SetValue(0)
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			at:RegisterEffect(e1)
+		end
 	else
 		Duel.SendtoGrave(tc,REASON_EFFECT+REASON_REVEAL)
 	end

--- a/script/c62017867.lua
+++ b/script/c62017867.lua
@@ -1,0 +1,62 @@
+--超重武者グロウ－V
+function c62017867.initial_effect(c)
+	--sort decktop
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_TO_GRAVE)
+	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e1:SetCondition(c62017867.condition)
+	e1:SetTarget(c62017867.target)
+	e1:SetOperation(c62017867.operation)
+	c:RegisterEffect(e1)
+	--atk
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH+CATEGORY_DECKDES)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetCondition(c62017867.atkcon)
+	e2:SetCost(aux.bfgcost)
+	e2:SetTarget(c62017867.atktg)
+	e2:SetOperation(c62017867.atkop)
+	c:RegisterEffect(e2)
+end
+function c62017867.condition(e,tp,eg,ep,ev,re,r,rp)
+	return not Duel.IsExistingMatchingCard(Card.IsType,tp,LOCATION_GRAVE,0,1,nil,TYPE_SPELL+TYPE_TRAP)
+end
+function c62017867.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>=5 end
+end
+function c62017867.operation(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)<5 then return end
+	Duel.SortDecktop(tp,tp,5)
+end
+function c62017867.atkcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetAttacker():IsControler(1-tp) and Duel.GetAttackTarget()==nil
+end
+function c62017867.atktg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDiscardDeck(tp,1) end
+end
+function c62017867.atkop(e,tp,eg,ep,ev,re,r,rp)
+	if not Duel.IsPlayerCanDiscardDeck(tp,1) then return end
+	Duel.ConfirmDecktop(tp,1)
+	local g=Duel.GetDecktopGroup(tp,1)
+	local tc=g:GetFirst()
+	Duel.DisableShuffleCheck()
+	if tc:IsSetCard(0x9a) then
+		if Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 then
+		  	Duel.ShuffleHand(tp)
+		  	local at=Duel.GetAttacker()
+		  	if at:IsFaceup() and at:IsRelateToBattle() then
+			  	local e1=Effect.CreateEffect(e:GetHandler())
+			  	e1:SetType(EFFECT_TYPE_SINGLE)
+			  	e1:SetCode(EFFECT_SET_ATTACK_FINAL)
+			  	e1:SetValue(0)
+			 	e1:SetReset(RESET_EVENT+0x1fe0000)
+				at:RegisterEffect(e1)
+			end
+    	end
+	else
+		Duel.SendtoGrave(tc,REASON_EFFECT+REASON_REVEAL)
+	end
+end


### PR DESCRIPTION
Must add revealed "Superheavy Samurai" monster to hand to reduce ATK ("and if you do").

Credit to Dragon for bringing the bug to my attention