### PR TITLE
"Hooked Shinin' Syncher" fix

### DIFF
--- a/script/c3111207.lua
+++ b/script/c3111207.lua
@@ -34,7 +34,7 @@ function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return not e:GetHandler():IsPublic() end
 end
 function s.spcon1(e,tp,eg,ep,ev,re,r,rp)
-	return bit.band(r,REASON_EFFECT)~=0 and e:GetHandler():IsPreviousLocation(LOCATION_DECK)
+	return e:GetHandler():IsPreviousLocation(LOCATION_DECK)
 end
 function s.sptg1(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0


### PR DESCRIPTION
Should be able to activate its first effect even if it's added to the hand by your normal draw.