### PR TITLE
"Super Anti-Kaiju War Machine Mecha-Thunder-King" fix

### DIFF
--- a/script/c101007081.lua
+++ b/script/c101007081.lua
@@ -67,7 +67,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 			local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.spfilter),tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
-			if #g>0 then Duel.SpecialSummon(g,0,tp,p,false,false,POS_FACEUP) end
+			if #g>0 then Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP) end
 		end
 	end
 end


### PR DESCRIPTION
Parameter typo caused the monster to be Special Summoned to the wrong player's field with the first effect.