### PR TITLE
"Tianwei" fixes

### DIFF
--- a/script/c101009014.lua
+++ b/script/c101009014.lua
@@ -51,7 +51,6 @@ end
 function s.negcon(e,tp,eg,ep,ev,re,r,rp)
 	if not (rp==1-tp and re:IsHasProperty(EFFECT_FLAG_CARD_TARGET)) then return false end
 	local g=Duel.GetChainInfo(ev,CHAININFO_TARGET_CARDS)
-	Debug.Message(g:IsExists(s.negfilter,1,nil,tp))
 	return g and g:IsExists(s.negfilter,1,nil,tp) and Duel.IsChainNegatable(ev)
 end
 function s.negtg(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/script/c101009015.lua
+++ b/script/c101009015.lua
@@ -42,7 +42,7 @@ end
 function s.atcon(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()
 	local b=Duel.GetAttackTarget()
-	return return a and b and ((a:IsControler(tp) and a:IsFaceup() and not a:IsType(TYPE_EFFECT)) or (b:IsControler(tp) and b:IsFaceup() and not b:IsType(TYPE_EFFECT)))
+	return a and b and ((a:IsControler(tp) and a:IsFaceup() and not a:IsType(TYPE_EFFECT)) or (b:IsControler(tp) and b:IsFaceup() and not b:IsType(TYPE_EFFECT)))
 end
 function s.atop(e,tp,eg,ep,ev,re,r,rp)
 	local tc

--- a/script/c101009015.lua
+++ b/script/c101009015.lua
@@ -42,7 +42,7 @@ end
 function s.atcon(e,tp,eg,ep,ev,re,r,rp)
 	local a=Duel.GetAttacker()
 	local b=Duel.GetAttackTarget()
-	return (a:IsControler(tp) and not a:IsType(TYPE_EFFECT)) or (b:IsControler(tp) and not b:IsType(TYPE_EFFECT))
+	return return a and b and ((a:IsControler(tp) and a:IsFaceup() and not a:IsType(TYPE_EFFECT)) or (b:IsControler(tp) and b:IsFaceup() and not b:IsType(TYPE_EFFECT)))
 end
 function s.atop(e,tp,eg,ep,ev,re,r,rp)
 	local tc

--- a/script/c101009058.lua
+++ b/script/c101009058.lua
@@ -30,7 +30,7 @@ function s.initial_effect(c)
 	e3:SetOperation(s.drop)
 	c:RegisterEffect(e3)
 end
-function s.efilter(e,te)
+function s.immfilter(e,te)
 	return te:IsActiveType(TYPE_MONSTER)
 end
 function s.drfilter(c,tp)

--- a/script/c101009058.lua
+++ b/script/c101009058.lua
@@ -34,7 +34,7 @@ function s.immfilter(e,te)
 	return te:IsActiveType(TYPE_MONSTER)
 end
 function s.drfilter(c,tp)
-	return c:GetSummonPlayer()~=tp
+	return c:GetSummonPlayer()~=tp and c:IsType(TYPE_EFFECT)
 end
 function s.drcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.drfilter,1,nil,tp)

--- a/script/c101009059.lua
+++ b/script/c101009059.lua
@@ -28,7 +28,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local gc=Duel.SelectMatchingCard(tp,s.gyfilter,tp,LOCATION_DECK,0,1,1,nil):GetFirst()
 	if not gc or Duel.SendtoGrave(gc,REASON_EFFECT)==0 or not gc:IsLocation(LOCATION_GRAVE) then return end
 	local g=Duel.GetMatchingGroup(s.thfilter,tp,LOCATION_DECK,0,nil,gc:GetCode())
-	if Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsNonEffectMonster),tp,LOCATION_MZONE,0,1,nil) and #g>0 and Duel.SelectYesNo(tp,aux.Stringid(id,0)) then
+	if Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsNonEffectMonster),tp,LOCATION_MZONE,0,1,nil) and #g>0 and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 		local sg=g:Select(tp,1,1,nil)
 		Duel.SendtoHand(sg,nil,REASON_EFFECT)

--- a/script/c101009059.lua
+++ b/script/c101009059.lua
@@ -29,6 +29,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not gc or Duel.SendtoGrave(gc,REASON_EFFECT)==0 or not gc:IsLocation(LOCATION_GRAVE) then return end
 	local g=Duel.GetMatchingGroup(s.thfilter,tp,LOCATION_DECK,0,nil,gc:GetCode())
 	if Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsNonEffectMonster),tp,LOCATION_MZONE,0,1,nil) and #g>0 and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
+		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_ATOHAND)
 		local sg=g:Select(tp,1,1,nil)
 		Duel.SendtoHand(sg,nil,REASON_EFFECT)


### PR DESCRIPTION
- Tianwei Dragon - Nahata: Hand/GY effect shouldn't be able to be used when you attack directly.
- The Hollow Cycle of Dragons: Fixed the string for adding a card to the hand. Also, sending to the GY and adding to your hand don't happen at the same time.
- Land of the Eternal Tianwei: Wrong function name. Also, the draw effect shouldn't trigger when the opponent Special Summons a non-Effect monster.
- Tianwei Dragon - Manira: Removed a leftover debug message.