### PR TITLE
Zombie World fix vs Necrovalley

### DIFF
--- a/script/c4064256.lua
+++ b/script/c4064256.lua
@@ -39,7 +39,12 @@ end
 function c4064256.tg(e,c)
 	if c:GetFlagEffect(1)==0 then
 		c:RegisterFlagEffect(1,0,0,0)
-		local eff={c:GetCardEffect(EFFECT_NECRO_VALLEY)}
+		local eff
+		if c:IsLocation(LOCATION_MZONE) then
+			eff={Duel.GetPlayerEffect(c:GetControler(),EFFECT_NECRO_VALLEY)}
+		else
+			eff={c:GetCardEffect(EFFECT_NECRO_VALLEY)}
+		end
 		c:ResetFlagEffect(1)
 		for _,te in ipairs(eff) do
 			local op=te:GetOperation()


### PR DESCRIPTION
Monster type changing on field is the same effect as changing in Graveyard, thus the whole effect would be negated by Necrovalley