### PR TITLE
Fixed "Imperion Magnum" and "Dance Princess of Nekroz"

### DIFF
--- a/script/c4628897.lua
+++ b/script/c4628897.lua
@@ -1,0 +1,84 @@
+--超電導戦機インペリオン・マグナム
+function c4628897.initial_effect(c)
+	--fusion material
+	c:EnableReviveLimit()
+	aux.AddFusionProcMix(c,false,false,75347539,42901635)
+	--spsummon condition
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e1:SetCode(EFFECT_SPSUMMON_CONDITION)
+	e1:SetValue(aux.fuslimit)
+	c:RegisterEffect(e1)
+	--negate
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(4628897,0))
+	e2:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_CHAINING)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL)
+	e2:SetCountLimit(1)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(c4628897.negcon)
+	e2:SetTarget(c4628897.negtg)
+	e2:SetOperation(c4628897.negop)
+	c:RegisterEffect(e2)
+	--special summon
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(4628897,1))
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetProperty(EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DAMAGE_CAL+EFFECT_FLAG_DELAY)
+	e3:SetCode(EVENT_LEAVE_FIELD)
+	e3:SetCondition(c4628897.spcon)
+	e3:SetTarget(c4628897.sptg)
+	e3:SetOperation(c4628897.spop)
+	c:RegisterEffect(e3)
+end
+c4628897.material_setcode=0xe9
+function c4628897.negcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if ep==tp or c:IsStatus(STATUS_BATTLE_DESTROYED) then return false end
+	return (re:IsActiveType(TYPE_MONSTER) or re:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(ev)
+end
+function c4628897.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_NEGATE,eg,1,0,0)
+	if re:GetHandler():IsDestructable() and re:GetHandler():IsRelateToEffect(re) then
+		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
+	end
+end
+function c4628897.negop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
+		Duel.Destroy(eg,REASON_EFFECT)
+	end
+end
+function c4628897.spcon(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	return c:GetReasonPlayer()==1-tp and c:GetPreviousControler()==tp and c:IsReason(REASON_EFFECT)
+		and c:IsPreviousLocation(LOCATION_ONFIELD) and c:IsPreviousPosition(POS_FACEUP)
+end
+function c4628897.spfilter(c,e,tp,code)
+	return c:IsCode(code) and c:IsCanBeSpecialSummoned(e,0,tp,true,false)
+end
+function c4628897.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return not Duel.IsPlayerAffectedByEffect(tp,59822133)
+		and Duel.GetLocationCount(tp,LOCATION_MZONE)>1
+		and Duel.IsExistingMatchingCard(c4628897.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,e,tp,75347539)
+		and Duel.IsExistingMatchingCard(c4628897.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,1,nil,e,tp,42901635) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_HAND+LOCATION_DECK)
+end
+function c4628897.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.IsPlayerAffectedByEffect(tp,59822133)
+		or Duel.GetLocationCount(tp,LOCATION_MZONE)<2 then return end
+	local g1=Duel.GetMatchingGroup(c4628897.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,nil,e,tp,75347539)
+	local g2=Duel.GetMatchingGroup(c4628897.spfilter,tp,LOCATION_HAND+LOCATION_DECK,0,nil,e,tp,42901635)
+	if g1:GetCount()>0 and g2:GetCount()>0 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg1=g1:Select(tp,1,1,nil)
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+		local sg2=g2:Select(tp,1,1,nil)
+		sg1:Merge(sg2)
+		Duel.SpecialSummon(sg1,0,tp,tp,true,false,POS_FACEUP)
+	end
+end

--- a/script/c52738610.lua
+++ b/script/c52738610.lua
@@ -1,0 +1,63 @@
+--影霊衣の舞姫
+function c52738610.initial_effect(c)
+	--act limit
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_CHAINING)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetOperation(c52738610.chainop)
+	c:RegisterEffect(e1)
+	--cannot be target
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e2:SetTargetRange(LOCATION_MZONE,0)
+	e2:SetTarget(c52738610.tgtg)
+	e2:SetValue(aux.tgoval)
+	c:RegisterEffect(e2)
+	--tohand
+	local e3=Effect.CreateEffect(c)
+	e3:SetCategory(CATEGORY_TOHAND)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e3:SetCode(EVENT_RELEASE)
+	e3:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP+EFFECT_FLAG_DELAY)
+	e3:SetCountLimit(1,52738610)
+	e3:SetCondition(c52738610.thcon)
+	e3:SetTarget(c52738610.thtg)
+	e3:SetOperation(c52738610.thop)
+	c:RegisterEffect(e3)
+end
+function c52738610.chainop(e,tp,eg,ep,ev,re,r,rp)
+	local rc=re:GetHandler()
+	if re:IsHasType(EFFECT_TYPE_ACTIVATE) and rc:IsSetCard(0xb4) and re:IsActiveType(TYPE_RITUAL) then
+		Duel.SetChainLimit(c52738610.chainlm)
+	end
+end
+function c52738610.chainlm(e,rp,tp)
+	return tp==rp
+end
+function c52738610.tgtg(e,c)
+	return c:IsSetCard(0xb4) and c:IsType(TYPE_RITUAL)
+end
+function c52738610.thcon(e,tp,eg,ep,ev,re,r,rp)
+	return bit.band(r,REASON_EFFECT)~=0
+end
+function c52738610.thfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0xb4) and c:IsType(TYPE_MONSTER) and not c:IsCode(52738610) and c:IsAbleToHand()
+end
+function c52738610.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_REMOVED) and chkc:IsControler(tp) and c52738610.thfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(c52738610.thfilter,tp,LOCATION_REMOVED,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectTarget(tp,c52738610.thfilter,tp,LOCATION_REMOVED,0,1,1,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,1,0,0)
+end
+function c52738610.thop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) then
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,tc)
+	end
+end


### PR DESCRIPTION
Fixed the issue where the effect of  "Imperion Magnum the Superconductive Battlebot" would activate even if the card was not in its owner control when it left the field.
Fixed the interaction of "Ash Blossom & Joyous Spring" with "Dance Princess of Nekroz"