### PR TITLE
Fix "Salamangreat Falco"

### DIFF
--- a/script/c20618081.lua
+++ b/script/c20618081.lua
@@ -55,7 +55,7 @@ end
 function c20618081.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and c:IsRelateToEffect(e) then
+	if tc:IsRelateToEffect(e) and Duel.SendtoHand(tc,nil,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_HAND) and c:IsRelateToEffect(e) then
 		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
 	end
 end


### PR DESCRIPTION
Target must return to hand (not e.g. Extra Deck) to Special Summon