### PR TITLE
Fix for "Millennium-Eyes Restrict"

### DIFF
--- a/script/c41578483.lua
+++ b/script/c41578483.lua
@@ -71,6 +71,7 @@ function c41578483.eqtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_EQUIP)
 	local g=Duel.SelectTarget(tp,c41578483.eqfilter,tp,0,LOCATION_MZONE+LOCATION_GRAVE,1,1,nil)
 	Duel.SetOperationInfo(0,CATEGORY_EQUIP,g,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,g,1,0,0)
 end
 function c41578483.equipop(c,e,tp,tc)
 	aux.EquipByEffectAndLimitRegister(c,e,tp,tc,41578483)


### PR DESCRIPTION
Fix for an incorrect interaction with "Necrovalley" where the target in the graveyard would still be equipped to "Millenium-Eyes Restrict".