### PR TITLE
Fix Secret Six Samurais

### DIFF
--- a/script/c44686185.lua
+++ b/script/c44686185.lua
@@ -1,0 +1,69 @@
+--影六武衆－ハツメ
+--Shadow Six Samurai – Hatsume
+function c44686185.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(44686185,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetCountLimit(1,44686185)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCost(c44686185.cost)
+	e1:SetTarget(c44686185.target)
+	e1:SetOperation(c44686185.operation)
+	c:RegisterEffect(e1)
+	--destroy replace
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EFFECT_DESTROY_REPLACE)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetTarget(c44686185.reptg)
+	e2:SetValue(c44686185.repval)
+	e2:SetOperation(c44686185.repop)
+	c:RegisterEffect(e2)
+end
+function c44686185.cfilter(c)
+	return c:IsSetCard(0x3d) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost() and (c:IsLocation(LOCATION_GRAVE) or c:IsFaceup()) 
+		and aux.SpElimFilter(c,true,true)
+end
+function c44686185.spfilter(c,e,tp)
+	return c:IsSetCard(0x3d) and not c:IsCode(44686185) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c44686185.rescon(sg,e,tp,mg)
+	return aux.ChkfMMZ(1)(sg,e,tp,mg) and Duel.IsExistingTarget(c44686185.spfilter,tp,LOCATION_GRAVE,0,1,sg,e,tp)
+end
+function c44686185.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local g=Duel.GetMatchingGroup(c44686185.cfilter,tp,LOCATION_GRAVE+LOCATION_MZONE,0,nil)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-2 and g:GetCount()>1 and aux.SelectUnselectGroup(g,e,tp,2,2,c44686185.rescon,0) end
+	local sg=aux.SelectUnselectGroup(g,e,tp,2,2,c44686185.rescon,1,tp,HINTMSG_REMOVE)
+	Duel.Remove(sg,POS_FACEUP,REASON_COST)
+end
+function c44686185.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c44686185.filter2(chkc,e,tp) end
+	if chk==0 then return true end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,c44686185.spfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function c44686185.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function c44686185.repfilter(c,tp)
+	return c:IsFaceup() and c:IsSetCard(0x3d)
+		and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
+end
+function c44686185.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),69832741) and e:GetHandler():IsAbleToRemove() and eg:IsExists(c44686185.repfilter,1,nil,tp)
+		and eg:GetCount()==1 end
+	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+end
+function c44686185.repval(e,c)
+	return c44686185.repfilter(c,e:GetHandlerPlayer())
+end
+function c44686185.repop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+end

--- a/script/c6579928.lua
+++ b/script/c6579928.lua
@@ -41,7 +41,7 @@ function c6579928.thop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c6579928.repfilter(c,tp)
 	return c:IsFaceup() and c:IsSetCard(0x3d)
-		and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsReason(REASON_EFFECT)
+		and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 end
 function c6579928.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not Duel.IsPlayerAffectedByEffect(e:GetHandlerPlayer(),69832741) and e:GetHandler():IsAbleToRemove() and eg:IsExists(c6579928.repfilter,1,nil,tp)

--- a/script/c70180284.lua
+++ b/script/c70180284.lua
@@ -1,0 +1,63 @@
+--影六武衆-ドウジ
+--Shadow Six Samurai - Douji
+--Scripted by Eerie Code
+function c70180284.initial_effect(c)
+	--to grave
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(70180284,0))
+	e1:SetCategory(CATEGORY_TOGRAVE)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(c70180284.tgcon)
+	e1:SetTarget(c70180284.tgtg)
+	e1:SetOperation(c70180284.tgop)
+	c:RegisterEffect(e1)
+	local e2=e1:Clone()
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	c:RegisterEffect(e2)
+	--destroy replace
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EFFECT_DESTROY_REPLACE)
+	e3:SetRange(LOCATION_GRAVE)
+	e3:SetTarget(c70180284.reptg)
+	e3:SetValue(c70180284.repval)
+	e3:SetOperation(c70180284.repop)
+	c:RegisterEffect(e3)
+end
+function c70180284.tgcfilter(c,tp)
+	return c:IsFaceup() and c:IsSetCard(0x3d) and c:IsControler(tp)
+end
+function c70180284.tgcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg and eg:IsExists(c70180284.tgcfilter,1,e:GetHandler(),tp)
+end
+function c70180284.tgfilter(c)
+	return c:IsSetCard(0x3d) and c:IsAbleToGrave()
+end
+function c70180284.tgtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c70180284.tgfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
+end
+function c70180284.tgop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c70180284.tgfilter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoGrave(g,REASON_EFFECT)
+	end
+end
+function c70180284.repfilter(c,tp)
+	return c:IsFaceup() and c:IsSetCard(0x3d)
+		and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
+end
+function c70180284.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(c70180284.repfilter,1,nil,tp)
+		and eg:GetCount()==1 end
+	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+end
+function c70180284.repval(e,c)
+	return c70180284.repfilter(c,e:GetHandlerPlayer())
+end
+function c70180284.repop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+end

