### PR TITLE
OCG Oct 1st banlist and anime banlist change

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -1,4 +1,4 @@
-#[2018.9 TCG][2018.7 OCG][2018.9 Worlds][2018.9 Traditional][2018.9 Anime][2018.10 OCG]
+#[2018.9 TCG][2018.10 OCG][2018.10 Worlds][2018.9 Traditional][2018.10 Anime]
 !2018.9 TCG
 #Forbidden TCG
 53804307 0 --Blaster, Dragon Ruler of Infernos			MAIN DECK MONSTERS
@@ -185,11 +185,10 @@
 23171610 2 --Limiter Removal			
 73915051 2 --Scapegoat			
 73628505 2 --Terraforming
-!2018.7 OCG
+!2018.10 OCG
 #Forbidden OCG
 20663556 0 --イレカエル Substitoad												MAIN DECK MONSTERS
 44910027 0 --ヴィクトリー・ドラゴン Victory Dragon
-89399912 0 --嵐征竜－テンペスト Tempest, Dragon Ruler of Storms
 53804307 0 --焔征竜－ブラスター Blaster, Dragon Ruler of Infernos
 90411554 0 --巌征竜－レドックス Redox, Dragon Ruler of Boulders
 26400609 0 --瀑征竜－タイダル Tidal, Dragon Ruler of Waterfalls
@@ -203,7 +202,6 @@
 96782886 0 --メンタルマスター Mind Master
 3078576 0 --八汰烏 Yata-Garasu
 88071625 0 --The Tyrant Neptune
-68819554 0 --Emダメージ・ジャグラー Performage Damage Juggler
 7563579 0 --Emヒグルミ Performage PlushFire
 17330916 0 --EMモンキーボード Performapal Monkeyboard
 31178212 0 --マジェスペクター・ユニコーン Majespecter Unicorn - Kirin
@@ -212,6 +210,8 @@
 23558733 0 --Phoenixian Cluster Amaryllis
 11384280 0 --Cannon Soldier
 79875176 0 --Toon Cannon Soldier
+91869203 0 --アマゾネスの射手 Amazoness Archer
+14702066 0 --メガキャノン・ソルジャー Cannon Soldier MK-2
 17412721 0 --旧神ノーデン Elder Entity Norden 						EXTRA DECK MONSTERS
 25862681 0 --Ancient Fairy Dragon
 34086406 0 --ラヴァルバル・チェイン Lavalval Chain
@@ -219,6 +219,7 @@
 54719828 0 --No.16 色の支配者ショック・ルーラー Number 16: Shock Master
 48905153 0 --十二獣ドランシア Zoodiac Drident
 85115440 0 --Zoodiac Broadbull
+61665245 0 --サモン・ソーサレス Summon Sorceress
 44763025 0 --いたずら好きな双子悪魔 Delinquent Duo								SPELLS  CARDS
 19613556 0 --大嵐 Heavy Storm
 17375316 0 --押収 Confiscation
@@ -268,7 +269,6 @@
 88264978 1 --レッドアイズ·ダークネスメタルドラゴン Red-Eyes Darkness Dragon
 10802915 1 --魔界発現世行きデスガイド Tour Guide From the underworld
 33508719 1 --メタモルポット Morphing Jar
-26674724 1 --ブリューナクの影霊衣 Nekroz of Brionac
 89463537 1 --ユニコールの影霊衣 Nekroz of Unicore
 92746535 1 --竜剣士ラスターP Luster Pendulum
 78872731 1 --十二獣モルモラット Zoodiac Ratpier
@@ -286,8 +286,9 @@
 35272499 1 --Predaplant Ophrys Scorpio
 76794549 1 --Astrograph Sorcerer
 73941492 1 --Harmonizing Magician
+89399912 1 --嵐征竜－テンペスト Tempest, Dragon Ruler of Storms
+68819554 1 --Emダメージ・ジャグラー Performage Damage Juggler
 74586817 1 --PSYフレームロード・Ω PSY-Framelord Omega								EXTRA DECK MONSTERS
-83531441 1 --彼岸の旅人 ダンテ Dante, Traveler of the Burning Abyss
 90953320 1 --TG ハイパー·ライブラリアン TG Hyper Librarian
 90809975 1 --餅カエル Toadally Awesome
 70583986 1 --氷結界の虎王ドゥローレン Dewloren, Tiger king of the Ice Barrier
@@ -298,6 +299,7 @@
 75286621 1 --Invoked Mechaba
 5043010 1 --Firewall Dragon
 24094258 1 --Heavymetalfoes Electrumite
+39064822 1 --トロイメア・ゴブリン Knightmare Goblin
 33782437 1 --一時休戦 One Day of peace										SPELLS CARDS
 66957584 1 --インフェルニティガン Infernity launcer
 81439173 1 --おろかな埋葬 Foolish Burial
@@ -313,7 +315,6 @@
 53208660 1 --ペンデュラム・コール Pendulum Call
 23171610 1 --リミッター解除 Limiter Removal
 14733538 1 --竜呼相打つ Draco Face-Off
-48130397 1 --超融合 Super Polymerization
 72892473 1 --手札抹殺 Card Destruction
 97211663 1 --影霊衣の反魂術 Nekroz Cycle
 93600443 1 --マスク・チェンジ・セカンド Mask Change 2
@@ -323,254 +324,250 @@
 23314220 1 --Spellbook of Knowledge
 52340444 1 --Sky Striker Mecha - Hornet Drones
 73468603 1 -- Set Rotation
+8949584 1 --ヒーローアライブ A Hero Lives
+75500286 1 --封印の黄金櫃 Gold Sarcophagus
 36468556 1 --停戦協定 Ceasefire 												TRAPS CARDS
-83555666 1 --破壊輪 Ring of Destruction
 21076084 1 --Trickstar Reincarnation
 5851097 1 --虚無空間 Vanity's Emptiness
-35125879 1 --True King's Return
 61740673 1 --王宮の勅命 Imperial Order
 #semi limited OCG
 40044918 2 --E·HERO エアーマン Elemental Hero Stratos
 14558127 2 --Ash Blossom & Joyous Spring
-86120751 2 --Aleister the Invoker
-4474060 2 --SPYRAL Gear - Drone
-56570271 2 --D－HERO ディスクガイ Destiny Hero - Disk Commander
 81275020 2 --SRベイゴマックス Speedroid Terrortop
-45222299 2 --イビリチュア·ガストクラーケ Evigishki Gustkraken
-94977269 2 --El Shaddoll Winda
-20366274 2 --エルシャドール・ネフィリム El Shaddoll Construct
-66399653 2 --ユニオン格納庫 Union Hangar
+42790071 2 --オルターガイスト・マルチフェイカー Altergeist Multifaker
+26674724 2 --ブリューナクの影霊衣 Nekroz of Brionac
+83531441 2 --彼岸の旅人 ダンテ Dante, Traveler of the Burning Abyss
+066399653 2 --ユニオン格納庫 Union Hangar
 73915051 2 --Scapegoat
 47325505 2 --Fossil Dig
 91623717 2 --連鎖爆撃 Chain Strike
 67723438 2 --緊急テレポート Emergency teleporter
+98338152 2 --閃刀機－ウィドウアンカー Sky Striker Mecha - Widow Anchor
+63166095 2 --閃刀起動－エンゲージ Sky Striker Mobilize - Engage!
+48130397 2 --超融合 Super Polymerization
+11110587 2 --隣の芝刈り That Grass Looks Greener
 40605147 2 --Solemn Strike
 84749824 2 --神の警告 Solemn Warning
 41420027 2 --神の宣告 Solemn Judgment
-!2018.9 Worlds
-#Forbidden Worlds
-53804307 0 --Blaster, Dragon Ruler of Infernos						MAIN DECK MONSTERS
-89399912 0 --Tempest, Dragon Ruler of Storms
-26400609 0 --Tidal, Dragon Ruler of Waterfalls
-90411554 0 --Redox, Dragon Ruler of Boulders
-82301904 0 --Chaos Emperor Dragon - Envoy of the End
-34124316 0 --Cyber Jar
-69015963 0 --Cyber Stein
-08903700 0 --Djinn Releaser of Rituals
-78706415 0 --Fiber Jar
-93369354 0 --Fishborg Blaster
-34206604 0 --Magical Scientist
-21593977 0 --Makyura the Destructor
-96782886 0 --Mind Master
-79106360 0 --Morphing Jar #2
-90307777 0 --Shurit, Strategist of the Nekroz
-88071625 0 --The Tyrant Neptune
-20663556 0 --Substitoad
-33184167 0 --Tribe-Infecting Virus
-44910027 0 --Victory Dragon
+35125879 2 --真竜皇の復活 True King's Return
+83555666 2 --破壊輪 Ring of Destruction
+!2018.10 Worlds
+#generated at https://alphakretin.github.io/html/worlds
+#forbidden worlds
 03078576 0 --Yata-Garasu
-17330916 0 --Performapal Monkeyboard
+05592689 0 --Samsara Lotus
 07563579 0 --Performage PlushFire
-68819554 0 --Performage Damage Juggler
-5592689 0 --Samsara Lotus
-57421866 0 --Level Eater
-16923472 0 --Wind-up Hunter
-31178212 0 --Majespecter Unicorn - Kirin
-21377582 0 --Master Peace, The True Dracoslaying King
-30539496 0 --True King Lithosagym, the Disaster
+08903700 0 --Djinn Releaser of Rituals
 09929398 0 --Blackwing - Gofu the Vague Shadow
-15341821 0 --Dandylion
-49684352 0 --Double Iris Magician
-23434538 0 --Maxx "C"
-40318957 0 --Performapal Skullcrobat Joker
-23558733 0 --Phoenixian Cluster Amaryllis
-76794549 0 --Astrograph Sorcerer
 11384280 0 --Cannon Soldier
+14702066 0 --Cannon Soldier MK-2
+15341821 0 --Dandylion
+16923472 0 --Wind-up Hunter
+17330916 0 --Performapal Monkeyboard
+20663556 0 --Substitoad
+21377582 0 --Master Peace, The True Dracoslaying King
+21593977 0 --Makyura the Destructor
+23434538 0 --Maxx "C"
+23558733 0 --Phoenixian Cluster Amaryllis
+26400609 0 --Tidal, Dragon Ruler of Waterfalls
+30539496 0 --True King Lithosagym, the Disaster
+31178212 0 --Majespecter Unicorn - Kirin
+33184167 0 --Tribe-Infecting Virus
+34124316 0 --Cyber Jar
+34206604 0 --Magical Scientist
+40318957 0 --Performapal Skullcrobat Joker
+44910027 0 --Victory Dragon
+49684352 0 --Double Iris Magician
+53804307 0 --Blaster, Dragon Ruler of Infernos
+57421866 0 --Level Eater
+69015963 0 --Cyber Stein
+76794549 0 --Astrograph Sorcerer
+78706415 0 --Fiber Jar
+79106360 0 --Morphing Jar #2
 79875176 0 --Toon Cannon Soldier
-20366274 0 --El Shaddoll Construct									EXTRA DECK MONSTERS
-43387895 0 --Supreme King Dragon Starving Venom
+82301904 0 --Chaos Emperor Dragon - Envoy of the End
+88071625 0 --The Tyrant Neptune
+89399912 0 --Tempest, Dragon Ruler of Storms
+90307777 0 --Shurit, Strategist of the Nekroz
+90411554 0 --Redox, Dragon Ruler of Boulders
+91869203 0 --Amazoness Archer
+93369354 0 --Fishborg Blaster
+96782886 0 --Mind Master
+00581014 0 --Daigusto Emeral
+04423206 0 --M-X-Saber Invoker
 17412721 0 --Elder Entity Norden
