### PR TITLE
Fixed "Jinzo"

### DIFF
--- a/script/c77585513.lua
+++ b/script/c77585513.lua
@@ -19,7 +19,7 @@ function s.initial_effect(c)
 	e2:SetTargetRange(1,1)
 	e2:SetValue(s.aclimit)
 	e2:SetReset(RESET_PHASE+PHASE_END)
-	Duel.RegisterEffect(e2,tp)
+	c:RegisterEffect(e2)
 	--disable
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_FIELD)

--- a/script/c77585513.lua
+++ b/script/c77585513.lua
@@ -1,5 +1,7 @@
 --人造人間－サイコ・ショッカー
-function c77585513.initial_effect(c)
+--Jinzo
+local s,id=GetID()
+function s.initial_effect(c)
 	--cannot trigger
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
@@ -9,40 +11,52 @@ function c77585513.initial_effect(c)
 	e1:SetTargetRange(0xa,0xa)
 	e1:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
 	c:RegisterEffect(e1)
-	--disable
+	--cannot activate
 	local e2=Effect.CreateEffect(c)
 	e2:SetType(EFFECT_TYPE_FIELD)
-	e2:SetCode(EFFECT_DISABLE)
-	e2:SetRange(LOCATION_MZONE)
-	e2:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
-	e2:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
-	c:RegisterEffect(e2)
-	--disable effect
+	e2:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetTargetRange(1,1)
+	e2:SetValue(s.aclimit)
+	e2:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e2,tp)
+	--disable
 	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e3:SetCode(EVENT_CHAIN_SOLVING)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_DISABLE)
 	e3:SetRange(LOCATION_MZONE)
-	e3:SetOperation(c77585513.disop)
+	e3:SetTargetRange(LOCATION_SZONE,LOCATION_SZONE)
+	e3:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
 	c:RegisterEffect(e3)
-	--disable trap monster
+	--disable effect
 	local e4=Effect.CreateEffect(c)
-	e4:SetType(EFFECT_TYPE_FIELD)
-	e4:SetCode(EFFECT_DISABLE_TRAPMONSTER)
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e4:SetCode(EVENT_CHAIN_SOLVING)
 	e4:SetRange(LOCATION_MZONE)
-	e4:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
-	e4:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
+	e4:SetOperation(s.disop)
 	c:RegisterEffect(e4)
-	--Double Snare
+	--disable trap monster
 	local e5=Effect.CreateEffect(c)
-	e5:SetType(EFFECT_TYPE_SINGLE)
-	e5:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e5:SetType(EFFECT_TYPE_FIELD)
+	e5:SetCode(EFFECT_DISABLE_TRAPMONSTER)
 	e5:SetRange(LOCATION_MZONE)
-	e5:SetCode(3682106)
+	e5:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e5:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_TRAP))
 	c:RegisterEffect(e5)
+	--Double Snare
+	local e6=Effect.CreateEffect(c)
+	e6:SetType(EFFECT_TYPE_SINGLE)
+	e6:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_SINGLE_RANGE)
+	e6:SetRange(LOCATION_MZONE)
+	e6:SetCode(3682106)
+	c:RegisterEffect(e6)
 end
-function c77585513.disop(e,tp,eg,ep,ev,re,r,rp)
+function s.disop(e,tp,eg,ep,ev,re,r,rp)
 	local tl=Duel.GetChainInfo(ev,CHAININFO_TRIGGERING_LOCATION)
 	if tl==LOCATION_SZONE and re:IsActiveType(TYPE_TRAP) then
 		Duel.NegateEffect(ev)
 	end
+end
+function s.aclimit(e,re,tp)
+	return re:GetHandler():IsType(TYPE_TRAP)
 end


### PR DESCRIPTION
Fixed an interaction with "Dinomight Knight, the True Dracofighter" where the player would still be able to activate the Trap card even if "Jinzo"'s effect is applying. The player should only be able to add it to hand.