### PR TITLE
Fix for monsters with equip effects

### DIFF
--- a/script/c14466224.lua
+++ b/script/c14466224.lua
@@ -1,0 +1,105 @@
+--The アトモスフィア
+function c14466224.initial_effect(c)
+	c:EnableReviveLimit()
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(c14466224.spcon)
+	e1:SetOperation(c14466224.spop)
+	c:RegisterEffect(e1)
+	--equip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(14466224,0))
+	e2:SetCategory(CATEGORY_EQUIP)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c14466224.eqcon)
+	e2:SetTarget(c14466224.eqtg)
+	e2:SetOperation(c14466224.eqop)
+	c:RegisterEffect(e2)
+	aux.AddEREquipLimit(c,c14466224.eqcon,function(ec,_,tp) return ec:IsControler(1-tp) end,c14466224.equipop,e2)
+end
+function c14466224.gfilter(c)
+	return c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost()
+end
+function c14466224.spcon(e,c)
+	if c==nil then return true end
+	local tp=c:GetControler()
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=-2 then return false end
+	if Duel.IsPlayerAffectedByEffect(tp,69832741) then
+		return Duel.IsExistingMatchingCard(Card.IsAbleToRemoveAsCost,tp,LOCATION_MZONE,0,3,nil)
+	else
+		return Duel.IsExistingMatchingCard(Card.IsAbleToRemoveAsCost,tp,LOCATION_MZONE,0,2,nil)
+			and Duel.IsExistingMatchingCard(c14466224.gfilter,tp,LOCATION_GRAVE,0,1,nil)
+	end
+end
+function c14466224.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	local g1
+	if Duel.IsPlayerAffectedByEffect(tp,69832741) then
+		g1=Duel.SelectMatchingCard(tp,Card.IsAbleToRemoveAsCost,tp,LOCATION_MZONE,0,3,3,nil)
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+		g1=Duel.SelectMatchingCard(tp,Card.IsAbleToRemoveAsCost,tp,LOCATION_MZONE,0,2,2,nil)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+		local g2=Duel.SelectMatchingCard(tp,c14466224.gfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+		g1:Merge(g2)
+	end
+	Duel.Remove(g1,POS_FACEUP,REASON_COST)
+end
+function c14466224.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetHandler():GetEquipGroup():Filter(c14466224.eqfilter,nil)
+	return g:GetCount()==0
+end
+function c14466224.eqfilter(c)
+	return c:GetFlagEffect(14466224)~=0 
+end
+function c14466224.filter(c)
+	return c:IsFaceup() and c:IsAbleToChangeControler()
+end
+function c14466224.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c14466224.filter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c14466224.filter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c14466224.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c14466224.equipop(c,e,tp,tc)
+	local atk=tc:GetTextAttack()
+	local def=tc:GetTextDefense()
+	if atk<0 then atk=0 end
+	if def<0 then def=0 end
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc,14466224) then return end
+	if atk>0 then
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_OWNER_RELATE)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		e2:SetValue(atk)
+		tc:RegisterEffect(e2)
+	end
+	if def>0 then
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_EQUIP)
+		e3:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_OWNER_RELATE)
+		e3:SetCode(EFFECT_UPDATE_DEFENSE)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		e3:SetValue(def)
+		tc:RegisterEffect(e3)
+	end
+end
+function c14466224.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c14466224.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end

--- a/script/c23756165.lua
+++ b/script/c23756165.lua
@@ -82,7 +82,7 @@ function c23756165.eqop(e,tp,eg,ep,ev,re,r,rp)
 	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			c23756165.equipop(c,e,tp,tc)
-		else Duel.SendtoGrave(tc,REASON_EFFECT) end
+		else Duel.SendtoGrave(tc,REASON_RULE) end
 	end
 end
 function c23756165.repval(e,re,r,rp)

--- a/script/c26211048.lua
+++ b/script/c26211048.lua
@@ -1,0 +1,67 @@
+--甲虫装機 エクサスタッグ
+function c26211048.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,aux.FilterBoolFunctionEx(Card.IsRace,RACE_INSECT),5,2)
+	c:EnableReviveLimit()
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(26211048,0))
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCost(c26211048.eqcost)
+	e1:SetTarget(c26211048.eqtg)
+	e1:SetOperation(c26211048.eqop)
+	c:RegisterEffect(e1,false,1)
+	aux.AddEREquipLimit(c,nil,function(ec,_,tp) return ec:IsControler(1-tp) end,c26211048.equipop,e1)
+end
+function c26211048.eqcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
+	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
+end
+function c26211048.eqfilter(c)
+	return c:IsLocation(LOCATION_MZONE) or c:IsType(TYPE_MONSTER) and not c:IsForbidden()
+end
+function c26211048.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE+LOCATION_MZONE) and chkc:IsControler(1-tp) and c26211048.eqfilter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c26211048.eqfilter,tp,0,LOCATION_GRAVE+LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c26211048.eqfilter,tp,0,LOCATION_GRAVE+LOCATION_MZONE,1,1,nil)
+	if g:GetFirst():IsLocation(LOCATION_GRAVE) then
+		Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,g,1,0,0)
+	end
+end
+function c26211048.equipop(c,e,tp,tc)
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc) then return end
+	if tc:IsFaceup() then
+		local atk=tc:GetTextAttack()/2
+		if atk<0 then atk=0 end
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		e2:SetValue(atk)
+		tc:RegisterEffect(e2)
+		local def=tc:GetTextDefense()/2
+		if def<0 then def=0 end
+		local e3=Effect.CreateEffect(c)
+		e3:SetType(EFFECT_TYPE_EQUIP)
+		e3:SetCode(EFFECT_UPDATE_DEFENSE)
+		e3:SetReset(RESET_EVENT+0x1fe0000)
+		e3:SetValue(def)
+		tc:RegisterEffect(e3)
+	end
+end
+function c26211048.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not tc or not tc:IsRelateToEffect(e) or not tc:IsType(TYPE_MONSTER) then return end
+	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 or c:IsFacedown() or not c:IsRelateToEffect(e) then
+		if tc:IsLocation(LOCATION_MZONE) then Duel.SendtoGrave(tc,REASON_EFFECT) end
+		return
+	end
+	c26211048.equipop(c,e,tp,tc)
+end

