### PR TITLE
Fixed "Raidraptor - Wise Strix"

### DIFF
--- a/script/c100235071.lua
+++ b/script/c100235071.lua
@@ -70,7 +70,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.setcon(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED) 
-		and re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0xba)
+		and re:IsActiveType(TYPE_MONSTER) and re:GetHandler():IsSetCard(0xba) and re:GetHandler():IsType(TYPE_XYZ)
 end
 function s.setfilter(c)
 	return c:IsType(TYPE_SPELL) and c:IsSetCard(0x95) and c:IsSSetable()


### PR DESCRIPTION
Should only trigger the second effect when a "Raidraptor" Xyz monster activates its effects, not any "Raidraptor"