### PR TITLE
fix for Trickstar Bouquet

### DIFF
--- a/script/c99890852.lua
+++ b/script/c99890852.lua
@@ -36,6 +36,8 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:GetNext()
 	if hc~=e:GetLabelObject() then tc,hc=hc,tc end
 	if hc:IsFaceup() and tc:IsFaceup() and Duel.SendtoHand(hc,nil,REASON_EFFECT)~=0 then
+		local sg=Duel.GetOperatedGroup()
+		if not sg:IsExists(Card.IsLocation,1,nil,LOCATION_HAND) then return end
 		local atk=hc:GetBaseAttack()
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_SINGLE)

--- a/script/c99890852.lua
+++ b/script/c99890852.lua
@@ -16,7 +16,7 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function s.filter(c,tp)
-	return c:IsFaceup() and c:IsSetCard(0xfb)
+	return c:IsFaceup() and c:IsSetCard(0xfb) and not c:IsType(TYPE_FUSION|TYPE_SYNCHRO|TYPE_TOKEN|TYPE_XYZ|TYPE_LINK)
 		and c:IsAbleToHand() and Duel.IsExistingMatchingCard(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,c)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
@@ -45,4 +45,3 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		tc:RegisterEffect(e1)
 	end
 end
-


### PR DESCRIPTION
Shouldn't be able to target a trickstar link (or any extra deck type/token) to return to hand.