### PR TITLE
2018.8 Anime Banlist Update

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -959,6 +959,7 @@
 511005654 0 --Dark Hole (DOR)
 511000751 0 --Blade Graveyard
 511000064 0 --Slash Draw
+11050415 0 --Super Hippo Carnival (Anime, via OCG ID)
 511000494 0 --Effect Shut
 511002089 0 --Instant Freeze
 511009613 0 --Abyss Invitation


### PR DESCRIPTION
Moved "Super Hippo Carnival (Anime)" from unlimited to banned