### PR TITLE
Fixed "Infernoid Tierra"

### DIFF
--- a/script/c82734805.lua
+++ b/script/c82734805.lua
@@ -1,33 +1,35 @@
 --インフェルノイド・ティエラ
-function c82734805.initial_effect(c)
+--Infernoid Tierra
+local s,id=GetID()
+function s.initial_effect(c)
 	c:EnableReviveLimit()
 	aux.AddFusionProcMixRep(c,true,true,aux.FilterBoolFunction(Card.IsFusionSetCard,0xbb),1,99,14799437,23440231)
 	--spsummon success
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(82734805,0))
+	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
-	e2:SetCondition(c82734805.con)
-	e2:SetTarget(c82734805.tg)
-	e2:SetOperation(c82734805.op)
+	e2:SetCondition(s.con)
+	e2:SetTarget(s.tg)
+	e2:SetOperation(s.op)
 	c:RegisterEffect(e2)
 	--material check
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_SINGLE)
 	e3:SetCode(EFFECT_MATERIAL_CHECK)
-	e3:SetValue(c82734805.valcheck)
+	e3:SetValue(s.valcheck)
 	e3:SetLabelObject(e2)
 	c:RegisterEffect(e3)
 end
-c82734805.material_setcode=0xbb
-function c82734805.valcheck(e,c)
+s.material_setcode=0xbb
+function s.valcheck(e,c)
 	local ct=e:GetHandler():GetMaterial():GetClassCount(Card.GetFusionCode)
 	e:GetLabelObject():SetLabel(ct)
 end
-function c82734805.con(e,tp,eg,ep,ev,re,r,rp)
+function s.con(e,tp,eg,ep,ev,re,r,rp)
 	return bit.band(e:GetHandler():GetSummonType(),SUMMON_TYPE_FUSION)==SUMMON_TYPE_FUSION
 end
-function c82734805.tg(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.tg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ct=e:GetLabel()
 	local con3,con5,con8,con10=nil
 	if ct>=3 then
@@ -45,8 +47,9 @@ function c82734805.tg(e,tp,eg,ep,ev,re,r,rp,chk)
 		con10=Duel.GetFieldGroupCount(tp,LOCATION_HAND,LOCATION_HAND)>0
 	end
 	if chk==0 then return con3 or con5 or con8 or con10 end
+	if con5 then Duel.SetOperationInfo(0,CATEGORY_DECKDES,nil,0,PLAYER_ALL,3) end
 end
-function c82734805.op(e,tp,eg,ep,ev,re,r,rp)
+function s.op(e,tp,eg,ep,ev,re,r,rp)
 	local ct=e:GetLabel()
 	if ct>=3 then
 		local g1=Duel.GetMatchingGroup(Card.IsAbleToGrave,tp,LOCATION_EXTRA,0,nil)


### PR DESCRIPTION
Fixed the interaction with "Ash Blossom & Joyous Spring": if "Infernoid Tierra" is summoned by using 5 or more materials, its effects should be able to be negated by Ash, according to rulings. Also includes an update for ID handling.