### PR TITLE
Fixed "Dragoncaller Magician"

### DIFF
--- a/script/c45667991.lua
+++ b/script/c45667991.lua
@@ -1,4 +1,5 @@
 --降竜の魔術師
+--Dragoncaller Magician
 function c45667991.initial_effect(c)
 	--pendulum summon
 	aux.EnablePendulumAttribute(c)
@@ -73,7 +74,7 @@ function c45667991.efop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local rc=c:GetReasonCard()
 	local e1=Effect.CreateEffect(rc)
-	e1:SetDescription(aux.Stringid(45667991,2))
+	e1:SetDescription(aux.Stringid(45667991,1))
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE+EFFECT_FLAG_CLIENT_HINT)
 	e1:SetCode(EFFECT_SET_ATTACK_FINAL)

--- a/script/c45667991.lua
+++ b/script/c45667991.lua
@@ -15,7 +15,7 @@ function c45667991.initial_effect(c)
 	c:RegisterEffect(e1)
 	--change race
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(45667991,1))
+	e2:SetDescription(aux.Stringid(45667991,0))
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetRange(LOCATION_MZONE)
 	e2:SetCountLimit(1)


### PR DESCRIPTION
Fixed the issue where the script, calling an incorrect string, would cause the monster summoned to have a incorrect tooltip.