-25862681 0 --Ancient Fairy Dragon
-65536818 0 --Denglong, First of the Yang Zing	
 18326736 0 --Tellarknight Ptolomaeus
+20366274 0 --El Shaddoll Construct
+25862681 0 --Ancient Fairy Dragon
 34086406 0 --Lavalval Chain
-54719828 0 --Number 16: Shock Master
 39064822 0 --Knightmare Goblin
-4423206 0 --M-X-Saber Invoker
-81122844 0 --Wind-Up Carrier Zenmaity
+43387895 0 --Supreme King Dragon Starving Venom
 48905153 0 --Zoodiac Drident
+54719828 0 --Number 16: Shock Master
+61665245 0 --Summon Sorceress
+65536818 0 --Denglong, First of the Yang Zing
+81122844 0 --Wind-Up Carrier Zenmaity
 85115440 0 --Zoodiac Broadbull
-581014 0 --Daigusto Emeral
-69243953 0 --Butterfly Dagger - Elma								SPELLS CARDS
-67616300 0 --Chicken Game
-12580477 0 --Raigeki
-35059553 0 --Kaiser Colloseum
-72892473 0 --Card Destruction
-57953380 0 --Card of Safe Return
 04031928 0 --Change of Heart
-60682203 0 --Cold Wave
-17375316 0 --Confiscation
-44763025 0 --Deliquent Duo
-23557835 0 --Dimension Fusion
-42703248 0 --Giant Trunade
-79571449 0 --Graceful Charity
-18144507 0 --Harpie's Feather Duster
-18144506 0 --Harpie's Feather Duster
-42829885 0 --The Forceful Sentry
-19613556 0 --Heavy Storm
-85602018 0 --Last Will
-46411259 0 --Metamorphosis
-74191942 0 --Painful Choice
-67169062 0 --Pot of Avarice
-55144522 0 --Pot of greed
-34906152 0 --Mass Driver
-41482598 0 --Mirage of Nightmare
-46060017 0 --Zoodiac Barrage
-70828912 0 --Premature Burial
-45986603 0 --Snatch Steal
-46448938 0 --Spellbook of Judgement
-27770341 0 --Super Rejuvenation
-13035077 0 --Dragonic Diagram
-94220427 0 --Rank-Up-Magic Argent Chaos Force
 11110587 0 --That Grass Looks Greener
-28566710 0 --Last Turn											TRAPS CARDS
-27174286 0 --Return from the Different Dimension
-93016201 0 --Royal Oppression
-17178486 0 --Life Equalizer
-57585212 0 --Self-Destruct Button
+12580477 0 --Raigeki
+13035077 0 --Dragonic Diagram
+17375316 0 --Confiscation
+18144506 0 --Harpie's Feather Duster
+18144507 0 --Harpie's Feather Duster
+19613556 0 --Heavy Storm
+23557835 0 --Dimension Fusion
+27770341 0 --Super Rejuvenation
+34906152 0 --Mass Driver
+35059553 0 --Kaiser Colloseum
+41482598 0 --Mirage of Nightmare
+42703248 0 --Giant Trunade
+42829885 0 --The Forceful Sentry
+44763025 0 --Deliquent Duo
+45986603 0 --Snatch Steal
+46060017 0 --Zoodiac Barrage
+46411259 0 --Metamorphosis
+46448938 0 --Spellbook of Judgement
+55144522 0 --Pot of greed
+57953380 0 --Card of Safe Return
+60682203 0 --Cold Wave
+67169062 0 --Pot of Avarice
+67616300 0 --Chicken Game
+69243953 0 --Butterfly Dagger - Elma
+70828912 0 --Premature Burial
+74191942 0 --Painful Choice
+79571449 0 --Graceful Charity
+85602018 0 --Last Will
+94220427 0 --Rank-Up-Magic Argent Chaos Force
 03280747 0 --Sixth Sense
+05851097 0 --Vanity's Emptiness
+17178486 0 --Life Equalizer
+27174286 0 --Return from the Different Dimension
+28566710 0 --Last Turn
+32723153 0 --Magical Explosion
 35316708 0 --Time Seal
+57585212 0 --Self-Destruct Button
 64697231 0 --Trap Dustshot
 80604091 0 --Ultimate Offering
-05851097 0 --Vanity's Emptiness
-32723153 0 --Magical Explosion
-#Limited Worlds
-07902349 1 --Left Arm of the forbidden one						MAIN DECK MONSTERS
-44519536 1 --Left Leg of the forbidden one
-70903634 1 --Right Arm of the forbidden one
+80604092 0 --Ultimate Offering
+93016201 0 --Royal Oppression
+#limited worlds
+04474060 1 --SPYRAL Gear - Drone
+07902349 1 --Left Arm of the forbidden one
 08124921 1 --Right Leg of the forbidden one
-65518099 1 --Qliporth Scout
-33396948 1 --Exxodia the Forbidden One
-65192027 1 --Dark Armed Dragon
-78868119 1 --Deep Sea Diva
-64034255 1 --Genex Ally birdman
-50720316 1 --Elemental Hero Shadow Mist
-20758643 1 --Graff, Malembrance of the Burning Abyss
-99177923 1 --Infernity Archfiend
-68184115 1 --Inzektor DragonFly
-69207766 1 --Inzektor Hornet
-28297833 1 --Necroface
-16226786 1 --Night Assailant
-78872731 1 --Zoodiac Ratpier
-55623480 1 --Fairy Tail - Snow
-40044918 1 --Elemental Hero Stratos
-88264978 1 --Red-eyes Darkness Metal Dragon
+09047460 1 --Blackwing - Steam the Cloak
 10802915 1 --Tour Guide From the Underworld
-81275020 1 --Speedroid Terrortop
-57143342 1 --Cir, Malebranche of the Burning Abyss
-55885348 1 --Kozmo Dark Destroyer
+11877465 1 --Evigishki Mind Augus
+16226786 1 --Night Assailant
+20758643 1 --Graff, Malembrance of the Burning Abyss
+26674724 1 --Nekroz of Brionac
+28297833 1 --Necroface
+30012506 1 --A-Assault Core
+33396948 1 --Exxodia the Forbidden One
 33508719 1 --Morphing Jar
-96570609 1 --Ether the Heavenly monarch
-44335251 1 --Souleating Oviraptor
+35272499 1 --Predaplant Ophrys Scorpio
 36042004 1 --Babycerasaurus
 38572779 1 --Miscellaneousaurus
-92746535 1 --Luster Pendulum, the Dracoslayer
-50720316 1 --Elemental Hero Shadow Mist
-4474060 1 --SPYRAL Gear - Drone
-78080961 1 --SPYRAL Quik-Fix
-9047460 1 --Blackwing - Steam the Cloak
-75732622 1 --Grinder Golem
-69610326 1 --Supreme King Dragon Darkwurm
-48686504 1 --Lonefire Blossom
-30012506 1 --A-Assault Core
-35272499 1 --Predaplant Ophrys Scorpio
-58984738 1 --Dinomight Knight, the True Dracofighter
-73941492 1 --Harmonizing Magician
+40044918 1 --Elemental Hero Stratos
+44335251 1 --Souleating Oviraptor
+44519536 1 --Left Leg of the forbidden one
 45222299 1 --Evigishki Gustkraken
-11877465 1 --Evigishki Mind Augus
-26674724 1 --Nekroz of Brionac
-89463537 1 --Nekroz of Unicore
-1561110 1 --ABC-Dragon Buster 									EXTRA DECK MONSTERS
-39512984 1 --Gem-Knight Master Diamond
-75286621 1 --Invoked Mechaba	
-18239909 1 --Ignister Prominence, the Blasting Dracoslayer
-48063985 1 --Ritual Beast Ulti-Cannahawk
-74586817 1 --PSY-Framelord Omega
-83531441 1 --Dante, Traveler of the Burning Abyss
-90809975 1 --Toadally Awesome
-06602300 1 --Blaze Fenix, The Burning Bombardment Bird
-70583986 1 --Dewloren, Tiger King of the Ice Barrier
-52687916 1 --Trishula, Dragon of the Ice Barrier
-90953320 1 --T.G. Hyper Librarian
-27552504 1 --Beatrice, Lady of Eternal
-46772449 1 --Evilswarm Exciton Knight
-5043010 1 --Firewall Dragon
-24094258 1 --Heavymetalfoes Electrumite			
-14087893 1 --Book of Moon 							SPELLS CARDS				
-97211663 1 --Nekroz Cycle
-81674782 1 --Dimensional Fissure
-95308449 1 --Final Countdown
-81439173 1 --Foolish Burial
-66957584 1 --Infernity Launcher
-23171610 1 --Limiter Removal
-53129443 1 --Dark Hole
-43040603 1 --Monster Gate
-33782437 1 --One Day of Peace
-02295440 1 --One for one
-32807846 1 --Reinforcement of the Army
-74845897 1 --Rekindling
-8949584 1 --A Hero Lives
-72892473 1 --Card Destruction
-72405967 1 --Royal Tribute
-27970830 1 --Gateway of the Six
-54447022 1 --Soul Charge
-45305419 1 --Symbol of Heritage
-14733538 1 --Draco Face-off
-73468603 1 --Set Rotation
-93600443 1 --Mask Change 2
-58577036 1 --Reasoning
-99330325 1 --Interrupted Kaiju Slumber
-23701465 1 --Primal Seed
-70368879 1 --Upstart Goblin
-67723438 1 --Emergency Teleporter
-73628505 1 --Terraforming
-53208660 1 --Pendulum Call
-22842126 1 --Phanteism of the Monarchs
-79844764 1 --The Monarchs Stormforth
-15854426 1 --Divine Wind of the Mist Valley
-54631665 1 --SPYRAL Resort
-83764718 1 --Monster Reborn
-83764719 1 --Monster Reborn	
-23314220 1 --Spellbook of Knowledge
-91623717 1 --Chain Strike
-52340444 1 --Sky Striker Mecha - Hornet Drones			
-48130397 1 --Super Polymerization
-54974237 1 --Eradicator Epidemic Virus					TRAP CARDS
-36468556 1 --Ceasefire
-21076084 1 --Trickstar Reincarnation
+48686504 1 --Lonefire Blossom
+50720316 1 --Elemental Hero Shadow Mist
+55623480 1 --Fairy Tail - Snow
+57143342 1 --Cir, Malebranche of the Burning Abyss
+58984738 1 --Dinomight Knight, the True Dracofighter
 61740673 1 --Imperial Order
