### PR TITLE
"Cubic Dharma" fix

### DIFF
--- a/script/c100236117.lua
+++ b/script/c100236117.lua
@@ -32,7 +32,7 @@ function s.initial_effect(c)
 	--to hand
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(id,2))
-	e4:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH)
+	e4:SetCategory(CATEGORY_TOHAND)
 	e4:SetType(EFFECT_TYPE_IGNITION)
 	e4:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e4:SetRange(LOCATION_GRAVE)


### PR DESCRIPTION
GY effect shouldn't be negatable by Ash Blossom (incorrect category).