--- a/script/c31930787.lua
+++ b/script/c31930787.lua
@@ -1,0 +1,132 @@
+--機皇帝スキエル∞
+function c31930787.initial_effect(c)
+	c:EnableReviveLimit()
+	--special summon condition
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(0)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(31930787,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c31930787.spcon)
+	e2:SetTarget(c31930787.sptg)
+	e2:SetOperation(c31930787.spop)
+	c:RegisterEffect(e2)
+	--cannot attack announce
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
+	e3:SetTargetRange(LOCATION_MZONE,0)
+	e3:SetTarget(c31930787.antarget)
+	c:RegisterEffect(e3)
+	--equip
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(31930787,1))
+	e4:SetCategory(CATEGORY_EQUIP)
+	e4:SetType(EFFECT_TYPE_IGNITION)
+	e4:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCountLimit(1)
+	e4:SetTarget(c31930787.eqtg)
+	e4:SetOperation(c31930787.eqop)
+	c:RegisterEffect(e4)
+	aux.AddEREquipLimit(c,nil,c31930787.eqval,c31930787.equipop,e4)
+	--direct attack
+	local e5=Effect.CreateEffect(c)
+	e5:SetDescription(aux.Stringid(31930787,2))
+	e5:SetType(EFFECT_TYPE_IGNITION)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetCondition(c31930787.dircon)
+	e5:SetCost(c31930787.dircost)
+	e5:SetOperation(c31930787.dirop)
+	c:RegisterEffect(e5)
+end
+function c31930787.eqval(ec,c,tp)
+	return ec:IsControler(1-tp) and ec:IsType(TYPE_SYNCHRO)
+end
+function c31930787.filter(c,tp)
+	return c:IsType(TYPE_MONSTER) and bit.band(c:GetReason(),0x41)==0x41 and c:GetPreviousControler()==tp
+		and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
+end
+function c31930787.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c31930787.filter,1,nil,tp)
+end
+function c31930787.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,true,true) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c31930787.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)~=0 then
+		c:CompleteProcedure()
+	end
+end
+function c31930787.antarget(e,c)
+	return c~=e:GetHandler()
+end
+function c31930787.eqfilter(c)
+	return c:IsFaceup() and c:IsType(TYPE_SYNCHRO) and c:IsAbleToChangeControler()
+end
+function c31930787.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c31930787.eqfilter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c31930787.eqfilter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c31930787.eqfilter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c31930787.equipop(c,e,tp,tc)
+	local atk=tc:GetTextAttack()
+	if atk<0 then atk=0 end
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc) then return end
+	if atk>0 then
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_OWNER_RELATE)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		e2:SetValue(atk)
+		tc:RegisterEffect(e2)
+	end
+end
+function c31930787.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsType(TYPE_MONSTER) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c31930787.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end
+function c31930787.dircon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()==PHASE_MAIN1 and not e:GetHandler():IsHasEffect(EFFECT_DIRECT_ATTACK)
+end
+function c31930787.dcfilter(c)
+	return bit.band(c:GetOriginalType(),TYPE_MONSTER)~=0 and c:IsAbleToGraveAsCost()
+end
+function c31930787.dircost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetEquipGroup():IsExists(c31930787.dcfilter,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=e:GetHandler():GetEquipGroup():FilterSelect(tp,c31930787.dcfilter,1,1,nil)
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c31930787.dirop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsFacedown() or not c:IsRelateToEffect(e) then return end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_DIRECT_ATTACK)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+	c:RegisterEffect(e1,true)
+end

--- a/script/c3897065.lua
+++ b/script/c3897065.lua
@@ -1,0 +1,79 @@
+--スーパービークロイド－ステルス・ユニオン
+function c3897065.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcMix(c,true,true,61538782,98049038,71218746,984114)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(3897065,0))
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetTarget(c3897065.eqtg)
+	e1:SetOperation(c3897065.eqop)
+	c:RegisterEffect(e1)
+	aux.AddEREquipLimit(c,nil,aux.NOT(aux.FilterBoolFunction(Card.IsRace,RACE_MACHINE)),c3897065.equipop,e1)
+	--attack all
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_ATTACK_ALL)
+	e2:SetCondition(c3897065.atcon)
+	e2:SetValue(1)
+	c:RegisterEffect(e2)
+	--pierce
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_PIERCE)
+	c:RegisterEffect(e3)
+	--atk
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_ATTACK_ANNOUNCE)
+	e4:SetOperation(c3897065.atkop)
+	c:RegisterEffect(e4)
+end
+c3897065.material_setcode=0x16
+function c3897065.eqfilter(c,tp)
+	return c:IsFaceup() and not c:IsRace(RACE_MACHINE) and (c:IsControler(tp) or c:IsAbleToChangeControler())
+end
+function c3897065.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c3897065.eqfilter(chkc,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c3897065.eqfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,e:GetHandler(),tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c3897065.eqfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,e:GetHandler(),tp)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c3897065.equipop(c,e,tp,tc)
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc) then return end
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e2:SetCode(3897065)
+	e2:SetReset(RESET_EVENT+0x1fe0000)
+	tc:RegisterEffect(e2)
+end
+function c3897065.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsType(TYPE_MONSTER) and not tc:IsRace(RACE_MACHINE) and tc:IsRelateToEffect(e) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c3897065.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end
+function c3897065.atcon(e)
+	return e:GetHandler():IsHasEffect(3897065)
+end
+function c3897065.atkop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local atk=c:GetBaseAttack()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_SET_BASE_ATTACK)
+	e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_DAMAGE)
+	e1:SetValue(atk/2)
+	c:RegisterEffect(e1)
+end

--- a/script/c39987164.lua
+++ b/script/c39987164.lua
@@ -1,0 +1,81 @@
+--ヴァイロン・ディシグマ
+function c39987164.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,nil,4,3)
+	c:EnableReviveLimit()
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(39987164,0))
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCost(c39987164.eqcost)
+	e1:SetTarget(c39987164.eqtg)
+	e1:SetOperation(c39987164.eqop)
+	c:RegisterEffect(e1,false,1)
+	aux.AddEREquipLimit(c,nil,c39987164.eqval,c39987164.equipop,e1)
+	--destroy
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(39987164,1))
+	e2:SetCategory(CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e2:SetCode(EVENT_BATTLE_START)
+	e2:SetCondition(c39987164.descon)
+	e2:SetTarget(c39987164.destg)
+	e2:SetOperation(c39987164.desop)
+	c:RegisterEffect(e2)
+end
+function c39987164.eqval(ec,c,tp)
+	return ec:IsControler(1-tp) and ec:IsAttackPos() and ec:IsType(TYPE_EFFECT)
+end
+function c39987164.eqcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
+	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
+end
+function c39987164.filter(c)
+	return c:IsFaceup() and c:IsAttackPos() and c:IsType(TYPE_EFFECT) and c:IsAbleToChangeControler()
+end
+function c39987164.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c39987164.filter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c39987164.filter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c39987164.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c39987164.equipop(c,e,tp,tc)
+	aux.EquipByEffectAndLimitRegister(c,e,tp,tc,39987164)
+end
+function c39987164.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsAttackPos() and tc:IsRelateToEffect(e) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c39987164.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end
+function c39987164.desfilter(c,att)
+	return c:GetFlagEffect(39987164)~=0 and c:IsAttribute(att)
+end
+function c39987164.descon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local dt=Duel.GetAttacker()
+	if dt==c then dt=Duel.GetAttackTarget() end
+	if not dt or dt:IsFacedown() then return false end
+	e:SetLabelObject(dt)
+	local att=dt:GetAttribute()
+	return c:GetEquipGroup():IsExists(c39987164.desfilter,1,nil,att)
+end
+function c39987164.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,e:GetLabelObject(),1,0,0)
+end
+function c39987164.desop(e,tp,eg,ep,ev,re,r,rp)
+	local dt=e:GetLabelObject()
+	if dt:IsRelateToBattle() then
+		Duel.Destroy(dt,REASON_EFFECT)
+	end
+end

