### PR TITLE
small fix for World Legacy Burgeoning

### DIFF
--- a/script/c14604710.lua
+++ b/script/c14604710.lua
@@ -76,7 +76,7 @@ function s.spop2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if not tc:IsRelateToEffect(e) and ft<2 or Duel.IsPlayerAffectedByEffect(tp,CARD_BLUEEYES_SPIRIT) then return end
+	if not tc:IsRelateToEffect(e) or ft<2 or Duel.IsPlayerAffectedByEffect(tp,CARD_BLUEEYES_SPIRIT) then return end
 	local g=Duel.GetMatchingGroup(s.spfilter3,tp,LOCATION_DECK,0,nil,e,tp,tc)
 	local sg=aux.SelectUnselectGroup(g,e,tp,2,2,s.spcheck,1,tp,HINTMSG_SPSUMMON)
 	if sg and #sg==2 then


### PR DESCRIPTION
The second effect should not proceed if the target leaves the field.