### PR TITLE
Anime Ban list Balance Changes

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -903,7 +903,6 @@
 511000784 0 --Card of Desperation
 511000814 0 --Extra Fusion
 511000866 0 --Xyz Trasure Ticket
-511001133 0 --Mischief of the Time Goddess
 511001417 0 --Water of Life
 511001582 0 --Performage Hurricane
 511001611 0 --Numbers Evaille
@@ -1029,6 +1028,9 @@
 84224627 0 --Cat Shark (Anime, via OCG ID)
 16404809 0 --Kuribandit (Anime, via OCG ID)
 44944304 0 --Performapal Laugh Maker (Anime, via OCG ID)
+511001895 0 --Junk Dealer (Anime)
+511002054 0 --Number 42: Galaxy Tomahawk (Anime)
+10389142 0 --Number 42: Galaxy Tomahawk (Anime, via OCG ID)
 #Limited Worlds (For Anime List)
 07902349 1 --Left Arm of the forbidden one						MAIN DECK MONSTERS
 44519536 1 --Left Leg of the forbidden one
@@ -1252,13 +1254,15 @@
 40450317 1 --Ties of the Brethren (Anime, via OCG ID)
 41209827 1 --Starving Venom Fusion Dragon (Anime)
 25614410 1 --Legacy of a HERO (Anime, via OCG ID)
-511001895 1 --Junk Dealer (Anime)
 70771599 1 --Supreme King Dragon Clear Wing (Anime, via OCG ID)
 42160203 1 --Supreme King Dragon Dark Rebellion (Anime, via OCG ID)
 36111775 1 --Pendulum Halt (Anime, via OCG ID)
 51402908 1 --The Supremacy Sun (Anime, via OCG ID)
 71525232 1 --Gandora-X the Dragon of Demolition (Anime, via OCG ID)
 7845138 1 --Endless Decay (Anime, via OCG ID)
+511001578 1 --Flying Dragon Whirl
+511000502 1 --Gift of the Weak
+511009153 1 --Junk Ball
 #Semi Limited Worlds (For Anime List)
 59297550 2 --Wind-up Magician
 14558127 2 --Ash Blossom & Joyous Spring


### PR DESCRIPTION
Added Flying Dragon Whirl to limited to prevent unhealthy extended dragon mirror combos along with other dragon grave dump combos.
Added Gift of the Weak to limited due to large level 1 pool usage (example banish origin thunder dragon or metaphys decoy dragon)  along with usage with allure + it at full 3. 
Added Junk Ball to ban due to troymare combos / MR4 link usage.
Moved Junk Dealer (Anime) from limited to ban due to MR4 usage. (It was strong to begin with, MR4 pushed it over the edge)
Added Number 42: Galaxy Tomahawk (Anime) to ban due to MR4 usage of tokens (example summon 2 link 4 monsters with just number 42's tokens due to no OPT limit or limit to number of tokens)

Removed Mischief of the Time Goddess from banlist as it is removed from the game. New rulings for the real version show us that the anime version interactions are incorrect and not scriptable so to prevent more issues, it was removed.

