### PR TITLE
Fixed "Lair of Darkness"

### DIFF
--- a/script/c59160188.lua
+++ b/script/c59160188.lua
@@ -60,8 +60,10 @@ function c59160188.condition(e)
 	return e:GetHandler():GetFlagEffect(59160188)==0
 end
 function c59160188.regop(e,tp,eg,ep,ev,re,r,rp)
-	local val=e:GetLabelObject():GetLabel()
-	e:GetLabelObject():SetLabel(val+eg:GetCount())
+	if eg:GetFirst():IsType(TYPE_MONSTER) then
+		local val=e:GetLabelObject():GetLabel()
+		e:GetLabelObject():SetLabel(val+eg:GetCount())
+	end
 end
 function c59160188.clearop(e,tp,eg,ep,ev,re,r,rp)
 	e:GetLabelObject():SetLabel(0)

--- a/script/c59160188.lua
+++ b/script/c59160188.lua
@@ -60,10 +60,11 @@ function c59160188.condition(e)
 	return e:GetHandler():GetFlagEffect(59160188)==0
 end
 function c59160188.regop(e,tp,eg,ep,ev,re,r,rp)
-	if eg:GetFirst():IsType(TYPE_MONSTER) then
+	local ec=eg:FilterCount(Card.IsType,nil,TYPE_MONSTER)
+	if ec>0 then
 		local val=e:GetLabelObject():GetLabel()
-		e:GetLabelObject():SetLabel(val+eg:GetCount())
-	end
+		e:GetLabelObject():SetLabel(val+ec)
+	end	
 end
 function c59160188.clearop(e,tp,eg,ep,ev,re,r,rp)
 	e:GetLabelObject():SetLabel(0)


### PR DESCRIPTION
Previously, if Spell/Traps were tributed (usually happening with True Dracos), Lair of Darkness would still summon the  appropriate number of tokens, when it is supposed to summon only for Monsters tributed.