### PR TITLE
Fixed "Trickstar Light Stage" damage condition

### DIFF
--- a/script/c35371948.lua
+++ b/script/c35371948.lua
@@ -156,7 +156,7 @@ function c35371948.damcon1(e,tp,eg,ep,ev,re,r,rp)
 	return ep~=tp and eg:GetFirst():IsSetCard(0xfb) and Duel.GetLP(1-tp)>0
 end
 function c35371948.damcon2(e,tp,eg,ep,ev,re,r,rp)
-	return ep~=tp and r&REASON_BATTLE==0 and re and re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0xfb)
+	return ep~=tp and r&REASON_BATTLE==0 and re and re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0xfb)  and Duel.GetLP(1-tp)>0
 end
 function c35371948.damop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_CARD,0,35371948)


### PR DESCRIPTION
Updated the secondary damage condition to prevent situations of infliciting damage when the opponent's LP have already reached 0 due to a "Trickstar" monster effect.