### PR TITLE
Fixed "Trickstar Light Stage"

### DIFF
--- a/script/c35371948.lua
+++ b/script/c35371948.lua
@@ -1,5 +1,5 @@
 --トリックスター・ライトステージ
---Trickster Light Stage
+--Trickstar Light Stage
 function c35371948.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -153,7 +153,7 @@ function c35371948.rstop2(e,tp,eg,ep,ev,re,r,rp)
 	if te then te:Reset() end
 end
 function c35371948.damcon1(e,tp,eg,ep,ev,re,r,rp)
-	return ep~=tp and eg:GetFirst():IsSetCard(0xfb)
+	return ep~=tp and eg:GetFirst():IsSetCard(0xfb) and not Duel.GetLP(1-tp)==0
 end
 function c35371948.damcon2(e,tp,eg,ep,ev,re,r,rp)
 	return ep~=tp and r&REASON_BATTLE==0 and re and re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0xfb)


### PR DESCRIPTION
Fixed the interaction of "D/D/D Oracle King d'Arc", "Trickstar Light Stage" and battle damage inflicted by a "Trickstar" monster that would cause the player to not lose the duel.


If you control "Trickstar Light Stage" and a "Trickstar" monster inflicts damage to your opponent (by battle) while "D/D/D Oracle King d'Arc" in on their field and that damage causes it to have its LP become 0,  "Trickstar Light Stage" also tries to inflict 200 additional damage, which is then reverted by D'arc, resulting in the opponent not losing the duel.