--- a/script/c41578483.lua
+++ b/script/c41578483.lua
@@ -81,7 +81,7 @@ function c41578483.eqop(e,tp,eg,ep,ev,re,r,rp)
 	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsType(TYPE_MONSTER) and tc:IsControler(1-tp) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) then
 			c41578483.equipop(c,e,tp,tc)
-		else Duel.SendtoGrave(tc,REASON_EFFECT) end
+		else Duel.SendtoGrave(tc,REASON_RULE) end
 	end
 end
 function c41578483.atkval(e,c)

--- a/script/c4252828.lua
+++ b/script/c4252828.lua
@@ -1,0 +1,75 @@
+--シー・アーチャー
+function c4252828.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(4252828,0))
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c4252828.eqcon)
+	e1:SetTarget(c4252828.eqtg)
+	e1:SetOperation(c4252828.eqop)
+	c:RegisterEffect(e1)
+	aux.AddEREquipLimit(c,c4252828.eqcon,c4252828.eqval,c4252828.equipop,e1)
+	--Destroy replace
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
+	e2:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCode(EFFECT_DESTROY_REPLACE)
+	e2:SetTarget(c4252828.desreptg)
+	e2:SetOperation(c4252828.desrepop)
+	c:RegisterEffect(e2)
+end
+function c4252828.eqval(ec,c,tp)
+	return ec:IsControler(tp) and ec:IsLevelBelow(3)
+end
+function c4252828.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetHandler():GetEquipGroup():Filter(c4252828.eqfilter,nil)
+	return g:GetCount()==0
+end
+function c4252828.eqfilter(c)
+	return c:GetFlagEffect(4252828)~=0 
+end
+function c4252828.filter(c)
+	return c:IsFaceup() and c:IsLevelBelow(3)
+end
+function c4252828.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and c4252828.filter(chkc) and chkc~=e:GetHandler() end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c4252828.filter,tp,LOCATION_MZONE,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c4252828.filter,tp,LOCATION_MZONE,0,1,1,e:GetHandler())
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c4252828.equipop(c,e,tp,tc)
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc,4252828) then return end
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetReset(RESET_EVENT+0x1fe0000)
+	e2:SetValue(800)
+	tc:RegisterEffect(e2)
+end
+function c4252828.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsType(TYPE_MONSTER) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c4252828.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end
+function c4252828.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	local ec=c:GetEquipGroup():Filter(c4252828.eqfilter,nil):GetFirst()
+	if chk==0 then return ec and ec:IsHasCardTarget(c) and ec:IsDestructable(e) and not ec:IsStatus(STATUS_DESTROY_CONFIRMED) 
+		and not c:IsReason(REASON_REPLACE) end
+	return Duel.SelectEffectYesNo(tp,c,96)
+end
+function c4252828.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetHandler():GetEquipGroup():Filter(c4252828.eqfilter,nil):GetFirst()
+	Duel.Destroy(ec,REASON_EFFECT+REASON_REPLACE)
+end

--- a/script/c50140163.lua
+++ b/script/c50140163.lua
@@ -1,0 +1,69 @@
+--魅惑の女王 LV7
+function c50140163.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetOperation(c50140163.regop)
+	c:RegisterEffect(e1)
+end
+c50140163.lvupcount=1
+c50140163.lvup={23756165}
+c50140163.lvdncount=2
+c50140163.lvdn={23756165,87257460}
+function c50140163.regop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:GetSummonType()==SUMMON_TYPE_SPECIAL+1 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(50140163,0))
+		e1:SetCategory(CATEGORY_EQUIP)
+		e1:SetType(EFFECT_TYPE_IGNITION)
+		e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetCountLimit(1)
+		e1:SetCondition(c50140163.eqcon)
+		e1:SetTarget(c50140163.eqtg)
+		e1:SetOperation(c50140163.eqop)
+		e1:SetReset(RESET_EVENT+0x1ff0000)
+		e1:SetLabelObject(e)
+		c:RegisterEffect(e1)
+		aux.AddEREquipLimit(c,c50140163.eqcon,function(ec,_,tp) return ec:IsControler(1-tp) end,c50140163.equipop,e1,nil,RESET_EVENT+0x1ff0000)
+	end
+end
+function c50140163.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetHandler():GetEquipGroup():Filter(c50140163.eqfilter,nil)
+	return g:GetCount()==0
+end
+function c50140163.eqfilter(c)
+	return c:GetFlagEffect(50140163)~=0 
+end
+function c50140163.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and chkc:IsAbleToChangeControler() end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(Card.IsAbleToChangeControler,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,Card.IsAbleToChangeControler,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c50140163.equipop(c,e,tp,tc)
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc,50140163) then return end
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_OWNER_RELATE+EFFECT_FLAG_SET_AVAILABLE)
+	e2:SetCode(EFFECT_DESTROY_SUBSTITUTE)
+	e2:SetReset(RESET_EVENT+0x1fe0000)
+	e2:SetValue(c50140163.repval)
+	tc:RegisterEffect(e2)
+end
+function c50140163.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c50140163.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end
+function c50140163.repval(e,re,r,rp)
+	return bit.band(r,REASON_BATTLE)~=0
+end

--- a/script/c57135971.lua
+++ b/script/c57135971.lua
@@ -108,6 +108,7 @@ function c57135971.desop(e,tp,eg,ep,ev,re,r,rp)
 		e3:SetReset(RESET_EVENT+0x1fe0000)
 		e3:SetLabelObject(tc)
 		c:RegisterEffect(e3)
+	else Duel.SendtoGrave(c,REASON_RULE)
 	end
 end
 function c57135971.eqlimit2(e,c)