-35125879 1 --True King's Return
-83555666 1 --Ring of Destruction
-83555667 1 --Ring of Destruction
-82732705 1 --Skill Drain
-73599290 1 --Soul Drain
-30241314 1 --Macro Cosmos
-17078030 1 --Wall of Revealing light
-09059700 1 --Infernity Barrier
-84749824 1 --Solemn Warning
-41420027 1 --Solemn Judgement
-#Semi Limited Worlds
-59297550 2 --Wind-up Magician
-14558127 2 --Ash Blossom & Joyous Spring
-86120751 2 --Aleister the Invoker
-56570271 2 --Destiny Hero - Disk Commander
+64034255 1 --Genex Ally birdman
+65192027 1 --Dark Armed Dragon
+65518099 1 --Qliporth Scout
+68184115 1 --Inzektor DragonFly
+68819554 1 --Performage Damage Juggler
+69207766 1 --Inzektor Hornet
+69610326 1 --Supreme King Dragon Darkwurm
+70903634 1 --Right Arm of the forbidden one
+73941492 1 --Harmonizing Magician
+75732622 1 --Grinder Golem
+78080961 1 --SPYRAL Quik-Fix
+78868119 1 --Deep Sea Diva
+78872731 1 --Zoodiac Ratpier
+81275020 1 --Speedroid Terrortop
+88264978 1 --Red-eyes Darkness Metal Dragon
+89463537 1 --Nekroz of Unicore
+92746535 1 --P Luster Pendulum
+96570609 1 --Ether the Heavenly monarch
+99177923 1 --Infernity Archfiend
+01561110 1 --ABC-Dragon Buster
+05043010 1 --Firewall Dragon
+06602300 1 --Blaze Fenix, The Burning Bombardment Bird
+18239909 1 --Ignister Prominence, the Blasting Dracoslayer 
+24094258 1 --Heavymetalfoes Electrumite
+27552504 1 --Beatrice, Lady of Eternal
+39512984 1 --Gem-Knight Master Diamond
+46772449 1 --Evilswarm Exciton Knight
+48063985 1 --Ritual Beast Ulti-Cannahawk
+52687916 1 --Trishula, Dragon of the Ice Barrier
+70583986 1 --Dewloren, Tiger King of the Ice Barrier
+74586817 1 --Psy-Framelord Omega
+75286621 1 --Invoked Mechaba
+90809975 1 --Toadally Awesome
+90953320 1 --TG Hyper Librarian
+02295440 1 --One for One
+08949584 1 --A Hero Lives
+14087893 1 --Book of Moon  
+14733538 1 --Draco Face-off
+15854426 1 --Divine Wind of the Mist Valley
+22842126 1 --Phanteism of the Monarchs
+23171610 1 --Limiter Removal
+23314220 1 --Spellbook of Knowledge
+23701465 1 --Primal Seed
+27970830 1 --Gateway of the Six
+32807846 1 --Reinforcement of the Army
+33782437 1 --One Day of Peace
+43040603 1 --Monster Gate
+45305419 1 --Symbol of Heritage
+48130397 1 --Super Polymerization
+52340444 1 --Sky Striker Mecha - Hornet Drones
+53129443 1 --Dark Hole
+53208660 1 --Pendulum Call
+54447022 1 --Soul Charge
+54631665 1 --SPYRAL Resort
+58577036 1 --Reasoning
+66957584 1 --Infernity Launcher
+67723438 1 --Emergency Teleporter
+70368879 1 --Upstart Goblin
+72405967 1 --Royal Tribute
+72892473 1 --Card Destruction
+73468603 1 --Set Rotation
+73628505 1 --Terraforming
+74845897 1 --Rekindling
+75500286 1 --Gold Sarcophagus
+79844764 1 --The Monarchs Stormforth
+81439173 1 --Foolish Burial
+81674782 1 --Dimensional Fissure
+83764718 1 --Monster Reborn
+83764719 1 --Monster Reborn
+91623717 1 --Chain Strike
+93600443 1 --Mask Change 2
+95308449 1 --Final Countdown
+97211663 1 --Nekroz Cycle
+99330325 1 --Interrupted Kaiju Slumber
+21076084 1 --Trickstar Reincarnation
+36468556 1 --Ceasefire 
+#semi limited worlds
 55885348 2 --Kozmo Dark Destroyer
-47325505 2 --Fossil Dig
-73915051 2 --Scapegoat
-66399653 2 --Union Hangar
-40605147 2 --Solemn Strike
-94977269 2 --El Shaddoll Winda
+59297550 2 --Wind-up Magician
 24224830 2 --Called By The Grave
+73915051 2 --Scapegoat
+14558127 2 --Ash Blossom & Joyous Spring
+40605147 2 --Solemn Strike
+42790071 2 --Altergeist Multifaker
+47325505 2 --Fossil Dig
+63166095 2 --Sky Striker Mobilize - Engage!
+83531441 2 --Dante, Traveler of the Burning Abyss
+83555666 2 --Ring of Destruction
+98338152 2 --Sky Striker Mecha - Widow Anchor
+066399653 2 --Union Hangar
 !2018.9 Traditional
 #Forbidden TCG Traditional
 #Limited TCG Traditional
@@ -757,158 +754,327 @@
 23171610 2 --Limiter Removal			
 73915051 2 --Scapegoat			
 73628505 2 --Terraforming
-!2018.9 Anime
-#Forbidden Worlds (For Anime List)
-53804307 0 --Blaster, Dragon Ruler of Infernos						MAIN DECK MONSTERS
-89399912 0 --Tempest, Dragon Ruler of Storms
-26400609 0 --Tidal, Dragon Ruler of Waterfalls
-90411554 0 --Redox, Dragon Ruler of Boulders
-82301904 0 --Chaos Emperor Dragon - Envoy of the End
-34124316 0 --Cyber Jar
-69015963 0 --Cyber Stein
-08903700 0 --Djinn Releaser of Rituals
-78706415 0 --Fiber Jar
-93369354 0 --Fishborg Blaster
-34206604 0 --Magical Scientist
-21593977 0 --Makyura the Destructor
-96782886 0 --Mind Master
-79106360 0 --Morphing Jar #2
-90307777 0 --Shurit, Strategist of the Nekroz
-88071625 0 --The Tyrant Neptune
-20663556 0 --Substitoad
-33184167 0 --Tribe-Infecting Virus
-44910027 0 --Victory Dragon
+!2018.10 Anime
+#worlds list
+#generated at https://alphakretin.github.io/html/worlds
+#forbidden worlds
 03078576 0 --Yata-Garasu
-17330916 0 --Performapal Monkeyboard
+05592689 0 --Samsara Lotus
 07563579 0 --Performage PlushFire
-68819554 0 --Performage Damage Juggler
-5592689 0 --Samsara Lotus
-57421866 0 --Level Eater
-16923472 0 --Wind-up Hunter
-31178212 0 --Majespecter Unicorn - Kirin
-21377582 0 --Master Peace, The True Dracoslaying King
-30539496 0 --True King Lithosagym, the Disaster
+08903700 0 --Djinn Releaser of Rituals
 09929398 0 --Blackwing - Gofu the Vague Shadow
-15341821 0 --Dandylion
-49684352 0 --Double Iris Magician
-23434538 0 --Maxx "C"
-40318957 0 --Performapal Skullcrobat Joker
-23558733 0 --Phoenixian Cluster Amaryllis
-76794549 0 --Astrograph Sorcerer
 11384280 0 --Cannon Soldier
+14702066 0 --Cannon Soldier MK-2
+15341821 0 --Dandylion
+16923472 0 --Wind-up Hunter
+17330916 0 --Performapal Monkeyboard
+20663556 0 --Substitoad
+21377582 0 --Master Peace, The True Dracoslaying King
+21593977 0 --Makyura the Destructor
+23434538 0 --Maxx "C"
+23558733 0 --Phoenixian Cluster Amaryllis
+26400609 0 --Tidal, Dragon Ruler of Waterfalls
+30539496 0 --True King Lithosagym, the Disaster
+31178212 0 --Majespecter Unicorn - Kirin
+33184167 0 --Tribe-Infecting Virus
+34124316 0 --Cyber Jar
+34206604 0 --Magical Scientist
+40318957 0 --Performapal Skullcrobat Joker
+44910027 0 --Victory Dragon
+49684352 0 --Double Iris Magician
+53804307 0 --Blaster, Dragon Ruler of Infernos
+57421866 0 --Level Eater
+69015963 0 --Cyber Stein
+76794549 0 --Astrograph Sorcerer
+78706415 0 --Fiber Jar
+79106360 0 --Morphing Jar #2
 79875176 0 --Toon Cannon Soldier
-20366274 0 --El Shaddoll Construct									EXTRA DECK MONSTERS
-43387895 0 --Supreme King Dragon Starving Venom
+82301904 0 --Chaos Emperor Dragon - Envoy of the End
+88071625 0 --The Tyrant Neptune
+89399912 0 --Tempest, Dragon Ruler of Storms
+90307777 0 --Shurit, Strategist of the Nekroz
+90411554 0 --Redox, Dragon Ruler of Boulders
+91869203 0 --Amazoness Archer
+93369354 0 --Fishborg Blaster
+96782886 0 --Mind Master
+00581014 0 --Daigusto Emeral
+04423206 0 --M-X-Saber Invoker
 17412721 0 --Elder Entity Norden
-25862681 0 --Ancient Fairy Dragon
-65536818 0 --Denglong, First of the Yang Zing	
 18326736 0 --Tellarknight Ptolomaeus
+20366274 0 --El Shaddoll Construct
+25862681 0 --Ancient Fairy Dragon
 34086406 0 --Lavalval Chain
-54719828 0 --Number 16: Shock Master
 39064822 0 --Knightmare Goblin
-4423206 0 --M-X-Saber Invoker
-81122844 0 --Wind-Up Carrier Zenmaity
+43387895 0 --Supreme King Dragon Starving Venom
 48905153 0 --Zoodiac Drident
+54719828 0 --Number 16: Shock Master
+61665245 0 --Summon Sorceress
+65536818 0 --Denglong, First of the Yang Zing
+81122844 0 --Wind-Up Carrier Zenmaity
 85115440 0 --Zoodiac Broadbull
-581014 0 --Daigusto Emeral
-69243953 0 --Butterfly Dagger - Elma								SPELLS CARDS
-67616300 0 --Chicken Game
-12580477 0 --Raigeki
-35059553 0 --Kaiser Colloseum
-72892473 0 --Card Destruction
-57953380 0 --Card of Safe Return
 04031928 0 --Change of Heart
-60682203 0 --Cold Wave
-17375316 0 --Confiscation
-44763025 0 --Deliquent Duo
-23557835 0 --Dimension Fusion
-42703248 0 --Giant Trunade
-79571449 0 --Graceful Charity
-18144507 0 --Harpie's Feather Duster
-18144506 0 --Harpie's Feather Duster
-42829885 0 --The Forceful Sentry
-19613556 0 --Heavy Storm
-85602018 0 --Last Will
-46411259 0 --Metamorphosis
-74191942 0 --Painful Choice
-67169062 0 --Pot of Avarice
-55144522 0 --Pot of greed
-34906152 0 --Mass Driver
-41482598 0 --Mirage of Nightmare
-46060017 0 --Zoodiac Barrage
-70828912 0 --Premature Burial
-45986603 0 --Snatch Steal
-46448938 0 --Spellbook of Judgement
-27770341 0 --Super Rejuvenation
-13035077 0 --Dragonic Diagram
-94220427 0 --Rank-Up-Magic Argent Chaos Force
 11110587 0 --That Grass Looks Greener
-28566710 0 --Last Turn											TRAPS CARDS
-27174286 0 --Return from the Different Dimension
-93016201 0 --Royal Oppression
-17178486 0 --Life Equalizer
-57585212 0 --Self-Destruct Button
+12580477 0 --Raigeki
+13035077 0 --Dragonic Diagram
+17375316 0 --Confiscation
+18144506 0 --Harpie's Feather Duster
+18144507 0 --Harpie's Feather Duster
+19613556 0 --Heavy Storm
+23557835 0 --Dimension Fusion
+27770341 0 --Super Rejuvenation
+34906152 0 --Mass Driver
+35059553 0 --Kaiser Colloseum
+41482598 0 --Mirage of Nightmare
+42703248 0 --Giant Trunade
+42829885 0 --The Forceful Sentry
+44763025 0 --Deliquent Duo
+45986603 0 --Snatch Steal
+46060017 0 --Zoodiac Barrage
+46411259 0 --Metamorphosis
+46448938 0 --Spellbook of Judgement
+55144522 0 --Pot of greed
+57953380 0 --Card of Safe Return
+60682203 0 --Cold Wave
+67169062 0 --Pot of Avarice
+67616300 0 --Chicken Game
+69243953 0 --Butterfly Dagger - Elma
+70828912 0 --Premature Burial
+74191942 0 --Painful Choice
+79571449 0 --Graceful Charity
+85602018 0 --Last Will
+94220427 0 --Rank-Up-Magic Argent Chaos Force
 03280747 0 --Sixth Sense
