### PR TITLE
"Spell Power Control" fix

### DIFF
--- a/script/c100308022.lua
+++ b/script/c100308022.lua
@@ -28,12 +28,13 @@ function s.thop(e,tp,eg,ep,ev,re,r,rp)
         Duel.ConfirmCards(1-tp,g)
         local ct=Duel.GetMatchingGroupCount(aux.FilterFaceupFunction(Card.IsCode,id,75014062),tp,LOCATION_ONFIELD+LOCATION_GRAVE,0,nil)
         local cg=Duel.GetMatchingGroup(aux.FilterFaceupFunction(Card.IsCanAddCounter,COUNTER_SPELL,1),tp,LOCATION_ONFIELD,0,nil)
-        if ct>0 and #cg>0 and Duel.SelectYesNo(tp,aux.Stringid(id,0)) then
-            Duel.BreakEffect()
-            local tc=cg:Select(tp,1,1,nil):GetFirst()
-            --hoping this will make it add as many as possible if #ct is too many
-            --couldn't find a function to get that cap
-            tc:AddCounter(COUNTER_SPELL,ct,true)
-        end
+		if ct>0 and #cg>0 and Duel.SelectYesNo(tp,aux.Stringid(id,0)) then
+			Duel.BreakEffect()
+			while ct>0 and #cg>0 do
+				cg=Duel.GetMatchingGroup(aux.FilterFaceupFunction(Card.IsCanAddCounter,COUNTER_SPELL,1),tp,LOCATION_ONFIELD,0,nil)
+				cg:Select(tp,1,1,nil):GetFirst():AddCounter(COUNTER_SPELL,1)
+				ct=ct-1 
+			end
+		end
     end
 end

--- a/script/c100308022.lua
+++ b/script/c100308022.lua
@@ -28,13 +28,13 @@ function s.thop(e,tp,eg,ep,ev,re,r,rp)
         Duel.ConfirmCards(1-tp,g)
         local ct=Duel.GetMatchingGroupCount(aux.FilterFaceupFunction(Card.IsCode,id,75014062),tp,LOCATION_ONFIELD+LOCATION_GRAVE,0,nil)
         local cg=Duel.GetMatchingGroup(aux.FilterFaceupFunction(Card.IsCanAddCounter,COUNTER_SPELL,1),tp,LOCATION_ONFIELD,0,nil)
-		if ct>0 and #cg>0 and Duel.SelectYesNo(tp,aux.Stringid(id,0)) then
-			Duel.BreakEffect()
-			while ct>0 and #cg>0 do
-				cg=Duel.GetMatchingGroup(aux.FilterFaceupFunction(Card.IsCanAddCounter,COUNTER_SPELL,1),tp,LOCATION_ONFIELD,0,nil)
-				cg:Select(tp,1,1,nil):GetFirst():AddCounter(COUNTER_SPELL,1)
-				ct=ct-1 
-			end
+	if ct>0 and #cg>0 and Duel.SelectYesNo(tp,aux.Stringid(id,0)) then
+		Duel.BreakEffect()
+		while ct>0 and #cg>0 do
+			cg=Duel.GetMatchingGroup(aux.FilterFaceupFunction(Card.IsCanAddCounter,COUNTER_SPELL,1),tp,LOCATION_ONFIELD,0,nil)
+			cg:Select(tp,1,1,nil):GetFirst():AddCounter(COUNTER_SPELL,1)
+			ct=ct-1 
 		end
+	end
     end
 end


### PR DESCRIPTION
Should distribute counters instead of adding all of them to 1 card