### PR TITLE
fix for Prank-Kids Rocket Ride

### DIFF
--- a/script/c18514525.lua
+++ b/script/c18514525.lua
@@ -18,6 +18,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 	--spsummon
 	local e2=Effect.CreateEffect(c)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetDescription(aux.Stringid(id,1))
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e2:SetType(EFFECT_TYPE_IGNITION)


### PR DESCRIPTION
Was missing the targeting property in the script.