### PR TITLE
fix for Death Control of the Evil Eye

### DIFF
--- a/script/c100412038.lua
+++ b/script/c100412038.lua
@@ -84,7 +84,7 @@ function s.descon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if c:IsStatus(STATUS_DESTROY_CONFIRMED) then return false end
 	local tc=c:GetFirstCardTarget()
-	return tc and eg:IsContains(tc) and tc:IsReason(REASON_DESTROY)
+	return tc and eg:IsContains(tc)
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Destroy(e:GetHandler(),REASON_EFFECT)


### PR DESCRIPTION
should destroy if target leave field and not when it is destroyed only.