+05851097 0 --Vanity's Emptiness
+17178486 0 --Life Equalizer
+27174286 0 --Return from the Different Dimension
+28566710 0 --Last Turn
+32723153 0 --Magical Explosion
 35316708 0 --Time Seal
+57585212 0 --Self-Destruct Button
 64697231 0 --Trap Dustshot
 80604091 0 --Ultimate Offering
-05851097 0 --Vanity's Emptiness
-32723153 0 --Magical Explosion
-#forbidden Anime
-100000000 0 --Chaos End Ruler -Ruler of the Beginning and the End
-511000787 0 --Rose Shaman
-14785765 0 --Blackwing - Zephyros the Elite (Anime, VIA OCG ID)
-29654737 0 --Amazoness Chain Master (Anime, VIA OCG ID)
-100000704 0 --Darkness Outsider
+80604092 0 --Ultimate Offering
+93016201 0 --Royal Oppression
+#limited worlds
+04474060 1 --SPYRAL Gear - Drone
+07902349 1 --Left Arm of the forbidden one
+08124921 1 --Right Leg of the forbidden one
+09047460 1 --Blackwing - Steam the Cloak
+10802915 1 --Tour Guide From the Underworld
+11877465 1 --Evigishki Mind Augus
+16226786 1 --Night Assailant
+20758643 1 --Graff, Malembrance of the Burning Abyss
+26674724 1 --Nekroz of Brionac
+28297833 1 --Necroface
+30012506 1 --A-Assault Core
+33396948 1 --Exxodia the Forbidden One
+33508719 1 --Morphing Jar
+35272499 1 --Predaplant Ophrys Scorpio
+36042004 1 --Babycerasaurus
+38572779 1 --Miscellaneousaurus
+40044918 1 --Elemental Hero Stratos
+44335251 1 --Souleating Oviraptor
+44519536 1 --Left Leg of the forbidden one
+45222299 1 --Evigishki Gustkraken
+48686504 1 --Lonefire Blossom
+50720316 1 --Elemental Hero Shadow Mist
+55623480 1 --Fairy Tail - Snow
+57143342 1 --Cir, Malebranche of the Burning Abyss
+58984738 1 --Dinomight Knight, the True Dracofighter
+61740673 1 --Imperial Order
+64034255 1 --Genex Ally birdman
+65192027 1 --Dark Armed Dragon
+65518099 1 --Qliporth Scout
+68184115 1 --Inzektor DragonFly
+68819554 1 --Performage Damage Juggler
+69207766 1 --Inzektor Hornet
+69610326 1 --Supreme King Dragon Darkwurm
+70903634 1 --Right Arm of the forbidden one
+73941492 1 --Harmonizing Magician
+75732622 1 --Grinder Golem
+78080961 1 --SPYRAL Quik-Fix
+78868119 1 --Deep Sea Diva
+78872731 1 --Zoodiac Ratpier
+81275020 1 --Speedroid Terrortop
+88264978 1 --Red-eyes Darkness Metal Dragon
+89463537 1 --Nekroz of Unicore
+92746535 1 --P Luster Pendulum
+96570609 1 --Ether the Heavenly monarch
+99177923 1 --Infernity Archfiend
+01561110 1 --ABC-Dragon Buster
+05043010 1 --Firewall Dragon
+06602300 1 --Blaze Fenix, The Burning Bombardment Bird
+18239909 1 --Ignister Prominence, the Blasting Dracoslayer 
+24094258 1 --Heavymetalfoes Electrumite
+27552504 1 --Beatrice, Lady of Eternal
+39512984 1 --Gem-Knight Master Diamond
+46772449 1 --Evilswarm Exciton Knight
+48063985 1 --Ritual Beast Ulti-Cannahawk
+52687916 1 --Trishula, Dragon of the Ice Barrier
+70583986 1 --Dewloren, Tiger King of the Ice Barrier
+74586817 1 --Psy-Framelord Omega
+75286621 1 --Invoked Mechaba
+90809975 1 --Toadally Awesome
+90953320 1 --TG Hyper Librarian
+02295440 1 --One for One
+08949584 1 --A Hero Lives
+14087893 1 --Book of Moon  
+14733538 1 --Draco Face-off
+15854426 1 --Divine Wind of the Mist Valley
+22842126 1 --Phanteism of the Monarchs
+23171610 1 --Limiter Removal
+23314220 1 --Spellbook of Knowledge
+23701465 1 --Primal Seed
+27970830 1 --Gateway of the Six
+32807846 1 --Reinforcement of the Army
+33782437 1 --One Day of Peace
+43040603 1 --Monster Gate
+45305419 1 --Symbol of Heritage
+48130397 1 --Super Polymerization
+52340444 1 --Sky Striker Mecha - Hornet Drones
+53129443 1 --Dark Hole
+53208660 1 --Pendulum Call
+54447022 1 --Soul Charge
+54631665 1 --SPYRAL Resort
+58577036 1 --Reasoning
+66957584 1 --Infernity Launcher
+67723438 1 --Emergency Teleporter
+70368879 1 --Upstart Goblin
+72405967 1 --Royal Tribute
+72892473 1 --Card Destruction
+73468603 1 --Set Rotation
+73628505 1 --Terraforming
+74845897 1 --Rekindling
+75500286 1 --Gold Sarcophagus
+79844764 1 --The Monarchs Stormforth
+81439173 1 --Foolish Burial
+81674782 1 --Dimensional Fissure
+83764718 1 --Monster Reborn
+83764719 1 --Monster Reborn
+91623717 1 --Chain Strike
+93600443 1 --Mask Change 2
+95308449 1 --Final Countdown
+97211663 1 --Nekroz Cycle
+99330325 1 --Interrupted Kaiju Slumber
+21076084 1 --Trickstar Reincarnation
+36468556 1 --Ceasefire 
+#semi limited worlds
+55885348 2 --Kozmo Dark Destroyer
+59297550 2 --Wind-up Magician
+24224830 2 --Called By The Grave
+73915051 2 --Scapegoat
+14558127 2 --Ash Blossom & Joyous Spring
+40605147 2 --Solemn Strike
+42790071 2 --Altergeist Multifaker
+47325505 2 --Fossil Dig
+63166095 2 --Sky Striker Mobilize - Engage!
+83531441 2 --Dante, Traveler of the Burning Abyss
+83555666 2 --Ring of Destruction
+98338152 2 --Sky Striker Mecha - Widow Anchor
+066399653 2 --Union Hangar
+#anime list
+#generated from https://docs.google.com/spreadsheets/d/1AvixmY86oPDZ82XeH39XQSGyhbll6Ji93Gitc5SxboY
+#forbidden anime
 110000110 0 --Big Bang Blow
-511001509 0 --Learning Elf
+513000004 0 --Hundred Eyes Dragon (Anime)
+95453143 0 --Hundred Eyes Dragon (Anime) (OCG Alias)
+100000000 0 --Chaos End Ruler - Ruler of the Beginning and the End
+100000274 0 --Destiny HERO - Dark Angel (Anime)
+26964762 0 --Destiny HERO - Dark Angel (Anime) (OCG Alias)
+100000704 0 --Darkness Outsider
+511000149 0 --Kuribandit (Anime)
+16404809 0 --Kuribandit (Anime) (OCG Alias)
+511000252 0 --Earthbound Immortal Wiraqocha Rasca (Anime)
+41181774 0 --Earthbound Immortal Wiraqocha Rasca (Anime) (OCG Alias)
 511000585 0 --Level Jar
-67441435 0 --Glow-Up Bulb (Anime, VIA OCG ID)
-10000000 0 --Obelisk the Tormentor
-41181774 0 --Earthbound Immortal Wiraqocha Rasca (Anime, VIA OCG ID)
-170000170 0 --Divine Serpent Geh (Anime)
-10000010 0 --The Winged Dragon of Ra
-10000020 0 --Slifer the Sky Dragon
-511001207 0 --Draw Slime
-26964762 0 --Destiny HERO - The Dark Angel (Anime, VIA OCG ID)
-95000001 0 --Darkness Outsider/Boss Duel
-95000002 0 --Darkness Neosphere/Boss Duel
-95000009 0 --Toon Gemini Elf/Boss Duel
-95000010 0 --Toon Masked Sorcerer/Boss Duel
-95000011 0 --Toon Summoned Skull/Boss Duel
-95000014 0 --Relinquished/Boss Duel
-95000022 0 --Number C1:Numeron Chaos Gate Shunya/Boss Duel
-95000025 0 --Number C1000: Numerronius/Boss Duel
-95000026 0 --Number iC1000: Numerronius Numerronia/Boss Duel
-95000030 0 --Michion, the Timelord/Boss Duel
-95000033 0 --Gabrion, the Timelord/Boss Duel
-95000036 0 --Sandaion, the Timelord/Boss Duel
-95000042 0 --Sephylon, the Ultimate Timelord/Boss Duel
-95000038 0 --Lazion, the Timelord/Boss Duel
-511009132 0 --Cup Meatball Cayenne
 511000633 0 --Yowie
-81055000 0 --Performapal Handstandaccoon (Anime, VIA OCG ID)
-53724621 0 --Performapal Guitartle (Anime, VIA OCG ID)
-128454 0 --Performapal Springoose (Anime, VIA OCG ID)
-63223260 0 --Photon Satellite (Anime, VIA OCG ID)
-13331639 0 --Supreme Dragon Zarc (Anime, VIA OCG ID)
-21521304 0 --Number 39: Utopia Beyond (Anime, VIA OCG ID)
-95453143 0 --Hundred Eyes Dragon (Anime, VIA OCG ID)
-42664989 0 --Card of Sanctity (Anime, VIA OCG ID)
-59750328 0 --Card of Demise (Anime, VIA OCG ID)
-68005187 0 --Soul Exchange (Anime, VIA OCG ID)
-85852291 0 --Magical Mallet (Anime, VIA OCG ID)
-95000000 0 --Boss Duel
+511000787 0 --Rose Shaman
+511001207 0 --Draw Slime
+511001320 0 --Ninja Commando Kabuki
+511001509 0 --Learning Elf
+511001961 0 --Blackwing - Zephyros the Elite (Anime)
+14785765 0 --Blackwing - Zephyros the Elite (Anime) (OCG Alias)
+511001971 0 --Road Raven Red Queen
+511002101 0 --Photon Satellite (Anime)
+63223260 0 --Photon Satellite (Anime) (OCG Alias)
+511002179 0 --Wish Dragon
+511002359 0 --Elemental HERO Flash (Anime)
+69572169 0 --Elemental HERO Flash (Anime) (OCG Alias)
+511002600 0 --Number 88: Gimmick Puppet of Leo (Anime)
+48995978 0 --Number 88: Gimmick Puppet of Leo (Anime) (OCG Alias)
+511002836 0 --Grinder Golem (Anime)
+75732622 0 --Grinder Golem (Anime) (OCG Alias)
+511005030 0 --Ojamachine Yellow
+511009132 0 --Cup Meatball Cayenne
+511020003 0 --Performapal Springoose (Anime)
+128454 0 --Performapal Springoose (Anime) (OCG Alias)
+513000058 0 --Dark Magician of Chaos (Anime)
+40737112 0 --Dark Magician of Chaos (Anime) (OCG Alias)
+513000134 0 --The Winged Dragon of Ra (Manga)
+10000010 0 --The Winged Dragon of Ra (Manga) (OCG Alias)
+513000135 0 --Obelisk the Tormentor (Manga)
+10000000 0 --Obelisk the Tormentor (Manga) (OCG Alias)
+513000136 0 --Slifer the Sky Dragon (Manga)
+10000020 0 --Slifer the Sky Dragon (Manga) (OCG Alias)
+513000164 0 --Mathematician (Anime)
+41386308 0 --Mathematician (Anime) (OCG Alias)
+810000028 0 --Amazoness Chain Master (Anime)
+29654737 0 --Amazoness Chain Master (Anime) (OCG Alias)
+511009441 0 --Supreme King Z-ARC (Anime)
+13331639 0 --Supreme King Z-ARC (Anime) (OCG Alias)
+511009735 0 --Topologic Gumblar Dragon (Anime)
+22593417 0 --Topologic Gumblar Dragon (Anime) (OCG Alias)
+511005712 0 --Performapal Laugh Maker (Anime)
+44944304 0 --Performapal Laugh Maker (Anime) (OCG Alias)
+511009162 0 --Performapal Handstandcoon (Anime)
+81055000 0 --Performapal Handstandcoon (Anime) (OCG Alias)
+511600001 0 --Performapal Guitartle (Anime)
+53724621 0 --Performapal Guitartle (Anime) (OCG Alias)
+511001973 0 --T.G. Recipro Dragonfly (Anime)
+62560742 0 --T.G. Recipro Dragonfly (Anime) (OCG Alias)
+511001983 0 --Catapult Warrior (Anime)
+37474917 0 --Catapult Warrior (Anime) (OCG Alias)
+511002598 0 --Glow-Up Bulb (Anime)
+67441435 0 --Glow-Up Bulb (Anime) (OCG Alias)
+111011904 0 --New Orders 8 Etheric Sebek
+511002054 0 --Number 42: Galaxy Tomahawk (Anime)
+10389142 0 --Number 42: Galaxy Tomahawk (Anime) (OCG Alias)
+511002076 0 --Cat Shark (Anime)
+84224627 0 --Cat Shark (Anime) (OCG Alias)
+511002092 0 --Number 73: Abyss Splash (Anime)
+36076683 0 --Number 73: Abyss Splash (Anime) (OCG Alias)
+513000060 0 --Number 39: Utopia Beyond (Anime)
+21521304 0 --Number 39: Utopia Beyond (Anime) (OCG Alias)
+513000141 0 --Number 69: Heraldry Crest (Anime)
+2407234 0 --Number 69: Heraldry Crest (Anime) (OCG Alias)
 100000083 0 --Illusion Gate
