### PR TITLE
Fix conditional "Unaffected by card effects" monsters

### DIFF
--- a/script/c41302052.lua
+++ b/script/c41302052.lua
@@ -1,7 +1,8 @@
 --トリックスター・ベラマドンナ
 --Trickstar Bella Madonna
 --Script by nekrozar
-function c41302052.initial_effect(c)
+local s,id=GetID()
+function s.initial_effect(c)
 	--link summon
 	aux.AddLinkProcedure(c,aux.FilterBoolFunction(Card.IsLinkSetCard,0xfb),2)
 	c:EnableReviveLimit()
@@ -11,46 +12,45 @@ function c41302052.initial_effect(c)
 	e1:SetCode(EFFECT_IMMUNE_EFFECT)
 	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e1:SetRange(LOCATION_MZONE)
-	--e1:SetCondition(c41302052.imcon) --handled in value for mid-resolution updating
-	e1:SetValue(c41302052.immval)
+	--e1:SetCondition(s.imcon) --handled in value for mid-resolution updating
+	e1:SetValue(s.immval)
 	c:RegisterEffect(e1)
 	--damage
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(41302052,0))
+	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetCategory(CATEGORY_DAMAGE)
 	e2:SetType(EFFECT_TYPE_IGNITION)
 	e2:SetRange(LOCATION_MZONE)
-	e2:SetCountLimit(1,41302052)
-	e2:SetCondition(c41302052.damcon)
-	e2:SetTarget(c41302052.damtg)
-	e2:SetOperation(c41302052.damop)
+	e2:SetCountLimit(1,id)
+	e2:SetCondition(s.damcon)
+	e2:SetTarget(s.damtg)
+	e2:SetOperation(s.damop)
 	c:RegisterEffect(e2)
 end
-function c41302052.imcon(e)
+function s.imcon(e)
 	local c=e:GetHandler()
 	return c:IsSummonType(SUMMON_TYPE_LINK) and c:GetLinkedGroupCount()==0
 end
-function c41302052.immval(e,te)
-	return te:GetOwner()~=e:GetHandler() and te:IsActivated() and c41302052.imcon(e) --condition handling for mid-resolution updating
+function s.immval(e,te)
+	return te:GetOwner()~=e:GetHandler() and te:IsActivated() and s.imcon(e) --condition handling for mid-resolution updating
 end
-function c41302052.damcon(e,tp,eg,ep,ev,re,r,rp)
+function s.damcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetLinkedGroupCount()==0
 end
-function c41302052.damfilter(c)
+function s.damfilter(c)
 	return c:IsSetCard(0xfb) and c:IsType(TYPE_MONSTER)
 end
-function c41302052.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(c41302052.damfilter,tp,LOCATION_GRAVE,0,1,nil) end
-	local g=Duel.GetMatchingGroup(c41302052.damfilter,tp,LOCATION_GRAVE,0,nil)
+function s.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.damfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	local g=Duel.GetMatchingGroup(s.damfilter,tp,LOCATION_GRAVE,0,nil)
 	local dam=g:GetClassCount(Card.GetCode)*200
 	Duel.SetTargetPlayer(1-tp)
 	Duel.SetTargetParam(dam)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,dam)
 end
-function c41302052.damop(e,tp,eg,ep,ev,re,r,rp)
+function s.damop(e,tp,eg,ep,ev,re,r,rp)
 	local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
-	local g=Duel.GetMatchingGroup(c41302052.damfilter,tp,LOCATION_GRAVE,0,nil)
+	local g=Duel.GetMatchingGroup(s.damfilter,tp,LOCATION_GRAVE,0,nil)
 	local dam=g:GetClassCount(Card.GetCode)*200
 	Duel.Damage(p,dam,REASON_EFFECT)
 end
-

--- a/script/c41302052.lua
+++ b/script/c41302052.lua
@@ -11,7 +11,7 @@ function c41302052.initial_effect(c)
 	e1:SetCode(EFFECT_IMMUNE_EFFECT)
 	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
 	e1:SetRange(LOCATION_MZONE)
