### PR TITLE
"Spell-Mining Cave" fix

### DIFF
--- a/script/c76375976.lua
+++ b/script/c76375976.lua
@@ -57,7 +57,7 @@ function s.conopp(e)
 	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)<Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)
 end
 function s.aclimit(e,re,tp)
-	return re:IsActiveType(TYPE_MONSTER) and not re:GetHandler():IsImmuneToEffect(e)
+	return re:IsActiveType(TYPE_MONSTER)
 end
 function s.descon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,0)==Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)


### PR DESCRIPTION
According to rulings, even if a monster is unaffected it cannot activate its effect or attack.