--- a/script/c57784563.lua
+++ b/script/c57784563.lua
@@ -1,0 +1,69 @@
+--闇魔界の戦士長 ダークソード
+function c57784563.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(57784563,0))
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c57784563.eqcon)
+	e1:SetCost(c57784563.eqcost)
+	e1:SetTarget(c57784563.eqtg)
+	e1:SetOperation(c57784563.eqop)
+	c:RegisterEffect(e1)
+end
+function c57784563.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetLabelObject()
+	return ec==nil or ec:GetFlagEffect(57784563)==0
+end
+function c57784563.cfilter(c)
+	return c:IsAttribute(ATTRIBUTE_DARK) and c:IsAbleToRemoveAsCost() and aux.SpElimFilter(c,true)
+end
+function c57784563.eqcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c57784563.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,e:GetHandler()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local g=Duel.SelectMatchingCard(tp,c57784563.cfilter,tp,LOCATION_MZONE+LOCATION_GRAVE,0,1,1,e:GetHandler())
+	Duel.Remove(g,POS_FACEUP,REASON_COST)
+end
+function c57784563.filter(c)
+	return c:IsFaceup() and c:IsLevelBelow(4) and c:IsAttribute(ATTRIBUTE_LIGHT) and c:IsAbleToChangeControler()
+end
+function c57784563.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c57784563.filter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c57784563.filter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c57784563.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c57784563.eqlimit(e,c)
+	return e:GetOwner()==c
+end
+function c57784563.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsType(TYPE_MONSTER) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			if not Duel.Equip(tp,tc,c,false) then return end
+			--Add Equip limit
+			tc:RegisterFlagEffect(57784563,RESET_EVENT+0x1fe0000,0,0)
+			e:SetLabelObject(tc)
+			local e1=Effect.CreateEffect(c)
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_EQUIP_LIMIT)
+			e1:SetProperty(EFFECT_FLAG_COPY_INHERIT+EFFECT_FLAG_OWNER_RELATE)
+			e1:SetReset(RESET_EVENT+0x1fe0000)
+			e1:SetValue(c57784563.eqlimit)
+			tc:RegisterEffect(e1)
+			local e2=Effect.CreateEffect(c)
+			e2:SetType(EFFECT_TYPE_EQUIP)
+			e2:SetProperty(EFFECT_FLAG_OWNER_RELATE+EFFECT_FLAG_IGNORE_IMMUNE)
+			e2:SetCode(EFFECT_DESTROY_SUBSTITUTE)
+			e2:SetReset(RESET_EVENT+0x1fe0000)
+			e2:SetValue(1)
+			tc:RegisterEffect(e2)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end

--- a/script/c63465535.lua
+++ b/script/c63465535.lua
@@ -1,0 +1,86 @@
+--地底のアラクネー
+function c63465535.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,aux.FilterBoolFunctionEx(Card.IsAttribute,ATTRIBUTE_DARK),1,1,aux.NonTunerEx(Card.IsRace,RACE_INSECT),1,1)
+	c:EnableReviveLimit()
+	--actlimit
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetTargetRange(0,1)
+	e1:SetValue(c63465535.aclimit)
+	e1:SetCondition(c63465535.actcon)
+	c:RegisterEffect(e1)
+	--equip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(63465535,0))
+	e2:SetCategory(CATEGORY_EQUIP)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c63465535.eqcon)
+	e2:SetTarget(c63465535.eqtg)
+	e2:SetOperation(c63465535.eqop)
+	c:RegisterEffect(e2)
+	aux.AddEREquipLimit(c,c63465535.eqcon,function(ec,_,tp) return ec:IsControler(1-tp) end,c63465535.equipop,e2)
+	--Destroy replace
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_CONTINUOUS+EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCode(EFFECT_DESTROY_REPLACE)
+	e3:SetTarget(c63465535.desreptg)
+	e3:SetOperation(c63465535.desrepop)
+	e3:SetLabelObject(e2)
+	c:RegisterEffect(e3)
+end
+function c63465535.aclimit(e,re,tp)
+	return re:IsHasType(EFFECT_TYPE_ACTIVATE)
+end
+function c63465535.actcon(e)
+	return Duel.GetAttacker()==e:GetHandler()
+end
+function c63465535.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetHandler():GetEquipGroup():Filter(c63465535.eqfilter,nil)
+	return g:GetCount()==0
+end
+function c63465535.eqfilter(c)
+	return c:GetFlagEffect(63465535)~=0 
+end
+function c63465535.filter(c)
+	return c:IsFaceup() and c:IsAbleToChangeControler()
+end
+function c63465535.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c63465535.filter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c63465535.filter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c63465535.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c63465535.equipop(c,e,tp,tc)
+	aux.EquipByEffectAndLimitRegister(c,e,tp,tc,63465535)
+end
+function c63465535.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsType(TYPE_MONSTER) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c63465535.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end
+function c63465535.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	local ec=c:GetEquipGroup():Filter(c63465535.eqfilter,nil):GetFirst()
+	if chk==0 then return c:IsReason(REASON_BATTLE) and ec and ec:IsHasCardTarget(c)
+		and ec:IsDestructable(e) and not ec:IsStatus(STATUS_DESTROY_CONFIRMED) end
+	return Duel.SelectEffectYesNo(tp,c,96)
+end
+function c63465535.desrepop(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetHandler():GetEquipGroup():Filter(c63465535.eqfilter,nil):GetFirst()
+	Duel.Destroy(ec,REASON_EFFECT+REASON_REPLACE)
+end

--- a/script/c63468625.lua
+++ b/script/c63468625.lua
@@ -1,0 +1,125 @@
+--機皇神マシニクル∞
+function c63468625.initial_effect(c)
+	c:EnableReviveLimit()
+	--special summon condition
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(0)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c63468625.spcon)
+	e2:SetOperation(c63468625.spop)
+	c:RegisterEffect(e2)
+	--equip
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(63468625,0))
+	e3:SetCategory(CATEGORY_EQUIP)
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCountLimit(1)
+	e3:SetTarget(c63468625.eqtg)
+	e3:SetOperation(c63468625.eqop)
+	c:RegisterEffect(e3)
+	aux.AddEREquipLimit(c,nil,c63468625.eqval,c63468625.equipop,e3)
+	--damage
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(63468625,1))
+	e4:SetCategory(CATEGORY_DAMAGE)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetType(EFFECT_TYPE_TRIGGER_O+EFFECT_TYPE_FIELD)
+	e4:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCountLimit(1)
+	e4:SetCondition(c63468625.damcon)
+	e4:SetCost(c63468625.damcost)
+	e4:SetTarget(c63468625.damtg)
+	e4:SetOperation(c63468625.damop)
+	c:RegisterEffect(e4)
+end
+function c63468625.eqval(ec,c,tp)
+	return ec:IsType(TYPE_SYNCHRO) and ec:IsControler(1-tp)
+end
+function c63468625.spfilter(c)
+	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x13) and c:IsAbleToGraveAsCost()
+end
+function c63468625.spcon(e,c)
+	if c==nil then return true end
+	return Duel.GetLocationCount(c:GetControler(),LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(c63468625.spfilter,c:GetControler(),LOCATION_HAND,0,3,c)
+end
+function c63468625.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=Duel.SelectMatchingCard(tp,c63468625.spfilter,tp,LOCATION_HAND,0,3,3,c)
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c63468625.eqfilter(c)
+	return c:IsFaceup() and c:IsType(TYPE_SYNCHRO) and c:IsAbleToChangeControler()
+end
+function c63468625.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c63468625.eqfilter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c63468625.eqfilter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c63468625.eqfilter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c63468625.equipop(c,e,tp,tc)
+	local atk=tc:GetTextAttack()
+	if atk<0 then atk=0 end
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc,63468625) then return end
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetReset(RESET_EVENT+0x1fe0000)
+	e2:SetValue(atk)
+	tc:RegisterEffect(e2)
+end
+function c63468625.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsType(TYPE_MONSTER) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c63468625.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end
+function c63468625.damcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp
+end
+function c63468625.dcfilter(c)
+	return c:GetFlagEffect(63468625)~=0 and c:IsAbleToGraveAsCost()
+end
+function c63468625.damcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():GetEquipGroup():IsExists(c63468625.dcfilter,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
+	local g=e:GetHandler():GetEquipGroup():FilterSelect(tp,c63468625.dcfilter,1,1,nil)
+	Duel.SendtoGrave(g,REASON_COST)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_BP)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET+EFFECT_FLAG_OATH)
+	e1:SetTargetRange(1,0)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+	local atk=g:GetFirst():GetTextAttack()
+	if atk<0 then atk=0 end
+	e:SetLabel(atk)
+end
+function c63468625.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetTargetPlayer(1-tp)
+	Duel.SetTargetParam(e:GetLabel())
+	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,e:GetLabel())
+end
+function c63468625.damop(e,tp,eg,ep,ev,re,r,rp)
+	local p,d=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER,CHAININFO_TARGET_PARAM)
+	Duel.Damage(p,d,REASON_EFFECT)
+end

