### PR TITLE
Updated TCG Forbidden/Limited List to 2018.12

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -1,5 +1,5 @@
-#[2018.9 TCG][2018.10 OCG][2018.10 Worlds][2018.9 Traditional][2018.10 Anime]
-!2018.9 TCG
+#[2018.12 TCG][2018.10 OCG][2018.12 Worlds][2018.12 Traditional][2018.12 Anime]
+!2018.12 TCG
 #Forbidden TCG
 53804307 0 --Blaster, Dragon Ruler of Infernos			MAIN DECK MONSTERS
 82301904 0 --Chaos Emperor Dragon - Envoy of the End
@@ -49,6 +49,7 @@
 85115440 0 --Zoodiac Broadbull
 39064822 0 --Knightmare Goblin
 4423206 0 --M-X-Saber Invoker
+5043010 0 --Firewall Dragon
 69243953 0 --Butterfly Dagger - Elma								SPELLS CARDS
 57953380 0 --Card of Safe Return
 4031928 0 --Change of Heart
@@ -119,9 +120,9 @@
 11877465 1 --Evigishki Mind Augus
 26674724 1 --Nekroz of Brionac
 89463537 1 --Nekroz of Unicore				
-30012506 1 --A-Assault Core
 40044918 1 --Elemental Hero Stratos
 33508719 1 --Morphing Jar
+28985331 1 --Armageddon Knight
 18239909 1 --Ignister Prominence, the Blasting Dracoslayer 		EXTRA DECK MONSTERS
 48063985 1 --Ritual Beast Ulti-Cannahawk
 39512984 1 --Gem-Knight Master Diamond
@@ -131,7 +132,6 @@
 46772449 1 --Evilswarm Exciton Knight
 24094258 1 --Heavymetalfoes Electrumite
 74586817 1 --Psy-Framelord Omega
-5043010 1 --Firewall Dragon
 14087893 1 --Book of Moon  										SPELLS CARDS
 81674782 1 --Dimensional Fissure
 95308449 1 --Final Countdown
@@ -176,12 +176,11 @@
 84749824 1 --Solemn Warning
 41420027 1 --Solemn Judgement
 #Semi limited TCG					
-55885348 2 --Kozmo Dark Destroyer			MONSTER CARDS
 92746535 2 --Luster Pendulum, the Dracoslayer			
 28297833 2 --Necroface			
-59297550 2 --Wind-up Magician			
+59297550 2 --Wind-up Magician
+9411399 2 --Destiny HERO - Malicious
 90953320 2 --T.G. Hyper Librarian			EXTRA DECK CARDS
-24224830 2 --Called By The Grave			SPELL CARDS
 23171610 2 --Limiter Removal			
 73915051 2 --Scapegoat			
 73628505 2 --Terraforming
@@ -351,7 +350,7 @@
 41420027 2 --神の宣告 Solemn Judgment
 35125879 2 --真竜皇の復活 True King's Return
 83555666 2 --破壊輪 Ring of Destruction
-!2018.10 Worlds
+!2018.12 Worlds
 #generated at https://alphakretin.github.io/html/worlds
 #forbidden worlds
 03078576 0 --Yata-Garasu
@@ -404,6 +403,7 @@
 43387895 0 --Supreme King Dragon Starving Venom
 48905153 0 --Zoodiac Drident
 54719828 0 --Number 16: Shock Master
+5043010 0 --Firewall Dragon
 61665245 0 --Summon Sorceress
 65536818 0 --Denglong, First of the Yang Zing
 81122844 0 --Wind-Up Carrier Zenmaity
@@ -462,7 +462,6 @@
 20758643 1 --Graff, Malembrance of the Burning Abyss
 26674724 1 --Nekroz of Brionac
 28297833 1 --Necroface
-30012506 1 --A-Assault Core
 33396948 1 --Exxodia the Forbidden One
 33508719 1 --Morphing Jar
 35272499 1 --Predaplant Ophrys Scorpio
@@ -564,9 +563,8 @@
 41420027 1 --Solemn Judgement
 54974237 1 --Eradicator Epidemic Virus
 #semi limited worlds
-55885348 2 --Kozmo Dark Destroyer
 59297550 2 --Wind-up Magician
-24224830 2 --Called By The Grave
+9411399 2 --Destiny HERO - Malicious
 73915051 2 --Scapegoat
 14558127 2 --Ash Blossom & Joyous Spring
 40605147 2 --Solemn Strike
@@ -577,10 +575,10 @@
 83555666 2 --Ring of Destruction
 98338152 2 --Sky Striker Mecha - Widow Anchor
 066399653 2 --Union Hangar
