### PR TITLE
Fixed "Crusadia Testament"

### DIFF
--- a/script/c87497553.lua
+++ b/script/c87497553.lua
@@ -50,7 +50,7 @@ function s.drcon(e,tp,eg,ep,ev,re,r,rp)
 	local d=Duel.GetAttackTarget()
 	if not d then return false end
 	if a:IsStatus(STATUS_OPPO_BATTLE) and d:IsControler(tp) then a,d=d,a end
-	if a:IsType(TYPE_LINK) and a:IsSetCard(0x116) and not a:IsStatus(STATUS_BATTLE_DESTROYED) and d:IsStatus(STATUS_BATTLE_DESTROYED) then
+	if a:IsType(TYPE_LINK) and a:IsSetCard(0x116) and d:IsStatus(STATUS_BATTLE_DESTROYED) then
 		e:SetLabelObject(a)
 		return true
 	else return false end


### PR DESCRIPTION
Fix to match "Abyss Script - Fire Dragon's Lair" and "F.A. Circuit Gran Prix"'s rulings in regards of activating it if the Crusadia Link monster is destroyed by battle with a monster with the same ATK.