### PR TITLE
Small fix "Droll & Lock Bird"

### DIFF
--- a/script/c94145021.lua
+++ b/script/c94145021.lua
@@ -26,7 +26,7 @@ function c94145021.cfilter(c,tp)
 	return c:IsControler(tp) and c:IsPreviousLocation(LOCATION_DECK)
 end
 function c94145021.regcon(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetCurrentPhase()==PHASE_DRAW then return false end
+	if Duel.GetCurrentPhase()==PHASE_DRAW or Duel.GetCurrentPhase()==PHASE_DAMAGE then return false end
 	local v=0
 	if eg:IsExists(c94145021.cfilter,1,nil,0) then v=v+1 end
 	if eg:IsExists(c94145021.cfilter,1,nil,1) then v=v+2 end


### PR DESCRIPTION
Previously allowed to be activated after a Damage Step in which the opponent added a card from their Deck to their hand (i.e. Skelengel)