### PR TITLE
fix for Ninjitsu Art of Shadow Sealing

### DIFF
--- a/script/c13629812.lua
+++ b/script/c13629812.lua
@@ -45,7 +45,7 @@ function c13629812.operation(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsRelateToEffect(e) or not tc then return end
 	local seq=tc:GetSequence()
 	if tc:IsControler(1-tp) then seq=seq+16 end
-	if tc:IsRelateToEffect(e) and Duel.Remove(tc,0,REASON_EFFECT+REASON_TEMPORARY)~=0 then
+	if tc:IsRelateToEffect(e) and Duel.Remove(tc,0,REASON_EFFECT+REASON_TEMPORARY)~=0 and tc:IsLocation(LOCATION_REMOVED) then
 		c:SetCardTarget(tc)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_FIELD)


### PR DESCRIPTION
Was trying to set an card in limbo as target which was causing it to crash