### PR TITLE
fix for Shinobird's Calling

### DIFF
--- a/script/c73055622.lua
+++ b/script/c73055622.lua
@@ -2,7 +2,7 @@
 --Shinobird's Calling
 local s,id=GetID()
 function s.initial_effect(c)
-	local e1=aux.AddRitualProcEqual(c,s.ritualfil,nil,nil,s.extrafil)
+	local e1=aux.AddRitualProcGreater(c,s.ritualfil,nil,s.extrafil)
 	if not GhostBelleTable then GhostBelleTable={} end
 	table.insert(GhostBelleTable,e1)
 end


### PR DESCRIPTION
was using wrong proc for the ritual summon.