### PR TITLE
"Sacred Temples of Necrovalley" fix

### DIFF
--- a/script/c56773577.lua
+++ b/script/c56773577.lua
@@ -75,7 +75,7 @@ function c56773577.acop(e,tp,eg,ep,ev,re,r,rp)
 end
 function c56773577.setcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return rp==1-tp and c:IsReason(REASON_DESTROY+REASON_EFFECT) and c:GetPreviousControler()==tp
+	return rp==1-tp and c:IsReason(REASON_DESTROY) and c:IsReason(REASON_EFFECT) and c:GetPreviousControler()==tp
 end
 function c56773577.setfilter(c)
 	return c:IsSetCard(0x91) and not c:IsCode(56773577) and c:IsSSetable()


### PR DESCRIPTION
The effect to Set from the Deck should only trigger when destroyed by a card effect.