-100000239 0 --Xyz Treasure
+100000247 0 --Sabatiel - The Philosopher's Stone (TF6)
+80831721 0 --Sabatiel - The Philosopher's Stone (TF6) (OCG Alias)
+100000474 0 --Fusion Birth
+170000117 0 --Time Fusion
 170000119 0 --Blasting Vein
+511000064 0 --Slash Draw (VG)
+71344451 0 --Slash Draw (VG) (OCG Alias)
+511000162 0 --Altar of Restoration
 511000204 0 --Card of Spell Containment
 511000207 0 --Card of Burial Magic
+511000270 0 --Nibelung's Treasure
+511000279 0 --Z-ONE (Anime)
+62499965 0 --Z-ONE (Anime) (OCG Alias)
 511000333 0 --Quick Rush
 511000381 0 --Wonder Cloud
+511000429 0 --Gold Moon Coin
 511000471 0 --Drawber
-511000504 0 --Magician's Archive
+511000474 0 --Riryoku (Anime)
+34016756 0 --Riryoku (Anime) (OCG Alias)
+511000504 0 --Magician's Library
+511000506 0 --Spellbook Inside the Pot
+511000543 0 --Summon Capture
+511000552 0 --Soul Charge (Anime)
+54447022 0 --Soul Charge (Anime) (OCG Alias)
 511000554 0 --Heaven's Lost Property
+511000613 0 --Magical Mallet (Anime)
+85852291 0 --Magical Mallet (Anime) (OCG Alias)
 511000654 0 --Card of Variation
 511000672 0 --Fire Whip
 511000691 0 --Card Exchange
@@ -917,570 +1083,218 @@
 511000752 0 --Card of Compensation
 511000784 0 --Card of Desperation
 511000814 0 --Extra Fusion
-511000866 0 --Xyz Trasure Ticket
+511000866 0 --Xyz Treasure Ticket
+511001126 0 --Card of Sanctity (Anime)
+42664989 0 --Card of Sanctity (Anime) (OCG Alias)
+511001142 0 --Roll of Fate
+511001149 0 --Card of Demise (Anime)
+59750328 0 --Card of Demise (Anime) (OCG Alias)
 511001417 0 --Water of Life
-511001582 0 --Performage Hurricane
+511001582 0 --Performance Mage Hurricane
 511001611 0 --Numbers Evaille
+511001627 0 --Galaxy Journey
+511001669 0 --Balloon Party
+511001676 0 --Raise the Woof
+511001678 0 --Pooch Party
+511001757 0 --Piri Reis Map
 511001758 0 --Akashic Record
+511001895 0 --Junk Dealer (Anime)
+511001370 0 --Junk Dealer (Anime) (OCG Alias)
+511001896 0 --Toy Robot Box
+511002048 0 --Call of the Living Dead
+97077563 0 --Call of the Living Dead (OCG Alias)
 511002115 0 --Magical Pendulum Box
+511002549 0 --Brain Control (Anime)
+87910978 0 --Brain Control (Anime) (OCG Alias)
+511002736 0 --Hell Gift
+511002846 0 --Tuning (Anime)
+96363153 0 --Tuning (Anime) (OCG Alias)
+511005599 0 --Raft Party
+511005654 0 --Dark Hole (DOR) 
+53129443 0 --Dark Hole (DOR)  (OCG Alias)
+511013015 0 --Photon Veil (Anime)
+9354555 0 --Photon Veil (Anime) (OCG Alias)
+511018008 0 --Duel
+511600081 0 --Hippo Carnival (Anime)
+18027138 0 --Hippo Carnival (Anime) (OCG Alias)
+511777003 0 --Spell Reproduction (Manga)
+29228529 0 --Spell Reproduction (Manga) (OCG Alias)
+513000054 0 --Soul Exchange (Anime)
+68005187 0 --Soul Exchange (Anime) (OCG Alias)
+513000057 0 --Sabatiel - The Philosopher's Stone (Anime)
+80831721 0 --Sabatiel - The Philosopher's Stone (Anime) (OCG Alias)
+513000080 0 --Graveyard Rebound
 513000119 0 --Card Hexative
+513000121 0 --Anti-Magic Arrows (Anime)
+97120394 0 --Anti-Magic Arrows (Anime) (OCG Alias)
+513000122 0 --Virus Cannon (Anime)
+54591086 0 --Virus Cannon (Anime) (OCG Alias)
+513000180 0 --Left Arm Offering (Manga)
+86541496 0 --Left Arm Offering (Manga) (OCG Alias)
 810000021 0 --Deepest Impact
+810000032 0 --Depth Eruption
 810000082 0 --Giant Flood
 810000088 0 --Pillager
-74519184 0 --Hand Destruction (Anime, VIA OCG ID)
-93108433 0 --Monster Recovery (Anime, VIA OCG ID)
-97120394 0 --Anti-Magic Arrows (Anime, VIA OCG ID)
-511000699 0 --Big Return
-511001307 0 --Energy Drain
-511002754 0 --Spirit Foresight
-56673480 0 --Contract with Don Thousand (Anime, VIA OCG ID)
-34016756 0 --Riryoku (Anime, VIA OCG ID)
-37520316 0 --Mind Control (Anime, VIA OCG ID)
-54447022 0 --Soul Charge (Anime, VIA OCG ID)
-80831721 0 --Philosopher's Stone - Sabatiel (Anime, VIA OCG ID)
-100000239 0 --Xyz Treasure
-100000474 0 --Fusion Birth
-170000117 0 --Time Fusion
-200000004 0 --Winning Formula
-511000270 0 --Nibelung's Treasure
-511000429 0 --Gold Moon Coin
-511000461 0 --Monster Replace
-511000506 0 --Spellbook Inside the Pot
-511000866 0 --Xyz Treasure Ticket
-511001142 0 --Roll of Fate
-511002736 0 --Hell Gift
-513000080 0 --Graveyard Rebound
-810000032 0 --Depth Eruption
-40703222 0 --Multiply (Anime, VIA OCG ID)
-100000312 0 --Past Life
-511000091 0 --Turn Jump
-511000920 0 --Spell Transfer
-511001307 0 --Energy Drain
-513000011 0 --Burning Soul
-29762407 0 --Temple of the Kings (Anime, VIA OCG ID)
-511000084 0 --White Night Fort
 511000171 0 --Spell Sanctuary
-513000007 0 --Sea of Rebirth
-511002449 0 --Prominence
-95000003 0 --Darkness/Boss Duel
-100000186 0 --Sphere Field
-95000017 0 --Numeron Callin/Boss Duel
-95000013 0 --Comic Hand/Boss Duel
-95000015 0 --Mimicat/Boss Duel
-95000024 0 --Numeron Chaos Ritual/Boss Duel
-511009410 0 --Ivy Bind Castle
-95000012 0 ---Toon World/Boss Duel
-95000023 0 --Numeron Network/Boss Duel
-511005654 0 --Dark Hole (DOR)
-511000751 0 --Blade Graveyard
-511000064 0 --Slash Draw
-11050415 0 --Super Hippo Carnival (Anime, via OCG ID)
-511000494 0 --Effect Shut
-511002089 0 --Instant Freeze
-511009613 0 --Abyss Invitation
-511001676 0 --Raise the Woof
-511001901 0 --Shield Wall
-511000162 0 --Altar of Restoration
-513000160 0 --Negative Energy
 511000809 0 --Spectral Ice Floe
-54591086 0 --Virus Cannon (Anime, VIA OCG ID)
-511000618 0 --Insightful Cards of Reversal
+511001186 0 --Contract with Don Thousand (Anime)
+56673480 0 --Contract with Don Thousand (Anime) (OCG Alias)
+511009410 0 --Ivy Bind Castle
+511009411 0 --Rapid Seed Fire
+511009613 0 --Abyss Invitation
+513000007 0 --Sea of Rebirth
+513000160 0 --Negative Energy
+511000578 0 --Necro Shot
+511000751 0 --Blade Graveyard
+511001891 0 --Spirit Illusion
+511002449 0 --Prominence
+513000094 0 --Future Fusion (Anime)
+77565204 0 --Future Fusion (Anime) (OCG Alias)
+810000064 0 --Synchronic Ability
+100000186 0 --Sphere Field
+511000715 0 --Kabuki Stage - The Rough Seas
+513000016 0 --Temple of the Kings (Anime)
+29762407 0 --Temple of the Kings (Anime) (OCG Alias)
+513000144 0 --Golden Castle of Stromberg (Anime)
+72283691 0 --Golden Castle of Stromberg (Anime) (OCG Alias)
+100000312 0 --Past Life
+511000091 0 --Turn Jump (Anime)
+511000358 0 --Miracle of Draconian Wrath
+511000373 0 --Monster Recovery (Anime)
+93108433 0 --Monster Recovery (Anime) (OCG Alias)
+511000494 0 --Effect Shut
+511000699 0 --Big Return
+511000920 0 --Spell Transfer
+511001307 0 --Energy Drain (Anime)
+511001901 0 --Shield Wall
+511002089 0 --Instant Freeze
+511002601 0 --Hand Destruction (Anime)
+74519184 0 --Hand Destruction (Anime) (OCG Alias)
+511002754 0 --Spirit Foresight
+513000011 0 --Burning Soul
+810000034 0 --Multiply (Anime)
+40703222 0 --Multiply (Anime) (OCG Alias)
+513000131 0 --Domain of the Dark Ruler
+511000278 0 --Mind Control (Anime)
+37520316 0 --Mind Control (Anime) (OCG Alias)
+511000407 0 --Curse Transfer
+511000618 0 --Talisman of Reversal
+511000648 0 --Elegant Light LV4
 511001125 0 --Life Shaver
 511001143 0 --Power Balance
