### PR TITLE
Various fix

### DIFF
--- a/script/c100410025.lua
+++ b/script/c100410025.lua
@@ -6,10 +6,14 @@ function c100410025.initial_effect(c)
 	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_FUSION_SUMMON)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetHintTiming(0,TIMING_END_PHASE)
+	e1:SetHintTiming(0,0x1c0+TIMING_MAIN_END)
+	e1:SetCondition(c100410025.condition)
 	e1:SetTarget(c100410025.target)
 	e1:SetOperation(c100410025.activate)
 	c:RegisterEffect(e1)
+end
+function c100410025.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2
 end
 function c100410025.filter1(c,e)
 	return not c:IsImmuneToEffect(e)

--- a/script/c1118137.lua
+++ b/script/c1118137.lua
@@ -64,8 +64,8 @@ end
 function c1118137.desreptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
 	local tg=c:GetEquipTarget()
-	if chk==0 then return not c:IsStatus(STATUS_DESTROY_CONFIRMED)
-		and tg and tg:IsReason(REASON_BATTLE+REASON_EFFECT)
+	if chk==0 then return tg 
+		and tg:IsReason(REASON_BATTLE+REASON_EFFECT)
 		and Duel.IsCanRemoveCounter(tp,1,0,0x1,1,REASON_EFFECT) end
 	return Duel.SelectEffectYesNo(tp,c,96)
 end

--- a/script/c53860621.lua
+++ b/script/c53860621.lua
@@ -1,6 +1,5 @@
 --グローウィング・ボウガン
 --Glowing Bowgun
---Script by dest
 function c53860621.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
@@ -37,6 +36,7 @@ function c53860621.initial_effect(c)
 	e5:SetCode(EVENT_BATTLE_DESTROYING)
 	e5:SetRange(LOCATION_SZONE)
 	e5:SetCountLimit(1,53860621)
+	e5:SetCondition(c53860621.descon)
 	e5:SetTarget(c53860621.destg)
 	e5:SetOperation(c53860621.desop)
 	c:RegisterEffect(e5)
@@ -71,6 +71,9 @@ function c53860621.operation(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():IsRelateToEffect(e) and tc:IsRelateToEffect(e) and tc:IsFaceup() then
 		Duel.Equip(tp,e:GetHandler(),tc)
 	end
+end
+function c53860621.descon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:GetFirst()==e:GetHandler():GetEquipTarget() and eg:GetFirst():IsStatus(STATUS_OPPO_BATTLE)
 end
 function c53860621.destg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFieldGroupCount(tp,0,LOCATION_HAND)>0 end

--- a/script/c94886282.lua
+++ b/script/c94886282.lua
@@ -1,0 +1,32 @@
+--光の援軍
+function c94886282.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetCost(c94886282.cost)
+	e1:SetTarget(c94886282.target)
+	e1:SetOperation(c94886282.activate)
+	c:RegisterEffect(e1)
+end
+function c94886282.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsPlayerCanDiscardDeckAsCost(tp,3) and 
+	Duel.GetFieldGroupCount(tp,LOCATION_DECK,0)>3 end
+	Duel.DiscardDeck(tp,3,REASON_COST)
+end
+function c94886282.filter(c)
+	return c:IsSetCard(0x38) and c:IsLevelBelow(4) and c:IsAbleToHand()
+end
+function c94886282.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(c94886282.filter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
+end
+function c94886282.activate(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
+	local g=Duel.SelectMatchingCard(tp,c94886282.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SendtoHand(g,nil,REASON_EFFECT)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end


### PR DESCRIPTION
Prankids on the Loose fix:
- Fixed the activation condition + Hint timing

Charge of the Light Brigade fix
- Shouldn't be able to activate it with only 3 cards left in the deck (including 1 Level 4 or lower "Lightsworn" monster).

Power of the Guardians fix
- If ""Power of the Guardians"" has a Spell Counter on it and both it and the equipped monster would be destroyed at the same time, you can still apply its effect to remove a Spell Counter instead of the monster being destroyed (only ""Power of the Guardians"" would be destroyed instead of both).

Glowing Bowgun fix
- The effect that discards a card from the opponent's hand triggers even if a monster other than the equipped monster destroys a monster by battle.