### PR TITLE
Updated "aux.disfilter1"

### DIFF
--- a/script/utility.lua
+++ b/script/utility.lua
@@ -576,7 +576,7 @@ function Auxiliary.IsCodeListed(c,...)
 end
 --card effect disable filter(target)
 function Auxiliary.disfilter1(c)
-	return c:IsFaceup() and not c:IsDisabled() and (not c:IsType(TYPE_NORMAL) or c:GetOriginalType()&TYPE_EFFECT~=0)
+	return c:IsFaceup() and not c:IsDisabled() and (not c:IsNonEffectMonster() or c:GetOriginalType()&TYPE_EFFECT~=0)
 end
 --condition of EVENT_BATTLE_DESTROYING
 function Auxiliary.bdcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Updated an auxiliary function used as filter for cards that negate the effects of other cards on the field, to avoid issues with non-Effect monsters.