-513000037 0 --Card of Last Will
-52503575 0 --Final Attack Orders (Anime, VIA OCG ID)
-97077563 0 --Call of the Haunted (Anime, VIA OCG ID)
-17484499 0 --Exchange of the Spirit (Anime, VIA OCG ID)
-57728570 0 --Crush Card Virus (Anime, VIA OCG ID)
-511000407 0 --Curse Transfer
-513000009 0 --Crush Card Virus
-800000000 0 --Forceful Deal
-95000004 0 --Infinity/Boss Duel
-95000005 0 --Zero/Boss Duel
-95000006 0 --Darkness 1/Boss Duel
-95000007 0 --Darkness 2/Boss Duel
-95000008 0 --Darkness 3/Boss Duel
-511001119 0 --Deck Destruction Virus
-513000077 0 --Beast-borg Medal of the Crimson Chain
-95000016 0 --Toon Briefcase/Boss Duel
 511001493 0 --Shining Reborn
-95000029 0 --Nonexistence/Boss Duel
-95000037 0 --Endless Emptiness/Boss Duel
-95000041 0 --Infinite Light/Boss Duel
+511001910 0 --Destruction of Destiny (Anime)
+62980542 0 --Destruction of Destiny (Anime) (OCG Alias)
+513000009 0 --Crush Card Virus (Anime)
+57728570 0 --Crush Card Virus (Anime) (OCG Alias)
+513000037 0 --Card of Last Will (Anime)
+450000130 0 --Card of Last Will (Anime) (OCG Alias)
+800000000 0 --Forceful Deal
 100000565 0 --Freezing Dance
-95000027 0 --Numeron Xyz Revision/Boss Duel
-95000028 0 --Numeron Spell Revision/Boss Duel
-513000002 0 --Mirror Wall
-511000907 0 --Compulsory Recoil Device
 511000773 0 --Traitor Fog
