### PR TITLE
Fixed Drochshúile the Spirit King and Hidden Village of Ninjitsu Arts

### DIFF
--- a/script/c100242301.lua
+++ b/script/c100242301.lua
@@ -40,7 +40,7 @@ function c100242301.spcon(e,tp,eg,ep,ev,re,r,rp)
 		and rp~=tp and c:GetPreviousControler()==tp
 end
 function c100242301.spfilter(c,e,tp)
-	return c:IsCode(CARD_SUMMONED_SKULL) and c:IsCanBeSpecialSummoned(e,0,tp,true,true)
+	return c:IsCode(CARD_SUMMONED_SKULL) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function c100242301.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
@@ -54,6 +54,6 @@ function c100242301.spop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local tc=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(c100242301.spfilter),tp,LOCATION_HAND+LOCATION_DECK+LOCATION_GRAVE,0,1,1,nil,e,tp):GetFirst()
 	if tc then 
-		Duel.SpecialSummon(tc,0,tp,tp,true,true,POS_FACEUP)
+		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c100307001.lua
+++ b/script/c100307001.lua
@@ -29,17 +29,24 @@ end
 function c100307001.disrmcon(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) then return false end
 	local c=re:GetHandler()
-	return c:IsRace(RACE_ZOMBIE) and c:IsType(TYPE_MONSTER) and not c:IsCode(100307001)
+	local race=c:GetRace()
+	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
+	if loc==LOCATION_HAND then race=c:GetOriginalRace() end
+	if loc==LOCATION_MZONE and not c:IsLocation(LOCATION_MZONE) then race=c:GetPreviousRaceOnField() end
+	return race==RACE_ZOMBIE and not c:IsCode(100307001)
 end
 function c100307001.disrmtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local b1=Duel.IsChainDisablable(ev) and Duel.GetFlagEffect(tp,100307001)==0
 	local b2=Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,nil)
 		and Duel.GetFlagEffect(tp,100307001+100)==0
 	if chk==0 then return b1 or b2 end
+	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
+	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,nil)
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
 end
 function c100307001.disrmop(e,tp,eg,ep,ev,re,r,rp)
 	local b1=Duel.IsChainDisablable(ev) and Duel.GetFlagEffect(tp,100307001)==0
-	local b2=Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,nil)
+	local b2=Duel.IsExistingMatchingCard(aux.NecroValleyFilter(c100307001.filter),tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,nil)
 		and Duel.GetFlagEffect(tp,100307001+100)==0
 	local op=0
 	if b1 and b2 then op=Duel.SelectOption(tp,aux.Stringid(100307001,1),aux.Stringid(100307001,2))

--- a/script/c26232916.lua
+++ b/script/c26232916.lua
@@ -76,7 +76,7 @@ end
 function c26232916.repfilter(c,tp)
 	return c:IsFaceup() and ((c:IsType(TYPE_MONSTER) and c:IsSetCard(0x2b)) or c:IsSetCard(0x61))
 		and c:IsOnField() and c:IsControler(tp)
-		and not c:IsReason(REASON_REPLACE) and (c:IsReason(REASON_BATTLE) or c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp)
+		and not c:IsReason(REASON_REPLACE) and (c:IsReason(REASON_BATTLE) or c:IsReason(REASON_EFFECT))
 end
 function c26232916.rmfilter(c)
 	return c:IsSetCard(0x2b) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemoveAsCost() and aux.SpElimFilter(c,true)


### PR DESCRIPTION
Drochshúile the Spirit King:
- Ghost Belle can disable it.
- The race in hand and field is correctly determined when Zombie World is in effect.

Hidden Village of Ninjitsu Arts:
- Can replace the cards destroyed by yourself.