-!2018.9 Traditional
+!2018.12 Traditional
 #Forbidden TCG Traditional
 #Limited TCG Traditional
-30012506 1 --A-Assault Core			MAIN DECK MONSTERS
+28985331 1 --Armageddon Knight	MAIN DECK MONSTERS
 76794549 1 --Astrograph Sorcerer			
 9929398 1 --Blackwing - Gofu the Vague Shadow			
 53804307 1 --Blaster, Dragon Ruler of Infernos			
@@ -646,7 +644,7 @@
 30539496 1 --True King Lithosagym, the Disaster			
 44910027 1 --Victory Dragon			
 3078576 1 --Yata-Garasu			
-78872731 1 --Zoodiac Ratpier			
+78872731 1 --Zoodiac Ratpier		
 25862681 1 --Ancient Fairy Dragon			EXTRA DECK MONSTERS
 27552504 1 --Beatrice, Lady of Eternal			
 581014 1 --Daigusto Emeral			
@@ -655,7 +653,7 @@
 20366274 1 --El Shaddoll Construct			
 17412721 1 --Elder Entity Norden			
 46772449 1 --Evilswarm Exciton Knight			
-5043010 1 --Firewall Dragon			
+5043010 1 --Firewall Dragon		
 39512984 1 --Gem-Knight Master Diamond			
 24094258 1 --Heavymetalfoes Electrumite			
 18239909 1 --Ignister Prominence, the Blasting Dracoslayer			
@@ -754,16 +752,15 @@
 5851097 1 --Vanity's Emptiness			
 17078030 1 --Wall of Revealing light
 #Semi Limited TCG Traditional
-55885348 2 --Kozmo Dark Destroyer			MONSTER CARDS
 92746535 2 --Luster Pendulum, the Dracoslayer			
-28297833 2 --Necroface			
-59297550 2 --Wind-up Magician			
-90953320 2 --T.G. Hyper Librarian			EXTRA DECK CARDS
-24224830 2 --Called By The Grave			SPELL CARDS
+28297833 2 --Necroface
+59297550 2 --Wind-up Magician
+9411399 2 --Destiny HERO - Malicious		
+90953320 2 --T.G. Hyper Librarian
 23171610 2 --Limiter Removal			
 73915051 2 --Scapegoat			
 73628505 2 --Terraforming
-!2018.10 Anime
+!2018.12 Anime
 #worlds list
 #generated at https://alphakretin.github.io/html/worlds
 #forbidden worlds
@@ -817,6 +814,7 @@
 43387895 0 --Supreme King Dragon Starving Venom
 48905153 0 --Zoodiac Drident
 54719828 0 --Number 16: Shock Master
+5043010 0 --Firewall Dragon
 61665245 0 --Summon Sorceress
 65536818 0 --Denglong, First of the Yang Zing
 81122844 0 --Wind-Up Carrier Zenmaity
@@ -875,7 +873,6 @@
 20758643 1 --Graff, Malembrance of the Burning Abyss
 26674724 1 --Nekroz of Brionac
 28297833 1 --Necroface
-30012506 1 --A-Assault Core
 33396948 1 --Exxodia the Forbidden One
 33508719 1 --Morphing Jar
 35272499 1 --Predaplant Ophrys Scorpio
@@ -966,7 +963,7 @@
 97211663 1 --Nekroz Cycle
 99330325 1 --Interrupted Kaiju Slumber
 21076084 1 --Trickstar Reincarnation
-36468556 1 --Ceasefire 
+36468556 1 --Ceasefire
 35125879 1 --True King's Return
 82732705 1 --Skill Drain
 73599290 1 --Soul Drain
@@ -977,9 +974,8 @@
 41420027 1 --Solemn Judgement
 54974237 1 --Eradicator Epidemic Virus
 #semi limited worlds
-55885348 2 --Kozmo Dark Destroyer
 59297550 2 --Wind-up Magician
-24224830 2 --Called By The Grave
+9411399 2 --Destiny HERO - Malicious
 73915051 2 --Scapegoat
 14558127 2 --Ash Blossom & Joyous Spring
 40605147 2 --Solemn Strike


### PR DESCRIPTION
Changes include Firewall Dragon (Forbidden), Armageddon Knight (Limited), Destiny HERO – Malicious (Semi-Limited), A-Assault Core, Kozmo Dark Destroyer and Called by the Grave (Unlimited)

Also includes updates to TCG Traditional, Worlds and Anime to match TCG 2018.12.