--- a/script/c71207871.lua
+++ b/script/c71207871.lua
@@ -1,0 +1,59 @@
+--影六武衆-フウマ
+--Shadow Six Samurai - Fuhma
+--Scripted by Eerie Code
+function c71207871.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(71207871,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY)
+	e1:SetCode(EVENT_DESTROYED)
+	e1:SetCondition(c71207871.spcon)
+	e1:SetTarget(c71207871.sptg)
+	e1:SetOperation(c71207871.spop)
+	c:RegisterEffect(e1)
+	--destroy replace
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EFFECT_DESTROY_REPLACE)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetTarget(c71207871.reptg)
+	e2:SetValue(c71207871.repval)
+	e2:SetOperation(c71207871.repop)
+	c:RegisterEffect(e2)
+end
+function c71207871.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return bit.band(r,REASON_EFFECT+REASON_BATTLE)~=0
+end
+function c71207871.spfilter(c,e,tp)
+	return c:IsSetCard(0x3d) and not c:IsCode(71207871) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function c71207871.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c71207871.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function c71207871.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	local tg=Duel.SelectMatchingCard(tp,c71207871.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp):GetFirst()
+	if tg then
+		Duel.SpecialSummon(tg,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function c71207871.repfilter(c,tp)
+	return c:IsFaceup() and c:IsSetCard(0x3d)
+		and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
+end
+function c71207871.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(c71207871.repfilter,1,nil,tp)
+	and eg:GetCount()==1
+	end
+	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+end
+function c71207871.repval(e,c)
+	return c71207871.repfilter(c,e:GetHandlerPlayer())
+end
+function c71207871.repop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+end

--- a/script/c7291576.lua
+++ b/script/c7291576.lua
@@ -1,0 +1,55 @@
+--影六武衆－ゲンバ
+--Shadow Six Samurai – Genba
+--Scripted by Eerie Code
+function c7291576.initial_effect(c)
+	--summon success
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(7291576,0))
+	e1:SetCategory(CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetTarget(c7291576.thtg)
+	e1:SetOperation(c7291576.thop)
+	c:RegisterEffect(e1)
+	--destroy replace
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EFFECT_DESTROY_REPLACE)
+	e2:SetRange(LOCATION_GRAVE)
+	e2:SetTarget(c7291576.reptg)
+	e2:SetValue(c7291576.repval)
+	e2:SetOperation(c7291576.repop)
+	c:RegisterEffect(e2)
+end
+function c7291576.thfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x3d) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
+end
+function c7291576.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_REMOVED) and c7291576.thfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c7291576.thfilter,tp,LOCATION_REMOVED,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectTarget(tp,c7291576.thfilter,tp,LOCATION_REMOVED,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+end
+function c7291576.thop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+	end
+end
+function c7291576.repfilter(c,tp)
+	return c:IsFaceup() and c:IsSetCard(0x3d)
+		and c:IsLocation(LOCATION_MZONE) and c:IsControler(tp) and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
+end
+function c7291576.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToRemove() and eg:IsExists(c7291576.repfilter,1,nil,tp)
+		and eg:GetCount()==1 end
+	return Duel.SelectEffectYesNo(tp,e:GetHandler(),96)
+end
+function c7291576.repval(e,c)
+	return c7291576.repfilter(c,e:GetHandlerPlayer())
+end
+function c7291576.repop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
+end


### PR DESCRIPTION
Fixed a bug where you could still banish them to destroy replace a Legendary Six Samurai - Shi En that has already used its destroy replace effect