--- a/script/c63519819.lua
+++ b/script/c63519819.lua
@@ -78,7 +78,7 @@ function c63519819.eqop(e,tp,eg,ep,ev,re,r,rp)
 	if tc and tc:IsRelateToEffect(e) and tc:IsType(TYPE_MONSTER) and tc:IsControler(1-tp) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) and c63519819.eqcon(e,tp,eg,ep,ev,re,r,rp) then
 			c63519819.equipop(c,e,tp,tc)
-		else Duel.SendtoGrave(tc,REASON_EFFECT) end
+		else Duel.SendtoGrave(tc,REASON_RULE) end
 	end
 end
 function c63519819.repval(e,re,r,rp)

--- a/script/c6387204.lua
+++ b/script/c6387204.lua
@@ -1,0 +1,90 @@
+--CNo.6 先史遺産カオス・アトランタル
+function c6387204.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,nil,7,3)
+	c:EnableReviveLimit()
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(6387204,0))
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetTarget(c6387204.eqtg)
+	e1:SetOperation(c6387204.eqop)
+	c:RegisterEffect(e1)
+	aux.AddEREquipLimit(c,nil,function(ec,_,tp) return ec:IsControler(1-tp) end,c6387204.equipop,e1)
+	--lp
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(6387204,1))
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c6387204.lpcon)
+	e2:SetCost(c6387204.lpcost)
+	e2:SetOperation(c6387204.lpop)
+	c:RegisterEffect(e2,false,1)
+end
+c6387204.xyz_number=6
+function c6387204.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and chkc:IsAbleToChangeControler() end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(Card.IsAbleToChangeControler,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,Card.IsAbleToChangeControler,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c6387204.equipop(c,e,tp,tc)
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc,6387204) then return end
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetReset(RESET_EVENT+0x1fe0000)
+	e2:SetValue(1000)
+	tc:RegisterEffect(e2)
+end
+function c6387204.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c6387204.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_CHANGE_DAMAGE)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e3:SetTargetRange(0,1)
+	e3:SetValue(0)
+	e3:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e3,tp)
+	local e4=e3:Clone()
+	e4:SetCode(EFFECT_NO_EFFECT_DAMAGE)
+	e4:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e4,tp)
+end
+function c6387204.lpcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetLP(1-tp)~=100 and e:GetHandler():GetOverlayGroup():IsExists(Card.IsCode,1,nil,9161357)
+end
+function c6387204.filter(c)
+	return c:GetFlagEffect(6387204)~=0 and c:IsSetCard(0x48) and c:IsFaceup() and c:IsAbleToGraveAsCost()
+end
+function c6387204.lpcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,3,REASON_COST)
+		and e:GetHandler():GetEquipGroup():IsExists(c6387204.filter,1,nil) end
+	e:GetHandler():RemoveOverlayCard(tp,3,3,REASON_COST)
+	local g=e:GetHandler():GetEquipGroup():Filter(c6387204.filter,nil)
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function c6387204.lpop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.SetLP(1-tp,100)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CHANGE_DAMAGE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(0,1)
+	e1:SetValue(0)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e1,tp)
+end

--- a/script/c64631466.lua
+++ b/script/c64631466.lua
@@ -73,7 +73,7 @@ function c64631466.eqop(e,tp,eg,ep,ev,re,r,rp)
 	if tc and tc:IsRelateToEffect(e) and tc:IsType(TYPE_MONSTER) and tc:IsControler(1-tp) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) and c64631466.eqcon(e,tp,eg,ep,ev,re,r,rp) then
 			c64631466.equipop(c,e,tp,tc)
-		else Duel.SendtoGrave(tc,REASON_EFFECT) end
+		else Duel.SendtoGrave(tc,REASON_RULE) end
 	end
 end
 function c64631466.repval(e,re,r,rp)

