### PR TITLE
"Astrograph Sorcerer" & "Formud Skipper" fixes

### DIFF
--- a/script/c50366775.lua
+++ b/script/c50366775.lua
@@ -1,4 +1,5 @@
 --フォーマッド・スキッパー
+--Formud Skipper
 local s,id=GetID()
 function s.initial_effect(c)
 	--link
@@ -14,7 +15,7 @@ function s.initial_effect(c)
 	local e2=Effect.CreateEffect(c)
 	e2:SetCode(CATEGORY_TOHAND+CATEGORY_SEARCH)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
-	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetCode(EVENT_BE_MATERIAL)
 	e2:SetProperty(EFFECT_FLAG_DELAY)
 	e2:SetCountLimit(1,id+1)
 	e2:SetCondition(s.thcon)
@@ -69,7 +70,7 @@ function s.chngcon(scard,sumtype,tp)
 	return sumtype==SUMMON_TYPE_LINK
 end
 function s.thcon(e,tp,eg,ep,ev,re,r,rp)
-	return e:GetHandler():IsReason(REASON_LINK)
+	return e:GetHandler():IsLocation(LOCATION_GRAVE) and r==REASON_LINK
 end
 function s.thfilter(c)
 	return c:IsRace(RACE_CYBERSE) and c:IsLevelAbove(5) and c:IsAbleToHand()

--- a/script/c76794549.lua
+++ b/script/c76794549.lua
@@ -1,4 +1,5 @@
 --アストログラフ・マジシャン
+--Astrograph Sorcerer
 local s,id=GetID()
 function s.initial_effect(c)
 	aux.EnablePendulumAttribute(c)
@@ -96,7 +97,7 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
 end
-function s.thfilter1(c,tp,id)
+function s.thfilter1(c,tp)
 	return c:IsType(TYPE_MONSTER) and c:GetFlagEffect(id)~=0
 		and (c:IsLocation(LOCATION_GRAVE) or c:IsFaceup())
 		and Duel.IsExistingMatchingCard(s.thfilter2,tp,LOCATION_DECK,0,1,nil,c:GetCode())
@@ -108,7 +109,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if not c:IsRelateToEffect(e) then return end
 	if Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)~=0 then
-		local g=Duel.GetMatchingGroup(s.thfilter1,tp,0x70,0x70,nil,tp,Duel.GetTurnCount())
+		local g=Duel.GetMatchingGroup(s.thfilter1,tp,0x70,0x70,nil,tp)
 		if #g>0 and Duel.SelectYesNo(tp,aux.Stringid(id,4)) then
 			Duel.BreakEffect()
 			Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(id,7))


### PR DESCRIPTION
- Astrograph Sorcerer: a leftover unused param caused an issue with the search part of its effect
- Formud Skipper: the search effect shouldn't trigger if the Link Summon is negated