### PR TITLE
"The Toughest! The Invincible! The Unbeatable!" fix

### DIFF
--- a/script/c100409005.lua
+++ b/script/c100409005.lua
@@ -92,7 +92,7 @@ function c100409005.setop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_LEAVE_FIELD_REDIRECT)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e1:SetReset(RESET_EVENT+RESETS_REDIRECT)
+		e1:SetReset(RESET_EVENT+0x47e0000)
 		e1:SetValue(LOCATION_REMOVED)
 		c:RegisterEffect(e1)
 	end


### PR DESCRIPTION
Should now be banished when it leaves the field after being re-Set by its own effect.