### PR TITLE
Fixed "Toll Hike"

### DIFF
--- a/script/c44716890.lua
+++ b/script/c44716890.lua
@@ -1,7 +1,8 @@
 --通行増税
---Extra Toll
+--Toll Hike
 --Scripted by Eerie Code
-function c44716890.initial_effect(c)	
+local s,id=GetID()
+function s.initial_effect(c)	
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
@@ -14,14 +15,22 @@ function c44716890.initial_effect(c)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e2:SetTargetRange(1,1)
-	e2:SetCost(c44716890.atcost)
-	e2:SetOperation(c44716890.atop)
+	e2:SetCost(s.atcost)
+	e2:SetOperation(s.atop)
 	c:RegisterEffect(e2)
+	--accumulate
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(0x10000000+82003859)
+	e3:SetRange(LOCATION_SZONE)
+	e3:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e3:SetTargetRange(1,1)
+	c:RegisterEffect(e3)
 end
-function c44716890.atcost(e,c,tp)
+function s.atcost(e,c,tp)
 	return Duel.IsExistingMatchingCard(Card.IsAbleToGraveAsCost,tp,LOCATION_HAND,0,1,nil)
 end
-function c44716890.atop(e,tp,eg,ep,ev,re,r,rp)
+function s.atop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.IsAttackCostPaid()~=2 and e:GetHandler():IsLocation(LOCATION_SZONE) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local g=Duel.SelectMatchingCard(tp,Card.IsAbleToGraveAsCost,tp,LOCATION_HAND,0,1,1,nil)
@@ -29,4 +38,3 @@ function c44716890.atop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.AttackCostPaid()
 	end
 end
-


### PR DESCRIPTION
Fixed the bug where, even if you had multiple copies of "Toll Hike" but only 1 card to discard, you could still declare an attack, which should not happen according to rulings.