### PR TITLE
small fix for Madolche Teacher Glassouffle

### DIFF
--- a/script/c101008039.lua
+++ b/script/c101008039.lua
@@ -52,6 +52,7 @@ function s.immop(e,tp,eg,ep,ev,re,r,rp)
         e1:SetRange(LOCATION_MZONE)
         e1:SetCode(EFFECT_IMMUNE_EFFECT)
         e1:SetValue(s.efilter)
+        e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
         tc:RegisterEffect(e1)
     end
 end


### PR DESCRIPTION
was not resetting the lingering effect of immunity.