### PR TITLE
"World Legacy Pawns" & "Crimson Knight Vampire Bram" fixes

### DIFF
--- a/script/c38250531.lua
+++ b/script/c38250531.lua
@@ -1,0 +1,90 @@
+--紅貴士－ヴァンパイア・ブラム
+--Crimson Knight Vampire Bram
+local s,id=GetID()
+function s.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,aux.FilterBoolFunctionEx(Card.IsRace,RACE_ZOMBIE),5,2)
+	c:EnableReviveLimit()
+	--spsummon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1,id)
+	e1:SetCost(s.spcost)
+	e1:SetTarget(s.sptg)
+	e1:SetOperation(s.spop)
+	c:RegisterEffect(e1,false,1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e2:SetCode(EVENT_TO_GRAVE)
+	e2:SetOperation(s.spreg)
+	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(id,1))
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e3:SetRange(LOCATION_GRAVE)
+	e3:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e3:SetCondition(s.spcon2)
+	e3:SetTarget(s.sptg2)
+	e3:SetOperation(s.spop2)
+	e3:SetLabelObject(e2)
+	c:RegisterEffect(e3)
+end
+function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
+	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
+end
+function s.spfilter(c,e,tp)
+	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(1-tp) and s.spfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(s.spfilter,tp,0,LOCATION_GRAVE,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,s.spfilter,tp,0,LOCATION_GRAVE,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc:IsRelateToEffect(e) and Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)>0 then
+		local e1=Effect.CreateEffect(e:GetHandler())
+		e1:SetType(EFFECT_TYPE_FIELD)
+		e1:SetCode(EFFECT_CANNOT_ATTACK)
+		e1:SetTargetRange(LOCATION_MZONE,0)
+		e1:SetTarget(s.ftarget)
+		e1:SetLabel(tc:GetFieldID())
+		e1:SetReset(RESET_PHASE+PHASE_END)
+		Duel.RegisterEffect(e1,tp)
+	end
+end
+function s.ftarget(e,c)
+	return e:GetLabel()~=c:GetFieldID()
+end
+function s.spreg(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if rp~=tp and c:IsReason(REASON_DESTROY) and c:IsPreviousLocation(LOCATION_ONFIELD) then
+		e:SetLabel(Duel.GetTurnCount()+1)
+		c:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,2)
+	end
+end
+function s.spcon2(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetLabelObject():GetLabel()==Duel.GetTurnCount() and e:GetHandler():GetFlagEffect(id)>0
+end
+function s.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return true end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+	e:GetHandler():ResetFlagEffect(id)
+end
+function s.spop2(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.SpecialSummon(c,1,tp,tp,false,false,POS_FACEUP_DEFENSE)
+	end
+end

--- a/script/c89320376.lua
+++ b/script/c89320376.lua
@@ -1,0 +1,118 @@
+--星遺物の傀儡
+--World Legacy Pawns
+local s,id=GetID()
+function s.initial_effect(c)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(s.target)
+	c:RegisterEffect(e1)
+	--pos (face-down)
+	local e2=Effect.CreateEffect(c)
+	e2:SetCategory(CATEGORY_POSITION)
+	e2:SetDescription(aux.Stringid(id,0))
+	e2:SetType(EFFECT_TYPE_QUICK_O)
+	e2:SetCode(EVENT_FREE_CHAIN)
+	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e2:SetRange(LOCATION_SZONE)
+	e2:SetCost(s.cost)
+	e2:SetTarget(s.postg1)
+	e2:SetOperation(s.posop1)
+	c:RegisterEffect(e2)
+	--pos (face-up)
+	local e3=e2:Clone()
+	e3:SetDescription(aux.Stringid(id,1))
+	e3:SetCost(s.poscost)
+	e3:SetTarget(s.postg2)
+	e3:SetOperation(s.posop2)
+	c:RegisterEffect(e3)
+end
+function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetFlagEffect(tp,id)==0 end
+	Duel.RegisterFlagEffect(tp,id,RESET_PHASE+PHASE_END,0,1)
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then
+		if e:GetLabel()==0 then
+			return s.postg1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+		else
+			return s.postg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+		end
+	end
+	if chk==0 then return true end
+	local b1=s.cost(e,tp,eg,ep,ev,re,r,rp,0) and s.postg1(e,tp,eg,ep,ev,re,r,rp,0)
+	local b2=s.poscost(e,tp,eg,ep,ev,re,r,rp,0) and s.postg2(e,tp,eg,ep,ev,re,r,rp,0)
+	if (b1 or b2) and Duel.SelectYesNo(tp,94) then
+		local op=0
+		if b1 and b2 then
+			op=Duel.SelectOption(tp,aux.Stringid(id,0),aux.Stringid(id,1))
+		elseif b1 then
+			op=Duel.SelectOption(tp,aux.Stringid(id,0))
+		else
+			op=Duel.SelectOption(tp,aux.Stringid(id,1))+1
+		end
+		e:SetLabel(op)
+		e:SetProperty(EFFECT_FLAG_CARD_TARGET)
+		if op==0 then
+			s.cost(e,tp,eg,ep,ev,re,r,rp,1)
+			s.postg1(e,tp,eg,ep,ev,re,r,rp,1)
+			e:SetOperation(s.posop1)
+		else
+			s.poscost(e,tp,eg,ep,ev,re,r,rp,1)
+			s.postg2(e,tp,eg,ep,ev,re,r,rp,1)
+			e:SetOperation(s.posop2)
+		end
+	else
+		e:SetProperty(0)
+		e:SetOperation(nil)
+	end
+end
+function s.postg1(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and chkc:IsControler(tp) and chkc:IsFacedown() end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsFacedown,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_POSCHANGE)
+	local g=Duel.SelectTarget(tp,Card.IsFacedown,tp,LOCATION_MZONE,0,1,1,nil)
+	e:SetLabel(0)
+	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,1,0,0)
+end
+function s.posop1(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and tc:IsFacedown() then
+		local pos1=0
+		if not tc:IsPosition(POS_FACEUP_ATTACK) then pos1=pos1+POS_FACEUP_ATTACK end
+		if not tc:IsPosition(POS_FACEUP_DEFENSE) then pos1=pos1+POS_FACEUP_DEFENSE end
+		local pos2=Duel.SelectPosition(tp,tc,pos1)
+		Duel.ChangePosition(tc,pos2)
+	end
+end
+function s.cfilter(c)
+	return c:IsSetCard(0x104) and c:IsType(TYPE_MONSTER) and c:IsAbleToDeckAsCost()
+end
+function s.poscost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return s.cost(e,tp,eg,ep,ev,re,r,rp,0)
+		and Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_GRAVE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
+	local g=Duel.SelectMatchingCard(tp,s.cfilter,tp,LOCATION_GRAVE,0,1,1,nil)
+	Duel.SendtoDeck(g,nil,2,REASON_COST)
+	s.cost(e,tp,eg,ep,ev,re,r,rp,1)
+end
+function s.posfilter(c)
+	return c:IsFaceup() and c:IsCanTurnSet()
+end
+function s.postg2(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_MZONE) and s.posfilter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(s.posfilter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_POSCHANGE)
+	local g=Duel.SelectTarget(tp,s.posfilter,tp,LOCATION_MZONE,0,1,1,nil)
+	e:SetLabel(1)
+	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,1,0,0)
+end
+function s.posop2(e,tp,eg,ep,ev,re,r,rp)
+	if not e:GetHandler():IsRelateToEffect(e) then return end
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsFaceup() and tc:IsRelateToEffect(e) then
+		Duel.ChangePosition(tc,POS_FACEDOWN_DEFENSE)
+	end
+end


### PR DESCRIPTION
- World Legacy Pawns: Shouldn't be able to return an Extra Deck "Krawler" monster as the cost for the second effect.
- Crimson Knight Vampire Bram: Shouldn't trigger to revive himself if his Xyz Summon was negated. Credits to Naim.