### PR TITLE
Updated "Sunburn the Solar Calamity"

### DIFF
--- a/script/c101007028.lua
+++ b/script/c101007028.lua
@@ -19,6 +19,8 @@ end
 function s.cfilter(c,tp)
 	return c:IsPreviousPosition(POS_FACEUP) and c:IsPreviousLocation(LOCATION_MZONE) 
 		and c:GetPreviousControler()==tp and c:GetPreviousAttributeOnField() & ATTRIBUTE_FIRE ~=0
+		and (c:IsReason(REASON_DESTROY) and c:IsReason(REASON_EFFECT) and c:GetReasonPlayer()==1-tp 
+		or c:IsReason(REASON_BATTLE)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.cfilter,1,nil,tp)


### PR DESCRIPTION
Was not special summoning itself, even if a FIRE monster(s) was destroyed.