### PR TITLE
Small fix for TCG F/L list

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -26,7 +26,6 @@
 26400609 0 --Tidal, Dragon Ruler of Waterfalls
 33184167 0 --Tribe-Infecting Virus
 44910027 0 --Victory Dragon
-58984738 0 --Dinomight Knight, the True Dracofighter
 30539496 0 --True King Lithosagym, the Disaster
 3078576 0 --Yata-Garasu
 9929398 0 --Blackwing - Gofu the Vague Shadow


### PR DESCRIPTION
Removed a second entry for "Dinomight Knight, the True Dracofighter" that would cause it to sometimes show as banned