### PR TITLE
"The Dragon's Bead" fix

### DIFF
--- a/script/c92408984.lua
+++ b/script/c92408984.lua
@@ -79,6 +79,7 @@ function s.activate(teg,tev,tre)
 				if e:GetHandler():IsRelateToEffect(e) and Duel.NegateEffect(tev) and tre:GetHandler():IsRelateToEffect(tre) then
 					Duel.Destroy(teg,REASON_EFFECT)
 				end
+				teg:DeleteGroup()
 			end
 end
 function s.disop(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c92408984.lua
+++ b/script/c92408984.lua
@@ -1,23 +1,25 @@
 --ドラゴンの宝珠
-function c92408984.initial_effect(c)
+--The Dragon's Bead
+local s,id=GetID()
+function s.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
-	e1:SetCost(c92408984.cost)
-	e1:SetTarget(c92408984.target)
+	e1:SetCost(s.cost)
+	e1:SetTarget(s.target)
 	c:RegisterEffect(e1)
 	--instant(chain)
 	local e2=Effect.CreateEffect(c)
-	e2:SetDescription(aux.Stringid(92408984,0))
+	e2:SetDescription(aux.Stringid(id,0))
 	e2:SetCategory(CATEGORY_DISABLE+CATEGORY_DESTROY)
 	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetRange(LOCATION_SZONE)
 	e2:SetCode(EVENT_CHAINING)
-	e2:SetCondition(c92408984.discon)
-	e2:SetCost(c92408984.discost)
-	e2:SetTarget(c92408984.distg)
-	e2:SetOperation(c92408984.disop)
+	e2:SetCondition(s.discon)
+	e2:SetCost(s.discost)
+	e2:SetTarget(s.distg)
+	e2:SetOperation(s.disop)
 	c:RegisterEffect(e2)
 	--Double Snare
 	local e6=Effect.CreateEffect(c)
@@ -27,14 +29,14 @@ function c92408984.initial_effect(c)
 	e6:SetCode(3682106)
 	c:RegisterEffect(e6)
 end
-function c92408984.cfilter(c)
+function s.cfilter(c)
 	return c:IsLocation(LOCATION_MZONE) and c:IsFaceup() and c:IsRace(RACE_DRAGON)
 end
-function c92408984.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e:SetLabel(1)
 	return true
 end
-function c92408984.target(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		e:SetLabel(0)
 		return true
@@ -43,26 +45,27 @@ function c92408984.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if ct<=0 then return end
 	local pe,p=Duel.GetChainInfo(ct,CHAININFO_TRIGGERING_EFFECT,CHAININFO_TRIGGERING_PLAYER)
 	local g=Group.FromCards(pe:GetHandler())
-	if c92408984.discon(e,tp,g,p,ct,pe,0,p) and (e:GetLabel()~=1 or c92408984.discost(e,tp,g,p,ct,pe,0,p,0)) and c92408984.distg(e,tp,g,p,ct,pe,0,p,0) then
+	if s.discon(e,tp,g,p,ct,pe,0,p) and (e:GetLabel()~=1 or s.discost(e,tp,g,p,ct,pe,0,p,0)) and s.distg(e,tp,g,p,ct,pe,0,p,0) 
+		and Duel.SelectYesNo(tp,94) then
 		e:SetCategory(CATEGORY_DISABLE+CATEGORY_DESTROY)
-		e:SetOperation(c92408984.activate(g,ct,pe))
-		if e:GetLabel()==1 then c92408984.discost(e,tp,g,p,ct,pe,0,p,1) end
-		c92408984.distg(e,tp,g,p,ct,pe,0,p,1)
+		e:SetOperation(s.activate(g,ct,pe))
+		if e:GetLabel()==1 then s.discost(e,tp,g,p,ct,pe,0,p,1) end
+		s.distg(e,tp,g,p,ct,pe,0,p,1)
 	else
 		e:SetCategory(0)
 		e:SetOperation(nil)
 	end
 end
-function c92408984.discon(e,tp,eg,ep,ev,re,r,rp)
-	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) or not re:GetHandler():IsType(TYPE_TRAP) then return false end
+function s.discon(e,tp,eg,ep,ev,re,r,rp)
+	if not re:IsHasProperty(EFFECT_FLAG_CARD_TARGET) or not (re:IsActiveType(TYPE_TRAP) and re:IsHasType(EFFECT_TYPE_ACTIVATE)) then return false end
 	local tg=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
-	return tg and tg:IsExists(c92408984.cfilter,1,nil) and Duel.IsChainDisablable(ev)
+	return tg and tg:IsExists(s.cfilter,1,nil) and Duel.IsChainDisablable(ev)
 end
-function c92408984.discost(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.discost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,e:GetHandler()) end
 	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
 end
-function c92408984.distg(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_DISABLE,eg,1,0,0)
 	if eg:GetFirst():IsOnField() then
@@ -70,14 +73,15 @@ function c92408984.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 		Duel.SetOperationInfo(0,CATEGORY_DESTROY,eg,1,0,0)
 	end
 end
-function c92408984.activate(teg,tev,tre)
+function s.activate(teg,tev,tre)
+	teg:KeepAlive()
 	return	function(e,tp,eg,ep,ev,re,r,rp)
 				if e:GetHandler():IsRelateToEffect(e) and Duel.NegateEffect(tev) and tre:GetHandler():IsRelateToEffect(tre) then
 					Duel.Destroy(teg,REASON_EFFECT)
 				end
 			end
 end
-function c92408984.disop(e,tp,eg,ep,ev,re,r,rp)
+function s.disop(e,tp,eg,ep,ev,re,r,rp)
 	if e:GetHandler():IsRelateToEffect(e) and Duel.NegateEffect(ev) and re:GetHandler():IsRelateToEffect(re) then
 		Duel.Destroy(eg,REASON_EFFECT)
 	end


### PR DESCRIPTION
- Fixed the effect fizzling out if you used it when activating the card itself.
- Added a Yes/No prompt asking if you want to use the effect on the initial card activation.
- According to rulings, should only be able to negate the effect of a Trap Card being activated, not of a Trap Effect.