### PR TITLE
Fix "Valkyrie Zwiete"

### DIFF
--- a/script/c100243002.lua
+++ b/script/c100243002.lua
@@ -54,6 +54,6 @@ end
 function c100243002.thop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
 	if tc and tc:IsRelateToEffect(e) then 
-		Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_HAND)
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)
 	end
 end

--- a/script/c100243002.lua
+++ b/script/c100243002.lua
@@ -53,9 +53,7 @@ function c100243002.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function c100243002.thop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_HAND) then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
-		local g=Duel.GetFieldGroup(tp,LOCATION_HAND,0):Select(tp,1,1,nil)
-		Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
+	if tc and tc:IsRelateToEffect(e) then 
+		Duel.SendtoHand(tc,nil,REASON_EFFECT)>0 and tc:IsLocation(LOCATION_HAND)
 	end
 end


### PR DESCRIPTION
Should not return cards to deck after recovering spell from GY. Copy paste error from Herald of Pure Light.