### PR TITLE
"Galaxy Braver" fix

### DIFF
--- a/script/c101006011.lua
+++ b/script/c101006011.lua
@@ -43,10 +43,11 @@ function c101006011.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and c:IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
 end
-function c101006011.spop(e,tp,eg,ep,ev,re,r,rp)	
+function c101006011.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
+	if not c:IsRelateToEffect(e) then return end
 	local lv=e:GetLabel()
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 and c:IsRelateToEffect(e) then
+	if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)~=0 then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_CHANGE_LEVEL)
@@ -55,8 +56,8 @@ function c101006011.spop(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e1)
 	end
 end
-function c101006011.aktfilter(c)
-	return c:IsFaceup() and c:IsSetCard(0x7b)
+function c101006011.atkfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x7b) and c:IsType(TYPE_MONSTER)
 end
 function c101006011.atktg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and c101006011.atkfilter(chkc) end


### PR DESCRIPTION
Should now Special Summon itself normally (credits to CC). Also, should now only be able to target "Galaxy" monsters in the Graveyard with its second effect.