### PR TITLE
Fixed "Doomking Balerdroch"

### DIFF
--- a/script/c39185163.lua
+++ b/script/c39185163.lua
@@ -1,82 +1,83 @@
 --死霊王 ドーハスーラ
---Drochshúile the Spirit King
+--Doomking Balerdroch
 --Script by dest
-function c39185163.initial_effect(c)
+local s,id=GetID()
+function s.initial_effect(c)
 	--negate / banish
 	local e1=Effect.CreateEffect(c)
-	e1:SetDescription(aux.Stringid(39185163,0))
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetCategory(CATEGORY_DISABLE+CATEGORY_REMOVE)
 	e1:SetType(EFFECT_TYPE_QUICK_O)
 	e1:SetCode(EVENT_CHAINING)
 	e1:SetRange(LOCATION_MZONE)
-	e1:SetCondition(c39185163.disrmcon)
-	e1:SetTarget(c39185163.disrmtg)
-	e1:SetOperation(c39185163.disrmop)
+	e1:SetCondition(s.disrmcon)
+	e1:SetTarget(s.disrmtg)
+	e1:SetOperation(s.disrmop)
 	c:RegisterEffect(e1)
 	--spsummon
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(39185163,3))
+	e2:SetDescription(aux.Stringid(id,3))
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e2:SetRange(LOCATION_GRAVE)
 	e2:SetCode(EVENT_PHASE+PHASE_STANDBY)
-	e2:SetCountLimit(1,39185163)
-	e2:SetCondition(c39185163.spcon)
-	e2:SetTarget(c39185163.sptg)
-	e2:SetOperation(c39185163.spop)
+	e2:SetCountLimit(1,id)
+	e2:SetCondition(s.spcon)
+	e2:SetTarget(s.sptg)
+	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
 end
-function c39185163.disrmcon(e,tp,eg,ep,ev,re,r,rp)
+function s.disrmcon(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) then return false end
 	local c=re:GetHandler()
 	local race=c:GetRace()
 	local loc=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
 	if loc==LOCATION_HAND then race=c:GetOriginalRace() end
 	if loc==LOCATION_MZONE and not c:IsLocation(LOCATION_MZONE) then race=c:GetPreviousRaceOnField() end
-	return race==RACE_ZOMBIE and not c:IsCode(39185163) and re:IsActiveType(TYPE_MONSTER)
+	return race==RACE_ZOMBIE and not c:IsCode(id) and re:IsActiveType(TYPE_MONSTER) and not e:GetHandler():IsStatus(STATUS_CHAINING) 
 end
-function c39185163.disrmtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local b1=Duel.IsChainDisablable(ev) and Duel.GetFlagEffect(tp,39185163)==0
+function s.disrmtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local b1=Duel.IsChainDisablable(ev) and Duel.GetFlagEffect(tp,id)==0
 	local b2=Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,nil)
-		and Duel.GetFlagEffect(tp,39185164)==0
+		and Duel.GetFlagEffect(tp,id+1)==0
 	if chk==0 then return b1 or b2 end
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 	local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,0)
 end
-function c39185163.disrmop(e,tp,eg,ep,ev,re,r,rp)
-	local b1=Duel.IsChainDisablable(ev) and Duel.GetFlagEffect(tp,39185163)==0
-	local b2=Duel.IsExistingMatchingCard(aux.NecroValleyFilter(c39185163.filter),tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,nil)
-		and Duel.GetFlagEffect(tp,39185164)==0
+function s.disrmop(e,tp,eg,ep,ev,re,r,rp)
+	local b1=Duel.IsChainDisablable(ev) and Duel.GetFlagEffect(tp,id)==0
+	local b2=Duel.IsExistingMatchingCard(aux.NecroValleyFilter(s.filter),tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,nil)
+		and Duel.GetFlagEffect(tp,id+1)==0
 	local op=0
-	if b1 and b2 then op=Duel.SelectOption(tp,aux.Stringid(39185163,1),aux.Stringid(39185163,2))
-	elseif b1 then op=Duel.SelectOption(tp,aux.Stringid(39185163,1))
-	elseif b2 then op=Duel.SelectOption(tp,aux.Stringid(39185163,2))+1
+	if b1 and b2 then op=Duel.SelectOption(tp,aux.Stringid(id,1),aux.Stringid(id,2))
+	elseif b1 then op=Duel.SelectOption(tp,aux.Stringid(id,1))
+	elseif b2 then op=Duel.SelectOption(tp,aux.Stringid(id,2))+1
 	else return end
 	if op==0 then
 		Duel.NegateEffect(ev)
-		Duel.RegisterFlagEffect(tp,39185163,RESET_PHASE+PHASE_END,0,1)
+		Duel.RegisterFlagEffect(tp,id,RESET_PHASE+PHASE_END,0,1)
 	else
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-		local g=Duel.SelectMatchingCard(tp,c39185163.filter,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,1,nil)
+		local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_MZONE+LOCATION_GRAVE,LOCATION_MZONE+LOCATION_GRAVE,1,1,nil)
 		Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
-		Duel.RegisterFlagEffect(tp,39185164,RESET_PHASE+PHASE_END,0,1)
+		Duel.RegisterFlagEffect(tp,id+1,RESET_PHASE+PHASE_END,0,1)
 	end
 end
-function c39185163.spcon(e,tp,eg,ep,ev,re,r,rp)
+function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_FZONE,LOCATION_FZONE,1,nil)
 end
-function c39185163.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 end
-function c39185163.spop(e,tp,eg,ep,ev,re,r,rp)
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP_DEFENSE)
 end
-function c39185163.filter(c)
+function s.filter(c)
 	return c:IsType(TYPE_MONSTER) and c:IsAbleToRemove()
 end
 


### PR DESCRIPTION
Fixed the bug where a single copy of "Doomking Balerdroch" would be able to activate both of its effects in the same chain, which is incorrect. Also includes an update for the ID handling used on its script.