-511018008 0 --Duel
-511005030 0 --Ojamachine Yellow
-511001971 0 --Road Raven Red Queen
-511000543 0 --Summon Capture
-511009000 0 --Timelord Proginitor, Vulgate
-513000131 0 --Domain of the Dark Ruler
-511001757 0 --Piri Reis Map
-511000648 0 --Elegant Light LV4
-111011904 0 --New Orders 8 Etheric Sebek
-511001973 0 --T.G. Recipro Dragonfly (Anime)
-513000141 0 --Number 69: Heraldry Crest (Anime)
-511002179 0 --Wish Dragon
-511001983 0 --Catapult Warrior (Anime)
-511002359 0 --Elemental HERO Flash (Anime)
-511005712 0 --Performapal Laugh Maker (Anime)
-62560742 0 --T.G. Recipro Dragonfly (Anime, via OCG ID)
-2407234 0 --Number 69: Heraldry Crest (Anime, via OCG ID)
-511001983 0 --Catapult Warrior (Anime, via OCG ID)
-69572169 0 --Elemental HERO Flash (Anime, via OCG ID)
-22593417 0 --Topologic Gumblar Dragon (Anime, via OCG ID)
-87910978  0 --Brain Control (Anime, via OCG ID)
-96363153 0 --Tuning (Anime, via OCG ID)
-9354555 0 --Photon Veil (Anime, via OCG ID)
-40737112 0 --Dark Magician of Chaos ((Anime, via OCG ID)
-81055000 0 --Performapal Handstandcoon (Anime, via OCG ID)
-77565204 0 --Future Fusion ((Anime, via OCG ID)
-72283691 0 --Golden Castle of Stromberg (Anime, via OCG ID)
-36076683 0 --Number 73: Abyss Splash (Anime, via OCG ID)
-84224627 0 --Cat Shark (Anime, via OCG ID)
-16404809 0 --Kuribandit (Anime, via OCG ID)
-44944304 0 --Performapal Laugh Maker (Anime, via OCG ID)
-511001370 0 --Junk Dealer (Anime)
-511002054 0 --Number 42: Galaxy Tomahawk (Anime)
-10389142 0 --Number 42: Galaxy Tomahawk (Anime, via OCG ID)
-95453143 0 --Hundred-Eyes Dragon (Anime, via OCG ID)
-513000118 0 --Underworld Circle
-#Limited Worlds (For Anime List)
-07902349 1 --Left Arm of the forbidden one						MAIN DECK MONSTERS
-44519536 1 --Left Leg of the forbidden one
-70903634 1 --Right Arm of the forbidden one
-08124921 1 --Right Leg of the forbidden one
-65518099 1 --Qliporth Scout
-33396948 1 --Exxodia the Forbidden One
-65192027 1 --Dark Armed Dragon
-78868119 1 --Deep Sea Diva
-64034255 1 --Genex Ally birdman
-50720316 1 --Elemental Hero Shadow Mist
-20758643 1 --Graff, Malembrance of the Burning Abyss
-99177923 1 --Infernity Archfiend
-68184115 1 --Inzektor DragonFly
-69207766 1 --Inzektor Hornet
-28297833 1 --Necroface
-16226786 1 --Night Assailant
-78872731 1 --Zoodiac Ratpier
-55623480 1 --Fairy Tail - Snow
-40044918 1 --Elemental Hero Stratos
-88264978 1 --Red-eyes Darkness Metal Dragon
-10802915 1 --Tour Guide From the Underworld
-81275020 1 --Speedroid Terrortop
-57143342 1 --Cir, Malebranche of the Burning Abyss
-55885348 1 --Kozmo Dark Destroyer
-33508719 1 --Morphing Jar
-96570609 1 --Ether the Heavenly monarch
-44335251 1 --Souleating Oviraptor
-36042004 1 --Babycerasaurus
-38572779 1 --Miscellaneousaurus
-92746535 1 --Luster Pendulum, the Dracoslayer
-50720316 1 --Elemental Hero Shadow Mist
-4474060 1 --SPYRAL Gear - Drone
-78080961 1 --SPYRAL Quik-Fix
-9047460 1 --Blackwing - Steam the Cloak
-75732622 1 --Grinder Golem
-69610326 1 --Supreme King Dragon Darkwurm
-48686504 1 --Lonefire Blossom
-30012506 1 --A-Assault Core
-35272499 1 --Predaplant Ophrys Scorpio
-58984738 1 --Dinomight Knight, the True Dracofighter
-73941492 1 --Harmonizing Magician
-45222299 1 --Evigishki Gustkraken
-11877465 1 --Evigishki Mind Augus
-26674724 1 --Nekroz of Brionac
-89463537 1 --Nekroz of Unicore
-1561110 1 --ABC-Dragon Buster 									EXTRA DECK MONSTERS
-39512984 1 --Gem-Knight Master Diamond
-75286621 1 --Invoked Mechaba	
-18239909 1 --Ignister Prominence, the Blasting Dracoslayer
-48063985 1 --Ritual Beast Ulti-Cannahawk
-74586817 1 --PSY-Framelord Omega
-83531441 1 --Dante, Traveler of the Burning Abyss
-90809975 1 --Toadally Awesome
-06602300 1 --Blaze Fenix, The Burning Bombardment Bird
-70583986 1 --Dewloren, Tiger King of the Ice Barrier
-52687916 1 --Trishula, Dragon of the Ice Barrier
-90953320 1 --T.G. Hyper Librarian
-27552504 1 --Beatrice, Lady of Eternal
-46772449 1 --Evilswarm Exciton Knight
-5043010 1 --Firewall Dragon
-24094258 1 --Heavymetalfoes Electrumite			
-14087893 1 --Book of Moon 							SPELLS CARDS				
-97211663 1 --Nekroz Cycle
-81674782 1 --Dimensional Fissure
-95308449 1 --Final Countdown
-81439173 1 --Foolish Burial
-66957584 1 --Infernity Launcher
-23171610 1 --Limiter Removal
-53129443 1 --Dark Hole
-43040603 1 --Monster Gate
-33782437 1 --One Day of Peace
-02295440 1 --One for one
-32807846 1 --Reinforcement of the Army
-74845897 1 --Rekindling
-8949584 1 --A Hero Lives
-72892473 1 --Card Destruction
-72405967 1 --Royal Tribute
-27970830 1 --Gateway of the Six
-54447022 1 --Soul Charge
-45305419 1 --Symbol of Heritage
-14733538 1 --Draco Face-off
-73468603 1 --Set Rotation
-93600443 1 --Mask Change 2
-58577036 1 --Reasoning
-99330325 1 --Interrupted Kaiju Slumber
-23701465 1 --Primal Seed
-70368879 1 --Upstart Goblin
-67723438 1 --Emergency Teleporter
-73628505 1 --Terraforming
-53208660 1 --Pendulum Call
-22842126 1 --Phanteism of the Monarchs
-79844764 1 --The Monarchs Stormforth
-15854426 1 --Divine Wind of the Mist Valley
-54631665 1 --SPYRAL Resort
-83764718 1 --Monster Reborn
-83764719 1 --Monster Reborn	
-23314220 1 --Spellbook of Knowledge
-91623717 1 --Chain Strike
-52340444 1 --Sky Striker Mecha - Hornet Drones			
-48130397 1 --Super Polymerization
-54974237 1 --Eradicator Epidemic Virus					TRAP CARDS
-36468556 1 --Ceasefire
-21076084 1 --Trickstar Reincarnation
-61740673 1 --Imperial Order
-35125879 1 --True King's Return
-83555666 1 --Ring of Destruction
-83555667 1 --Ring of Destruction
-82732705 1 --Skill Drain
-73599290 1 --Soul Drain
-30241314 1 --Macro Cosmos
-17078030 1 --Wall of Revealing light
-09059700 1 --Infernity Barrier
-84749824 1 --Solemn Warning
-41420027 1 --Solemn Judgement
-#Limited Anime
-501000078 1 --Leonardo's Silver Skyship					MAIN DECK MONSTERS START HERE
-501000079 1 --The Twin Kings, Founders of the Empire
-501000080 1 --Kuzunoha, the Onmyojin
-501000081 1 --Sakyo, Swordsmaster of the Far East
-501000000 1 --Ulevo	
-501000001 1 --Meteo the Matchless
-501000002 1 --King of Destruction - Xexex
-501000003 1 --Queen of Fate - Eternia
-501000004 1 --Testament of the Arcane Lords
-501000006 1 --Chimaera, the Master of Beasts
-501000005 1 --Armament of the Lethal Lords
-501000007 1 --Emperor of Lightning
-501000008 1 --Tyr, the Vanquishing Warlord
-501000009 1 --Lorelei, the Symphonic Arsenal
-501000010 1 --Aggiba, the Malevolent Sh'nn S'yo
-501000011 1 --Skuna, the Leonine Rakan
-511000544 1 --Mother Spider
-73130445 1 --Performapal Lizardraw (Anime,  VIA OCG ID)
+511000907 0 --Compulsory Recoil Device
+511001119 0 --Deck Destruction Virus
+511002267 0 --Graveyard of Wandering Souls
+513000077 0 --Beast-borg Medal of the Crimson Chain
+513000111 0 --Final Attack Orders (Anime)
+52503575 0 --Final Attack Orders (Anime) (OCG Alias)
+#limited anime
+511000082 1 --Snow Fairy
+511000291 1 --Infernity Pawn
+511000762 1 --Red Lotus King, Flame Crime
 511002196 1 --Jester Puppet Trick Rider
-31709826 1 --Revival Jam (Anime, VIA OCG ID)
-81275020 1 --Speedroid Terrortop (Anime, VIA OCG ID)
-511001320 1 --Ninja Commando Kabuki
-82103466 1 --Divine Serpent Geh  (Anime, VIA OCG ID)
-100000002 1 --Sandaion, the Timelord
-100000003 1 --Hailon, the Timelord
-100000004 1 --Raphion, the Timelord
-100000005 1 --Gabrion, the Timelord
-100000008 1 --Michion, the Timelord
-513000003 1 --Zaphion, the Timelord (To check Alias)
-513000044 1 --Sadion, the Timelord (To check Alias)
-513000041 1 --Lazion, the Timelord (To check Alias)
-513000040 1 --Kamion, the Timelord (To check Alias)
-28929131 1 --Zaphion, the Timelord (Anime, VIA OCG ID)
-65314286 1 --Sadion, the Timelord (Anime, VIA OCG ID)
-91712985 1 --Kamion, the Timelord (Anime, VIA OCG ID)
-92435533 1 --Lazion, the Timelord (Anime, VIA OCG ID)
-511001131 1 --Clone Dragon
-511004423 1 --Odd-Eyes Phantasma Dragon
-511001726 1 --Ancient Gear Ultimate Hound Dog
-501000012 1 --Stardust Divinity
-501000013 1 --Grizzly, the Red Star Beast
-6165656 1 --Number 88 (Anime, VIA OCG ID)
-501000019 1 --Grandopolis, the Eternal Golden City
-501000018 1 --E Hero Pit Boss
-501000017 1 --Legendary Magician of Dark
-501000016 1 --Legendary Magician of White
-501000015 1 --Queen Nereia the Silvercrown
-501000014 1 --King Landia the Goldfang
-440556 1 --Bahamut Shark (Anime, VIA OCG ID)
-30864377 1 --Gladiator Beast Tamer Editor (Anime, VIA OCG ID)
-35952884 1 --Shooting Quasar Dragon (Anime, VIA OCG ID)
-97836203 1 ---T.G. Halberd Cannon (Anime, VIA OCG ID)
-37279508 1 --Number 37: Hope Woven Dragon Spider Shark (Anime, VIA OCG ID)
-40450317 1 --Ties of the Brethren (Anime, VIA OCG ID)
-57734012 1 --Rank-Up Magic the Seventh One (Anime, VIA OCG ID)
-98045062 1 --Enemy Controller (Anime, VIA OCG ID)
+511002467 1 --Twilight Ninja Shogun - Getsuga (Anime)
+76930964 1 --Twilight Ninja Shogun - Getsuga (Anime) (OCG Alias)
+511003077 1 --Endless Decay (Anime)
+7845138 1 --Endless Decay (Anime) (OCG Alias)
+511600050 1 --Gandora-X the Dragon of Demolition (Anime)
+71525232 1 --Gandora-X the Dragon of Demolition (Anime) (OCG Alias)
+513000005 1 --Thousand-Eyed Ghost
+513000006 1 --Three-Eyed Ghost
+513000022 1 --The Supremacy Sun (Anime)
+51402908 1 --The Supremacy Sun (Anime) (OCG Alias)
+513000142 1 --Revival Jam (Anime)
+31709826 1 --Revival Jam (Anime) (OCG Alias)
+511001726 1 --Ultimate Ancient Gear Hunting Hound
+511009025 1 --Starving Venom Fusion Dragon (Anime)
+41209827 1 --Starving Venom Fusion Dragon (Anime) (OCG Alias)
+511009047 1 --Performapal Lizardraw (Anime)
+73130445 1 --Performapal Lizardraw (Anime) (OCG Alias)
+511009517 1 --Supreme King Dragon Clear Wing (Anime)
+70771599 1 --Supreme King Dragon Clear Wing (Anime) (OCG Alias)
+511001273 1 --Number 37: Hope Woven Dragon Spider Shark (Anime)
+37279508 1 --Number 37: Hope Woven Dragon Spider Shark (Anime) (OCG Alias)
+511002075 1 --Bahamut Shark (Anime)
+440556 1 --Bahamut Shark (Anime) (OCG Alias)
+100000474 1 --Fusion Birth
+100000478 1 --Ties of the Brethren (Anime)
+40450317 1 --Ties of the Brethren (Anime) (OCG Alias)
+170000121 1 --Bonfire
 511000418 1 --Beckon to Darkness
+511000502 1 --Gift of the Weak
+511000503 1 --Legacy of a HERO (Anime)
+25614410 1 --Legacy of a HERO (Anime) (OCG Alias)
 511000551 1 --Treasures of the Dead
+511000612 1 --Lightning Crash
 511000680 1 --Ice Age Panic
-511000829 1 ---Re-Xyz
-511002620 1 --Underworld Resonance - Synchro Fusion
-511004000 1 --Destiny Draw
-511004001 1 --Speed Duel
-511001172 1 --Underwater Snow Prison
-511001614 1 --Spirit Xyz Spark
-511004421 1 --Rank-Up-Magic Cipher shock
-810000002 1 --Dark Spell Regeneration
-511000800 1 --Celestial Bell Tower
-500000147 1 ---École de Zone
-81439173 1 --Foolish Burial (Anime, VIA OCG ID)
-26194151 1 --Necroid Synchro (Anime, VIA OCG ID)
-88032456 1 --Mimicat (Anime, VIA OCG ID)
-95200000 1 --Command Duel
-511000970 1 --Mirror Prison
-511001627 1 --Galaxy Journey
-76714458 1 --Spell of Pain (Anime, VIA OCG ID)
-511000598 1 --Fallout
-110000102 1 --Living Fossil
-513000020 1 --Negative Energy Generator
+511000685 1 --Double-Rank-Up-Magic Utopia Force
+511000829 1 --Re-Xyz
 511000924 1 --Pump Up!
-99789342 1 --Dark Magic Curtain (Anime, VIA OCG ID)
-44095762 1 --Mirror Force (Anime, VIA OCG ID)
-17078030 1 --Wall of Revealing Light (Anime, VIA OCG ID)
-65430834 1 --Jurassic Impact (Anime, VIA OCG ID)
+511000970 1 --Mirror Prison
+511001136 1 --Mimicat (GX)
+88032456 1 --Mimicat (GX) (OCG Alias)
+511001164 1 --Fish Spawn
+511001596 1 --Fiend's Sanctuary (Anime)
+24874630 1 --Fiend's Sanctuary (Anime) (OCG Alias)
+511002456 1 --Refracting Prism
+511009080 1 --Ancient Gear Double Imitation
+511009153 1 --Junk Ball
+511009386 1 --Pendulum Halt (Anime)
+36111775 1 --Pendulum Halt (Anime) (OCG Alias)
+511009582 1 --Pendulum Card Burst
+511009731 1 --Dual-Colored Eyes
+511600013 1 --Cards of Consonance (Anime)
+39701395 1 --Cards of Consonance (Anime) (OCG Alias)
+513000008 1 --Rank-Up-Magic - The Seventh One (Anime)
+57734012 1 --Rank-Up-Magic - The Seventh One (Anime) (OCG Alias)
+513000020 1 --Negative Energy Generator
+100000581 1 --Rank-Up Spider Web
+511000800 1 --Celestial Bell Tower
+110000102 1 --Living Fossil (Anime)
+34959756 1 --Living Fossil (Anime) (OCG Alias)
+511000598 1 --Fallout
+511001172 1 --Underwater Snow Prison
+511001578 1 --Flying Dragon Whirl
+511001614 1 --Spirit Xyz Spark
+511001785 1 --Spell of Pain (Anime)
+76714458 1 --Spell of Pain (Anime) (OCG Alias)
+511004421 1 --Rank-Up-Magic Cipher Shock
+810000002 1 --Dark Spell Regeneration
 100000470 1 --Soul Fusion
 511000789 1 --Briar Transplant
 511001642 1 --Synchro Alliance
-513000091 1 --Jurassic Impact (To check Alias)
-511001583 1 --Fortress of Prophecy
-511004424 1 --Supreme King Dance
-511009310 1 --Synchro Zone
-511004411 1 --Photo Frame
+511003083 1 --Scrap-Iron Pitfall
+513000091 1 --Jurassic Impact (Anime)
+511000036 1 --Jurassic Impact (Anime) (OCG Alias)
+511001583 1 --Mage's Fortress
 511001802 1 --Fake Friendship Treaty
-513000101 1 --Scrap-Iron Pitfall
-170000121 1 --Bonfire
-511000330 1 --Infernal Transaction
-511002456 1 --Refracting Prism
-511002923 1 --Fair Exchange
-511009080 1 --Ancient Gear Double Imitation
-511009731 1 --Dual-Colored Eyes
-511009582 1 --Pendulum Card Burst
-511000762 1 --Red Lotus King, Flame Crime
-513000006 1 --Three-Eyed Ghost
-513000005 1 --Thousand-Eyed Ghost
-511000291 1 --Infernity Pawn
-100000474 1 --Fusion Birth
-511000685 1 --Double-Rank-Up-Magic Utopia Force
-511000082 1 --Snow Fairy
-39701395 1 --Cards of Consonance(Anime, via OCG ID)
-40450317 1 --Ties of the Brethren (Anime, via OCG ID)
-41209827 1 --Starving Venom Fusion Dragon (Anime)
-25614410 1 --Legacy of a HERO (Anime, via OCG ID)
-70771599 1 --Supreme King Dragon Clear Wing (Anime, via OCG ID)
-42160203 1 --Supreme King Dragon Dark Rebellion (Anime, via OCG ID)
-36111775 1 --Pendulum Halt (Anime, via OCG ID)
-51402908 1 --The Supremacy Sun (Anime, via OCG ID)
-71525232 1 --Gandora-X the Dragon of Demolition (Anime, via OCG ID)
-7845138 1 --Endless Decay (Anime, via OCG ID)
-511001578 1 --Flying Dragon Whirl
-511000502 1 --Gift of the Weak
-511009153 1 --Junk Ball
-#Semi Limited Worlds (For Anime List)
-59297550 2 --Wind-up Magician
-14558127 2 --Ash Blossom & Joyous Spring
-86120751 2 --Aleister the Invoker
-56570271 2 --Destiny Hero - Disk Commander
-55885348 2 --Kozmo Dark Destroyer
-47325505 2 --Fossil Dig
-73915051 2 --Scapegoat
-66399653 2 --Union Hangar
-40605147 2 --Solemn Strike
-94977269 2 --El Shaddoll Winda
-24224830 2 --Called By The Grave
-#Semi-Limited Anime
-100000020 2 --After Glow
-100000117 2 --Life Force
-511001357 2 --Remove Bomb
-511001470 2 --Doll Hammer
-511001669 2 --Balloon Party
-511001678 2 --Pooch Party
-511001888 2 --Palenque Sarcophagus
+#semi-limited anime
+344000000 2 --Garbage Lord (Anime)
+44682448 2 --Garbage Lord (Anime) (OCG Alias)
 511001945 2 --Battlewasp - Twinbow the Attacker
 511005044 2 --Giant Kra-Corn
-100000262 2 --Xyz Frame
-100000239 2 --Xyz Treasure
+810000022 2 --Zeta Reticulant (Anime)
+64382839 2 --Zeta Reticulant (Anime) (OCG Alias)
+100000020 2 --Afterglow
 100000167 2 --Miracle Rupture
-64382839 2 --Zeta Reticulant (Anime, via OCG ID)
-44682448 2 --Garbage Lord (Anime, via OCG ID)
-21715135 2 --Gagaga Academy Emergency Network (Anime, via OCG ID)
-72355441 2 --Xyz Gift (Anime, via OCG ID)
+100000239 2 --Xyz Treasure
 111011901 2 --Rank-Up-Magic Astral Force (Anime)
-1073952 2 --Magic Planter (Anime, via OCG ID)
+45950291 2 --Rank-Up-Magic Astral Force (Anime) (OCG Alias)
+511000330 2 --Infernal Transaction
+511001357 2 --Remove Bomb
+511001470 2 --Doll Hammer
+511002701 2 --Magic Planter (Anime)
+1073952 2 --Magic Planter (Anime) (OCG Alias)
+511002878 2 --Gagaga Academy Emergency Network (Anime)
+21715135 2 --Gagaga Academy Emergency Network (Anime) (OCG Alias)
 511003002 2 --Dis-swing Fusion
-!2018.10 OCG
-#Forbidden OCG
-20663556 0 --イレカエル Substitoad												MAIN DECK MONSTERS
-44910027 0 --ヴィクトリー・ドラゴン Victory Dragon
-53804307 0 --焔征竜－ブラスター Blaster, Dragon Ruler of Infernos
-90411554 0 --巌征竜－レドックス Redox, Dragon Ruler of Boulders
-26400609 0 --瀑征竜－タイダル Tidal, Dragon Ruler of Waterfalls
-57421866 0 --レベル・スティーラー Level Eater
-34124316 0 --サイバーポッド Cyber Jar
-21593977 0 --処刑人－マキュラ Makyura the Destructor
-16923472 0 --ゼンマイハンター Wind-up Hunter
-78706415 0 --ファイバーポッド Fiber Jar
-93369354 0 --フィッシュボーグ－ガンナー Fishborg Blaster
-34206604 0 --魔導サイエンティスト Magical Scientist
-96782886 0 --メンタルマスター Mind Master
-3078576 0 --八汰烏 Yata-Garasu
-88071625 0 --The Tyrant Neptune
-7563579 0 --Emヒグルミ Performage PlushFire
-17330916 0 --EMモンキーボード Performapal Monkeyboard
-31178212 0 --マジェスペクター・ユニコーン Majespecter Unicorn - Kirin
-21377582 0 --Master Peace, The True Dracoslaying King
-9929398 0 --BF－朧影のゴウフウ Blackwing - Gofu the Vague Shadow
-23558733 0 --Phoenixian Cluster Amaryllis
-11384280 0 --Cannon Soldier
-79875176 0 --Toon Cannon Soldier
-91869203 0 --アマゾネスの射手 Amazoness Archer
-14702066 0 --メガキャノン・ソルジャー Cannon Soldier MK-2
-17412721 0 --旧神ノーデン Elder Entity Norden 						EXTRA DECK MONSTERS
-25862681 0 --Ancient Fairy Dragon
-34086406 0 --ラヴァルバル・チェイン Lavalval Chain
-18326736 0 --星守の騎士 プトレマイオス Tellarknight Ptolomaeus
-54719828 0 --No.16 色の支配者ショック・ルーラー Number 16: Shock Master
-48905153 0 --十二獣ドランシア Zoodiac Drident
-85115440 0 --Zoodiac Broadbull
-61665245 0 --サモン・ソーサレス Summon Sorceress
-44763025 0 --いたずら好きな双子悪魔 Delinquent Duo								SPELLS  CARDS
-19613556 0 --大嵐 Heavy Storm
-17375316 0 --押収 Confiscation
-74191942 0 --苦渋の選択 Painful Choice
-42829885 0 --強引な番兵 The Forceful Sentry
-55144522 0 --強欲な壺 Pot of Greed
-4031928 0 --心変わり Change of Heart
-12580477 0 --サンダー·ボルト Raigeki
-60682203 0 --大寒波 Cold Wave
-42703248 0 --ハリケーン Giant Trunade
-79571449 0 --天使の施し Graceful Charity
-23557835 0 --次元融合 Dimension Fusion
-46411259 0 --突然変異 Methamorphosis
-85602018 0 --遺言状 Last Will
-41482598 0 --悪夢の蜃気楼 Mirage of Nightmare
-57953380 0 --生還の宝札 Card of the Safe Return
-46060017 0 --十二獣の会局 Zoodiac Barrage
-45986603 0 --強奪 Snatch Steal
-69243953 0 --蝶の短剣－エルマ Butterfly Dagger - Elma
-70828912 0 --早すぎた埋葬 Premature Burial
-34906152 0 --マスドライバー Mass Driver
-46448938 0 --魔導書の神判 Spellbook of Judgment
-13035077 0 --Dragonic Diagram
-27174286 0 --異次元からの帰還 Return from the Different Dimension				TRAPS  CARDS
-3280747 0 --第六感 Sixth Sense
-64697231 0 --ダスト·シュート Trap Dustshoot
-35316708 0 --刻の封印 Time Seal
-17178486 0 --ライフチェンジャー Life Equalizer
-28566710 0 --ラストバトル！ Last turn
-93016201 0 --王宮の弾圧 Royal Oppression
-80604091 0 --血の代償 Ultimate Offering
-32723153 0 --マジカル·エクスプロージョン Magical Explosion
-#limited OCG
-64034255 1 --A·ジェネクス·バードマン Genex Ally Birdman							MAIN DECK MONSTERS
-50720316 1 --E·HERO シャドー·ミスト Elemental Hero Shadow Mist
-40318957 1 --EMドクロバット・ジョーカー Performapal Skullcrobat Joker
-78868119 1 --深海のディーヴァ Deep sea Diva
-65192027 1 --ダーク·アームド·ドラゴン Dark Armed Dragon
-69015963 1 --デビル・フランケン Cyber Stein
-16226786 1 --深淵の暗殺者 Night Assailant
-28297833 1 --ネクロフェイス Necroface
-33396948 1 --封印されしエクゾディア Exxodia the forbidden
-7902349 1 --封印されし者の左腕 Left Arm
-70903634 1 --封印されし者の右腕 Right Arm
-44519536 1 --封印されし者の左足 Left Leg 
-8124921 1 --封印されし者の右足 Right Leg
-88264978 1 --レッドアイズ·ダークネスメタルドラゴン Red-Eyes Darkness Dragon
-10802915 1 --魔界発現世行きデスガイド Tour Guide From the underworld
-33508719 1 --メタモルポット Morphing Jar
-89463537 1 --ユニコールの影霊衣 Nekroz of Unicore
-92746535 1 --竜剣士ラスターP Luster Pendulum
-78872731 1 --十二獣モルモラット Zoodiac Ratpier
-55623480 1 --妖精伝姫－シラユキ Fairy Tail - Snow
-58984738 1 --Dinomight Knight, the True Dracofighter
-44335251 1 --Souleating Oviraptor
-36042004 1 --Babycerasaurus
-78080961 1 --SPYRAL Quik-Fix
-15341821 1 --Dandylion
-9047460 1 --Blackwing - Steam the Cloak
-49684352 1 --Double Iris Magician
-69610326 1 --Supreme King Dragon Darkwurm
-75732622 1 --Grinder Golem
-48686504 1 --Lonefire Blossom
-35272499 1 --Predaplant Ophrys Scorpio
-76794549 1 --Astrograph Sorcerer
-73941492 1 --Harmonizing Magician
-89399912 1 --嵐征竜－テンペスト Tempest, Dragon Ruler of Storms
-68819554 1 --Emダメージ・ジャグラー Performage Damage Juggler
-74586817 1 --PSYフレームロード・Ω PSY-Framelord Omega								EXTRA DECK MONSTERS
-90953320 1 --TG ハイパー·ライブラリアン TG Hyper Librarian
-90809975 1 --餅カエル Toadally Awesome
-70583986 1 --氷結界の虎王ドゥローレン Dewloren, Tiger king of the Ice Barrier
-52687916 1 --氷結界の龍 トリシューラ Trishula, Dragon of the Ice barrier
-6602300 1 --重爆撃禽 ボム・フェネクス  Blaze Fenix, The Burning Bombardment Bird
-1561110 1 --ABC-Dragon Buster
-65536818 1 --Denglong, First of the Yang Zing
-75286621 1 --Invoked Mechaba
-5043010 1 --Firewall Dragon
-24094258 1 --Heavymetalfoes Electrumite
-39064822 1 --トロイメア・ゴブリン Knightmare Goblin
-33782437 1 --一時休戦 One Day of peace										SPELLS CARDS
-66957584 1 --インフェルニティガン Infernity launcer
-81439173 1 --おろかな埋葬 Foolish Burial
-23701465 1 --原初の種 Primal Seed
-99330325 1 --妨げられた壊獣の眠り Interrupted Kaiju Slumber
-2295440 1 --ワン·フォー·ワン One for One
-73628505 1 --Terraforming
-83764718 1 --死者蘇生 Monster Reborn
-32807846 1 --増援 Reinforcement of the Army
-54447022 1 --ソウル・チャージ Soul Charge
-58577036 1 --名推理 Reasoning
-18144506 1 --ハーピィの羽根帚 Harpie's Feather Duster
-53208660 1 --ペンデュラム・コール Pendulum Call
-23171610 1 --リミッター解除 Limiter Removal
-14733538 1 --竜呼相打つ Draco Face-Off
-72892473 1 --手札抹殺 Card Destruction
-97211663 1 --影霊衣の反魂術 Nekroz Cycle
-93600443 1 --マスク・チェンジ・セカンド Mask Change 2
-45305419 1 --継承の印 Symbol of Heritage
-54631665 1 --SPYRAL Resort
-15854426 1 --霞の谷の神風 Divine Wind of Mist Valley
-23314220 1 --Spellbook of Knowledge
-52340444 1 --Sky Striker Mecha - Hornet Drones
-73468603 1 -- Set Rotation
-8949584 1 --ヒーローアライブ A Hero Lives
-75500286 1 --封印の黄金櫃 Gold Sarcophagus
-36468556 1 --停戦協定 Ceasefire 												TRAPS CARDS
-21076084 1 --Trickstar Reincarnation
-5851097 1 --虚無空間 Vanity's Emptiness
-61740673 1 --王宮の勅命 Imperial Order
-#semi limited OCG
-40044918 2 --E·HERO エアーマン Elemental Hero Stratos
-14558127 2 --Ash Blossom & Joyous Spring
-81275020 2 --SRベイゴマックス Speedroid Terrortop
-42790071 2 --オルターガイスト・マルチフェイカー Altergeist Multifaker
-26674724 2 --ブリューナクの影霊衣 Nekroz of Brionac
-83531441 2 --彼岸の旅人 ダンテ Dante, Traveler of the Burning Abyss
-066399653 2 --ユニオン格納庫 Union Hangar
-73915051 2 --Scapegoat
-47325505 2 --Fossil Dig
-91623717 2 --連鎖爆撃 Chain Strike
-67723438 2 --緊急テレポート Emergency teleporter
-98338152 2 --閃刀機－ウィドウアンカー Sky Striker Mecha - Widow Anchor
-63166095 2 --閃刀起動－エンゲージ Sky Striker Mobilize - Engage!
-48130397 2 --超融合 Super Polymerization
-11110587 2 --隣の芝刈り That Grass Looks Greener
-40605147 2 --Solemn Strike
-84749824 2 --神の警告 Solemn Warning
-41420027 2 --神の宣告 Solemn Judgment
-35125879 2 --真竜皇の復活 True King's Return
-83555666 2 --破壊輪 Ring of Destruction


### PR DESCRIPTION
Update for OCG list and anime banlist.
Banlist changes included but not limited to: N88 ban, Z-One(anime) ban, Most token generation cards and spell searchers banned, and Snow fairy to limited.
For more info, view https://tinyurl.com/ycdhaysq (Google Doc of anime banlist changes and details on why)