### PR TITLE
Fixed "Gravekeeper's Spiritualist"

### DIFF
--- a/script/c58657303.lua
+++ b/script/c58657303.lua
@@ -17,7 +17,7 @@ function c58657303.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsEnvironment(47355498)
 end
 function c58657303.filter1(c,e)
-	return c:IsOnField() and not c:IsImmuneToEffect(e)
+	return not c:IsImmuneToEffect(e)
 end
 function c58657303.filter2(c,e,tp,m,f,gc,chkf)
 	return c:IsType(TYPE_FUSION) and c:IsRace(RACE_SPELLCASTER) and (not f or f(c))
@@ -46,7 +46,7 @@ function c58657303.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local chkf=tp
 	if c:IsFacedown() or not c:IsRelateToEffect(e) or c:IsImmuneToEffect(e) then return end
-	local mg1=Duel.GetFusionMaterial(tp)
+	local mg1=Duel.GetFusionMaterial(tp):Filter(c58657303.filter1,nil,e)
 	local sg1=Duel.GetMatchingGroup(c58657303.filter2,tp,LOCATION_EXTRA,0,nil,e,tp,mg1,nil,c,chkf)
 	local mg2=nil
 	local sg2=nil


### PR DESCRIPTION
shouldn't be able to skip materials immune to its effect