### PR TITLE
Update anime banlist

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -1,4 +1,4 @@
-#[2018.5 TCG][2018.7 OCG][2018.7 Worlds][2018.5 Traditional][2018.7 Anime]
+#[2018.5 TCG][2018.7 OCG][2018.7 Worlds][2018.5 Traditional][2018.8 Anime]
 !2018.5 TCG
 #Forbidden TCG			
 53804307 0 --Blaster, Dragon Ruler of Infernos			MAIN DECK MONSTERS
@@ -740,7 +740,7 @@
 48976825 2 --Burial from a Different Dimension
 83555666 2 --Ring of Destruction
 83555667 2 --Ring of Destruction
-!2018.7 Anime
+!2018.8 Anime
 #Forbidden Worlds (For Anime List)
 53804307 0 --Blaster, Dragon Ruler of Infernos						MAIN DECK MONSTERS
 89399912 0 --Tempest, Dragon Ruler of Storms
@@ -1012,6 +1012,7 @@
 511002179 0 --Wish Dragon
 511001983 0 --Catapult Warrior (Anime)
 511002359 0 --Elemental HERO Flash (Anime)
+511005712 0 --Performapal Laugh Maker (Anime)
 62560742 0 --T.G. Recipro Dragonfly (Anime, via OCG ID)
 2407234 0 --Number 69: Heraldry Crest (Anime, via OCG ID)
 511001983 0 --Catapult Warrior (Anime, via OCG ID)
@@ -1027,6 +1028,7 @@
 36076683 0 --Number 73: Abyss Splash (Anime, via OCG ID)
 84224627 0 --Cat Shark (Anime, via OCG ID)
 16404809 0 --Kuribandit (Anime, via OCG ID)
+44944304 0 --Performapal Laugh Maker (Anime, via OCG ID)
 #Limited Worlds (For Anime List)
 07902349 1 --Left Arm of the forbidden one						MAIN DECK MONSTERS
 44519536 1 --Left Leg of the forbidden one
@@ -1225,7 +1227,6 @@
 100000470 1 --Soul Fusion
 511000789 1 --Briar Transplant
 511001642 1 --Synchro Alliance
-511003002 1 --Dis-swing Fusion
 513000091 1 --Jurassic Impact (To check Alias)
 511001583 1 --Fortress of Prophecy
 511004424 1 --Supreme King Dance
@@ -1288,3 +1289,4 @@
 72355441 2 --Xyz Gift (Anime, via OCG ID)
 111011901 2 --Rank-Up-Magic Astral Force (Anime)
 1073952 2 --Magic Planter (Anime, via OCG ID)
+511003002 2 --Dis-swing Fusion


### PR DESCRIPTION
Added Performapal Laugh Maker (Anime) to ban due to able to loop itself until near inf atk. 

Moved Dis-Swing Fusion to 2 due to MR4 changes. Battle traps are non existent in MR4 and this now requires a open zone extra zone to use.

List date changed to 2018.8 for the above changes. Change's discussed with multiple team members.