--- a/script/c66094973.lua
+++ b/script/c66094973.lua
@@ -1,0 +1,111 @@
+--トランスフォーム・スフィア
+function c66094973.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(66094973,0))
+	e1:SetCategory(CATEGORY_HANDES+CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c66094973.eqcon)
+	e1:SetTarget(c66094973.eqtg)
+	e1:SetOperation(c66094973.eqop)
+	c:RegisterEffect(e1)
+	aux.AddEREquipLimit(c,c66094973.eqcon,c66094973.eqval,c66094973.equipop,e1)
+	--to defense
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c66094973.poscon)
+	e2:SetOperation(c66094973.posop)
+	c:RegisterEffect(e2)
+	--spsummon
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(66094973,1))
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_PHASE+PHASE_END)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCountLimit(1)
+	e3:SetCondition(c66094973.spcon)
+	e3:SetTarget(c66094973.sptg)
+	e3:SetOperation(c66094973.spop)
+	c:RegisterEffect(e3)
+end
+function c66094973.eqval(ec,c,tp)
+	return ec:IsControler(1-tp) and ec:IsPosition(POS_FACEUP_DEFENSE)
+end
+function c66094973.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetHandler():GetEquipGroup():Filter(c66094973.eqfilter,nil)
+	return g:GetCount()==0
+end
+function c66094973.eqfilter(c)
+	return c:GetFlagEffect(66094973)~=0 
+end
+function c66094973.filter(c)
+	return c:IsPosition(POS_FACEUP_DEFENSE) and c:IsAbleToChangeControler()
+end
+function c66094973.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c66094973.filter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0 and Duel.GetFieldGroup(tp,LOCATION_HAND,0)~=0
+		and Duel.IsExistingTarget(c66094973.filter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c66094973.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c66094973.equipop(c,e,tp,tc)
+	local atk=tc:GetTextAttack()
+	if atk<0 then atk=0 end
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc,66094973) then return end
+	if atk>0 then
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_OWNER_RELATE+EFFECT_FLAG_SET_AVAILABLE)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		e2:SetValue(atk)
+		tc:RegisterEffect(e2)
+	end
+end
+function c66094973.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if Duel.GetFieldGroup(tp,LOCATION_HAND,0)==0 then return end
+	Duel.DiscardHand(tp,nil,1,1,REASON_EFFECT+REASON_DISCARD)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c66094973.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end
+function c66094973.poscon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetAttackedCount()>0
+end
+function c66094973.posop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsAttackPos() then
+		Duel.ChangePosition(c,POS_FACEUP_DEFENSE)
+	end
+end
+function c66094973.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetHandler():GetEquipGroup():Filter(c66094973.eqfilter,nil)
+	return g:GetCount()==1
+end
+function c66094973.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	local tc=e:GetHandler():GetEquipGroup():Filter(c66094973.eqfilter,nil):GetFirst()
+	Duel.SetTargetCard(tc)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tc,1,0,0)
+end
+function c66094973.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and Duel.IsPlayerCanSpecialSummon(tp) then
+		if Duel.SpecialSummon(tc,0,tp,1-tp,false,false,POS_FACEUP_DEFENSE)==0 then
+			Duel.SendtoGrave(tc,REASON_EFFECT)
+		end
+	end
+end

--- a/script/c68140974.lua
+++ b/script/c68140974.lua
@@ -1,0 +1,130 @@
+--機皇帝ワイゼル∞
+function c68140974.initial_effect(c)
+	c:EnableReviveLimit()
+	--special summon condition
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(0)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(68140974,0))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c68140974.spcon)
+	e2:SetTarget(c68140974.sptg)
+	e2:SetOperation(c68140974.spop)
+	c:RegisterEffect(e2)
+	--cannot attack announce
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCode(EFFECT_CANNOT_ATTACK_ANNOUNCE)
+	e3:SetTargetRange(LOCATION_MZONE,0)
+	e3:SetTarget(c68140974.antarget)
+	c:RegisterEffect(e3)
+	--equip
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(68140974,1))
+	e4:SetCategory(CATEGORY_EQUIP)
+	e4:SetType(EFFECT_TYPE_IGNITION)
+	e4:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCountLimit(1)
+	e4:SetTarget(c68140974.eqtg)
+	e4:SetOperation(c68140974.eqop)
+	c:RegisterEffect(e4)
+	aux.AddEREquipLimit(c,nil,c68140974.eqval,c68140974.equipop,e4)
+	--negate spell
+	local e5=Effect.CreateEffect(c)
+	e5:SetDescription(aux.Stringid(68140974,2))
+	e5:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
+	e5:SetType(EFFECT_TYPE_QUICK_O)
+	e5:SetCode(EVENT_CHAINING)
+	e5:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetCountLimit(1)
+	e5:SetCondition(c68140974.negcon)
+	e5:SetTarget(c68140974.negtg)
+	e5:SetOperation(c68140974.negop)
+	c:RegisterEffect(e5)
+end
+function c68140974.eqval(ec,c,tp)
+	return ec:IsControler(1-tp) and ec:IsType(TYPE_SYNCHRO)
+end
+function c68140974.filter(c,tp)
+	return c:IsType(TYPE_MONSTER) and bit.band(c:GetReason(),0x41)==0x41 and c:GetPreviousControler()==tp
+		and c:IsPreviousLocation(LOCATION_MZONE) and c:IsPreviousPosition(POS_FACEUP)
+end
+function c68140974.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(c68140974.filter,1,nil,tp)
+end
+function c68140974.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,true,true) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c68140974.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
+	if Duel.SpecialSummon(c,0,tp,tp,true,false,POS_FACEUP)~=0 then
+		c:CompleteProcedure()
+	end
+end
+function c68140974.antarget(e,c)
+	return c~=e:GetHandler()
+end
+function c68140974.eqfilter(c)
+	return c:IsFaceup() and c:IsType(TYPE_SYNCHRO) and c:IsAbleToChangeControler()
+end
+function c68140974.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c68140974.eqfilter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c68140974.eqfilter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c68140974.eqfilter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c68140974.equipop(c,e,tp,tc)
+	local atk=tc:GetTextAttack()
+	if atk<0 then atk=0 end
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc) then return end
+	if atk>0 then
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_OWNER_RELATE)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		e2:SetValue(atk)
+		tc:RegisterEffect(e2)
+	end
+end
+function c68140974.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) and tc:IsType(TYPE_MONSTER) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c68140974.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end
+function c68140974.negcon(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) then return false end
+	return ep~=tp and re:IsActiveType(TYPE_SPELL) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev)
+end
+function c68140974.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
+end
+function c68140974.negop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
+		Duel.Destroy(eg,REASON_EFFECT)
+	end
+end

