### PR TITLE
fix for Fairy Dragon Larvalaur

### DIFF
--- a/script/c8972398.lua
+++ b/script/c8972398.lua
@@ -33,7 +33,7 @@ function s.cfilter(c,tp,rp)
 		(c:IsReason(REASON_BATTLE) or (c:IsReason(REASON_EFFECT) and rp~=tp))
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return eg:IsExists(s.cfilter,1,nil,tp,rp)
+	return eg:IsExists(s.cfilter,1,nil,tp,rp) and not eg:IsContains(e:GetHandler())
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0


### PR DESCRIPTION
should not triger first effect if it is caused by it own destruction.