-	e1:SetCondition(c41302052.imcon)
+	--e1:SetCondition(c41302052.imcon) --handled in value for mid-resolution updating
 	e1:SetValue(c41302052.immval)
 	c:RegisterEffect(e1)
 	--damage
@@ -31,7 +31,7 @@ function c41302052.imcon(e)
 	return c:IsSummonType(SUMMON_TYPE_LINK) and c:GetLinkedGroupCount()==0
 end
 function c41302052.immval(e,te)
-	return te:GetOwner()~=e:GetHandler() and te:IsActivated()
+	return te:GetOwner()~=e:GetHandler() and te:IsActivated() and c41302052.imcon(e) --condition handling for mid-resolution updating
 end
 function c41302052.damcon(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():GetLinkedGroupCount()==0

--- a/script/c63504681.lua
+++ b/script/c63504681.lua
@@ -1,0 +1,99 @@
+--No.86 H－C ロンゴミアント
+--Number 86: Heroic Champion - Rhongomyniad
+local s,id=GetID()
+function s.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,aux.FilterBoolFunction(Card.IsRace,RACE_WARRIOR),4,2,nil,nil,5)
+	c:EnableReviveLimit()
+	--remove material
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e1:SetCode(EVENT_PHASE+PHASE_END)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCondition(s.rmcon)
+	e1:SetOperation(s.rmop)
+	c:RegisterEffect(e1)
+	--battle indestructable
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
+	e2:SetValue(1)
+	e2:SetCondition(s.effcon)
+	e2:SetLabel(1)
+	c:RegisterEffect(e2)
+	--atk/def
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCode(EFFECT_UPDATE_ATTACK)
+	e3:SetValue(1500)
+	e3:SetCondition(s.effcon)
+	e3:SetLabel(2)
+	c:RegisterEffect(e3)
+	local e4=e3:Clone()
+	e4:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e4)
+	--immune
+	local e5=Effect.CreateEffect(c)
+	e5:SetType(EFFECT_TYPE_SINGLE)
+	e5:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e5:SetRange(LOCATION_MZONE)
+	e5:SetCode(EFFECT_IMMUNE_EFFECT)
+	e5:SetValue(s.efilter)
+	--e5:SetCondition(s.effcon) --handled in Value for mid-resolution updating
+	e5:SetLabel(3)
+	c:RegisterEffect(e5)
+	--disable spsummon
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_FIELD)
+	e6:SetRange(LOCATION_MZONE)
+	e6:SetCode(EFFECT_CANNOT_SUMMON)
+	e6:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e6:SetTargetRange(0,1)
+	e6:SetCondition(s.effcon)
+	e6:SetLabel(4)
+	c:RegisterEffect(e6)
+	local e7=e6:Clone()
+	e7:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	c:RegisterEffect(e7)
+	--destroy
+	local e8=Effect.CreateEffect(c)
+	e8:SetDescription(aux.Stringid(id,1))
+	e8:SetCategory(CATEGORY_DESTROY)
+	e8:SetType(EFFECT_TYPE_IGNITION)
+	e8:SetCountLimit(1)
+	e8:SetRange(LOCATION_MZONE)
+	e8:SetCondition(s.effcon)
+	e8:SetTarget(s.destg)
+	e8:SetOperation(s.desop)
+	e8:SetLabel(5)
+	c:RegisterEffect(e8)
+end
+s.xyz_number=86
+function s.rmcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()~=tp
+end
+function s.rmop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:GetOverlayCount()>0 then
+		c:RemoveOverlayCard(tp,1,1,REASON_EFFECT)
+	end
+end
+function s.effcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetOverlayCount()>=e:GetLabel()
+end
+function s.efilter(e,te)
+	return te:GetOwner()~=e:GetOwner() and s.effcon(e) --condition handling for mid-resolution updating
+end
+function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(aux.TRUE,tp,0,LOCATION_ONFIELD,1,nil) end
+	local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,#g,0,0)
+end
+function s.desop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)
+	Duel.Destroy(g,REASON_EFFECT)
+end


### PR DESCRIPTION
If condition ceases to be true, stops applying immediately. This is a temporary workaround that will need to be reverted when the core is updated to handle conditions properly.