--- a/script/c77693536.lua
+++ b/script/c77693536.lua
@@ -1,0 +1,81 @@
+--フルメタルフォーゼ・アルカエスト
+function c77693536.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcMix(c,true,true,aux.FilterBoolFunction(Card.IsFusionSetCard,0xe1),aux.FilterBoolFunctionEx(Card.IsType,TYPE_NORMAL))
+	--spsummon condition
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(aux.fuslimit)
+	c:RegisterEffect(e1)
+	--equip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(77693536,0))
+	e2:SetCategory(CATEGORY_EQUIP)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetHintTiming(0,0x1e0)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(c77693536.eqcon)
+	e2:SetTarget(c77693536.eqtg)
+	e2:SetOperation(c77693536.eqop)
+	c:RegisterEffect(e2)
+	aux.AddEREquipLimit(c,nil,aux.FilterBoolFunction(Card.IsType,TYPE_EFFECT),c77693536.equipop,e2)
+	--equip fusion material
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_EXTRA_FUSION_MATERIAL)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetTargetRange(LOCATION_SZONE,0)
+	e3:SetTarget(c77693536.mttg)
+	e3:SetValue(c77693536.mtval)
+	c:RegisterEffect(e3)
+end
+c77693536.material_setcode=0xe1
+function c77693536.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp
+end
+function c77693536.eqfilter(c,tp)
+	return c:IsFaceup() and c:IsType(TYPE_EFFECT)
+		and (c:IsControler(tp) or c:IsAbleToChangeControler())
+end
+function c77693536.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and c77693536.eqfilter(chkc,tp) and chkc~=e:GetHandler() end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c77693536.eqfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,e:GetHandler(),tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c77693536.eqfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,e:GetHandler(),tp)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c77693536.equipop(c,e,tp,tc)
+	local atk=tc:GetTextAttack()
+	if atk<0 then atk=0 end
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc,nil,true) then return end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_EQUIP)
+	e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_OWNER_RELATE)
+	e1:SetCode(EFFECT_UPDATE_DEFENSE)
+	e1:SetValue(atk)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
+	tc:RegisterEffect(e1)
+end
+function c77693536.eqop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 then return end
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not tc or not (tc:IsRelateToEffect(e) and tc:IsFaceup() and tc:IsType(TYPE_EFFECT)) then return end
+	if c:IsFaceup() and c:IsRelateToEffect(e) then
+		c77693536.equipop(c,e,tp,tc)
+	else Duel.SendtoGrave(tc,REASON_RULE) end
+end
+function c77693536.mttg(e,c)
+	return c:GetEquipTarget()==e:GetHandler()
+end
+function c77693536.mtval(e,c)
+	if not c then return false end
+	return c:IsSetCard(0xe1) and c:IsControler(e:GetHandlerPlayer())
+end

--- a/script/c82962242.lua
+++ b/script/c82962242.lua
@@ -1,0 +1,109 @@
+--ヴァンプ・オブ・ヴァンパイア
+function c82962242.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(82962242,0))
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_SUMMON_SUCCESS)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
+	e1:SetTarget(c82962242.eqtg)
+	e1:SetOperation(c82962242.eqop)
+	c:RegisterEffect(e1)
+	aux.AddEREquipLimit(c,nil,c82962242.eqval,c82962242.equipop,e1)
+	--equip
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(82962242,1))
+	e2:SetCategory(CATEGORY_EQUIP)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_SUMMON_SUCCESS)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetCountLimit(1,EFFECT_COUNT_CODE_SINGLE)
+	e2:SetCondition(c82962242.eqcon)
+	e2:SetTarget(c82962242.eqtg)
+	e2:SetOperation(c82962242.eqop)
+	c:RegisterEffect(e2)
+	aux.AddEREquipLimit(c,nil,c82962242.eqval,c82962242.equipop,e2)
+	--spsummon
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_LEAVE_FIELD_P)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e3:SetOperation(c82962242.checkop)
+	c:RegisterEffect(e3)
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(82962242,2))
+	e4:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e4:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+	e4:SetCode(EVENT_TO_GRAVE)
+	e4:SetCondition(c82962242.spcon)
+	e4:SetTarget(c82962242.sptg)
+	e4:SetOperation(c82962242.spop)
+	c:RegisterEffect(e4)
+	e3:SetLabelObject(e4)
+end
+function c82962242.eqval(ec,c,tp)
+	return ec:IsControler(1-tp) and ec:GetAttack()>c:GetAttack()
+end
+function c82962242.cfilter(c,tp)
+	return c:IsFaceup() and c:IsSetCard(0x8e) and c:IsControler(tp)
+end
+function c82962242.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	return not eg:IsContains(e:GetHandler()) and eg:IsExists(c82962242.cfilter,1,nil,tp)
+end
+function c82962242.eqfilter(c,atk)
+	return c:IsFaceup() and c:GetAttack()>atk and c:IsAbleToChangeControler()
+end
+function c82962242.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c82962242.eqfilter(chkc,e:GetHandler():GetAttack()) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c82962242.eqfilter,tp,0,LOCATION_MZONE,1,nil,e:GetHandler():GetAttack()) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c82962242.eqfilter,tp,0,LOCATION_MZONE,1,1,nil,e:GetHandler():GetAttack())
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c82962242.equipop(c,e,tp,tc)
+	local atk=tc:GetTextAttack()
+	if tc:IsFacedown() or atk<0 then atk=0 end
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc,82962242,true) then return end
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_EQUIP)
+	e1:SetCode(EFFECT_UPDATE_ATTACK)
+	e1:SetValue(atk)
+	e1:SetReset(RESET_EVENT+0x1fe0000)
+	tc:RegisterEffect(e1)
+end
+function c82962242.eqop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 then return end
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not tc or not tc:IsRelateToEffect(e) or not tc:IsType(TYPE_MONSTER) then return end
+	if c:IsFaceup() and c:IsRelateToEffect(e) then
+		c82962242.equipop(c,e,tp,tc)
+	else Duel.SendtoGrave(tc,REASON_RULE) end
+end
+function c82962242.spfilter(c)
+	return c:GetFlagEffect(82962242)~=0
+end
+function c82962242.checkop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():GetEquipGroup():IsExists(c82962242.spfilter,1,nil) then
+		e:GetLabelObject():SetLabel(1)
+	else
+		e:GetLabelObject():SetLabel(0)
+	end
+end
+function c82962242.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetLabel()==1 and e:GetHandler():IsPreviousLocation(LOCATION_MZONE)
+end
+function c82962242.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+end
+function c82962242.spop(e,tp,eg,ep,ev,re,r,rp)
+	if e:GetHandler():IsRelateToEffect(e) then
+		Duel.SpecialSummon(e:GetHandler(),0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/script/c83965310.lua
+++ b/script/c83965310.lua
@@ -1,0 +1,111 @@
+--D－HERO Bloo－D 
+function c83965310.initial_effect(c)
+	c:EnableReviveLimit()
+	--cannot special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(aux.FALSE)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(83965310,0))
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_SPSUMMON_PROC)
+	e2:SetProperty(EFFECT_FLAG_UNCOPYABLE)
+	e2:SetRange(LOCATION_HAND)
+	e2:SetCondition(c83965310.spcon)
+	e2:SetOperation(c83965310.spop)
+	c:RegisterEffect(e2)
+	--equip
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(83965310,1))
+	e3:SetCategory(CATEGORY_EQUIP)
+	e3:SetType(EFFECT_TYPE_IGNITION)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCountLimit(1)
+	e3:SetCondition(c83965310.eqcon)
+	e3:SetTarget(c83965310.eqtg)
+	e3:SetOperation(c83965310.eqop)
+	c:RegisterEffect(e3)
+	aux.AddEREquipLimit(c,c83965310.eqcon,function(ec,_,tp) return ec:IsControler(1-tp) end,c83965310.equipop,e3)
+	--disable
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetTargetRange(0,LOCATION_MZONE)
+	e4:SetCode(EFFECT_DISABLE)
+	c:RegisterEffect(e4)
+end
+function c83965310.mzfilter(c,tp)
+	return c:IsControler(tp) and c:GetSequence()<5
+end
+function c83965310.spcon(e,c)
+	if c==nil then return true end
+	local tp=c:GetControler()
+	local rg=Duel.GetReleaseGroup(tp)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local ct=-ft+1
+	return ft>-3 and rg:GetCount()>2 and (ft>0 or rg:IsExists(c83965310.mzfilter,ct,nil,tp))
+end
+function c83965310.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	local rg=Duel.GetReleaseGroup(tp)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	local g=nil
+	if ft>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		g=rg:Select(tp,3,3,nil)
+	elseif ft>-2 then
+		local ct=-ft+1
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		g=rg:FilterSelect(tp,c83965310.mzfilter,ct,ct,nil,tp)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		local g2=rg:Select(tp,3-ct,3-ct,g)
+		g:Merge(g2)
+	else
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_RELEASE)
+		g=rg:FilterSelect(tp,c83965310.mzfilter,3,3,nil,tp)
+	end
+	Duel.Release(g,REASON_COST)
+end
+function c83965310.eqfilter(c)
+	return c:GetFlagEffect(83965310)~=0 
+end
+function c83965310.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetHandler():GetEquipGroup():Filter(c83965310.eqfilter,nil)
+	return g:GetCount()==0
+end
+function c83965310.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and chkc:IsAbleToChangeControler() end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(Card.IsAbleToChangeControler,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,Card.IsAbleToChangeControler,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c83965310.equipop(c,e,tp,tc)
+	local atk=tc:GetTextAttack()/2
+	if tc:IsFacedown() then atk=0 end
+	if atk<0 then atk=0 end
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc,83965310) then return end
+	if atk>0 then
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_EQUIP)
+		e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_OWNER_RELATE)
+		e2:SetCode(EFFECT_UPDATE_ATTACK)
+		e2:SetReset(RESET_EVENT+0x1fe0000)
+		e2:SetValue(atk)
+		tc:RegisterEffect(e2)
+	end
+end
+function c83965310.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c83965310.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end

