### PR TITLE
Empress of Endymion Fix

### DIFF
--- a/script/c100308002.lua
+++ b/script/c100308002.lua
@@ -67,18 +67,24 @@ function s.cfilter(c,e,tp)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>1 and
-	 c:IsCanBeSpecialSummoned(e,0,tp,false,false) and Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_HAND,0,1,nil,e,tp) 
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>1 
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false) 
+		and Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_HAND,0,1,nil,e,tp)
+		and not Duel.IsPlayerAffectedByEffect(tp,CARD_BLUEEYES_SPIRIT) 
 	end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,2,tp,LOCATION_PZONE+LOCATION_HAND)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=1 then return end
+	if (Duel.GetLocationCount(tp,LOCATION_MZONE)<=1)
+		or not c:IsRelateToEffect(e)
+		or not c:IsCanBeSpecialSummoned(e,0,tp,false,false) 
+		or Duel.IsPlayerAffectedByEffect(tp,CARD_BLUEEYES_SPIRIT) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=Duel.SelectMatchingCard(tp,s.cfilter,tp,LOCATION_HAND,0,1,1,nil,e,tp)
 	g:AddCard(c)
-	if c:IsRelateToEffect(e) and #g>1 and Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)~=0 then
+	if #g>1 and Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)==2 then
+		Duel.BreakEffect()
 		local ct=g:GetFirst()
 		while ct do
 			ct:AddCounter(0x1,1)

--- a/script/c100308002.lua
+++ b/script/c100308002.lua
@@ -1,5 +1,5 @@
 --エンプレス・オブ・エンディミオン
---Empress of Endymion
+--Empress of Endymion 
 --scripted by Hatter
 
 local s,id=GetID()


### PR DESCRIPTION
Should not be able to summon if Blue-Eyes Spirit Dragon is on field, or if it left the Pendulum Zone