--- a/script/c87257460.lua
+++ b/script/c87257460.lua
@@ -1,0 +1,99 @@
+--魅惑の女王 LV3
+function c87257460.initial_effect(c)
+	--equip
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(87257460,0))
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(c87257460.eqcon)
+	e1:SetTarget(c87257460.eqtg)
+	e1:SetOperation(c87257460.eqop)
+	c:RegisterEffect(e1)
+	aux.AddEREquipLimit(c,c87257460.eqcon,c87257460.eqval,c87257460.equipop,e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(87257460,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e2:SetCondition(c87257460.spcon)
+	e2:SetCost(c87257460.spcost)
+	e2:SetTarget(c87257460.sptg)
+	e2:SetOperation(c87257460.spop)
+	e2:SetLabelObject(e1)
+	c:RegisterEffect(e2)
+end
+c87257460.lvupcount=1
+c87257460.lvup={23756165}
+function c87257460.eqcon(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetHandler():GetEquipGroup():Filter(c87257460.eqfilter,nil)
+	return g:GetCount()==0
+end
+function c87257460.eqfilter(c)
+	return c:GetFlagEffect(87257460)~=0 
+end
+function c87257460.eqval(ec,c,tp)
+	return ec:IsControler(1-tp) and ec:IsLevelBelow(3)
+end
+function c87257460.filter(c)
+	return c:IsLevelBelow(3) and c:IsFaceup() and c:IsAbleToChangeControler()
+end
+function c87257460.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(1-tp) and c87257460.filter(chkc) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(c87257460.filter,tp,0,LOCATION_MZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
+	local g=Duel.SelectTarget(tp,c87257460.filter,tp,0,LOCATION_MZONE,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+end
+function c87257460.equipop(c,e,tp,tc)
+	if not aux.EquipByEffectAndLimitRegister(c,e,tp,tc,87257460) then return end
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_EQUIP)
+	e2:SetCode(EFFECT_DESTROY_SUBSTITUTE)
+	e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE+EFFECT_FLAG_OWNER_RELATE)
+	e2:SetReset(RESET_EVENT+0x1fe0000)
+	e2:SetValue(c87257460.repval)
+	tc:RegisterEffect(e2)
+end
+function c87257460.eqop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		if c:IsFaceup() and c:IsRelateToEffect(e) then
+			c87257460.equipop(c,e,tp,tc)
+		else Duel.SendtoGrave(tc,REASON_RULE) end
+	end
+end
+function c87257460.repval(e,re,r,rp)
+	return r&REASON_BATTLE~=0
+end
+function c87257460.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetHandler():GetEquipGroup():Filter(c87257460.eqfilter,nil)
+	return Duel.GetTurnPlayer()==tp and g:GetCount()==1
+end
+function c87257460.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsAbleToGraveAsCost() end
+	Duel.SendtoGrave(e:GetHandler(),REASON_COST)
+end
+function c87257460.spfilter(c,e,tp)
+	return c:IsCode(23756165) and c:IsCanBeSpecialSummoned(e,1,tp,true,false)
+end
+function c87257460.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if e:GetHandler():GetSequence()<5 then ft=ft+1 end
+	if chk==0 then return ft>0 and Duel.IsExistingMatchingCard(c87257460.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND+LOCATION_DECK)
+end
+function c87257460.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local tc=Duel.SelectMatchingCard(tp,c87257460.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,1,nil,e,tp):GetFirst()
+	if tc and Duel.SpecialSummon(tc,1,tp,tp,true,false,POS_FACEUP)>0 then
+		tc:CompleteProcedure()
+	end
+end

--- a/script/c94259633.lua
+++ b/script/c94259633.lua
@@ -58,7 +58,7 @@ function c94259633.eqop(e,tp,eg,ep,ev,re,r,rp)
 	if tc and tc:IsRelateToEffect(e) and tc:IsType(TYPE_MONSTER) then
 		if c:IsFaceup() and c:IsRelateToEffect(e) and c94259633.eqcon(e,tp,eg,ep,ev,re,r,rp) then
 			c94259633.equipop(c,e,tp,tc)
-		else Duel.SendtoGrave(tc,REASON_EFFECT) end
+		else Duel.SendtoGrave(tc,REASON_RULE) end
 	end
 end
 function c94259633.adcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
-Red-Eyes Fang with Chain: by game mechanics, if the Red-eyes monster can no longer be equipped with the target (e.g. being flipped face-down by Book of Moon) the target must be sent to the Graveyard.
-Relinquinsed: previously, it was sending the equipp target to the Graveyard (when no longer possible to equip) by a card effect, when it is a game mechanics