### PR TITLE
Fix "Fantastic Striborg"

### DIFF
--- a/script/c79176962.lua
+++ b/script/c79176962.lua
@@ -1,0 +1,70 @@
+--旋風機ストリボーグ
+--Fantastic Striborg
+local s,id=GetID()
+function s.initial_effect(c)
+	--to hand
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_TOHAND)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCost(s.thcost)
+	e1:SetTarget(s.thtg)
+	e1:SetOperation(s.thop)
+	c:RegisterEffect(e1)
+	--tribute
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE)
+	e2:SetCode(EFFECT_MATERIAL_CHECK)
+	e2:SetValue(s.valcheck)
+	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_SUMMON_COST)
+	e3:SetOperation(s.facechk)
+	e3:SetLabelObject(e2)
+	c:RegisterEffect(e3)
+end
+function s.thcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,nil) end
+	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD)
+end
+function s.thfilter(c,g)
+	return c:IsAbleToHand() and g:IsContains(c)
+end
+function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local cg=e:GetHandler():GetColumnGroup()
+	if chk==0 then return Duel.IsExistingMatchingCard(s.thfilter,tp,0,LOCATION_ONFIELD,1,nil,cg) end
+	local g=Duel.GetMatchingGroup(s.thfilter,tp,0,LOCATION_ONFIELD,nil,cg)
+	Duel.SetOperationInfo(0,CATEGORY_TOHAND,g,#g,0,0)
+end
+function s.thop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local cg=c:GetColumnGroup():AddCard(c)
+	if c:IsRelateToEffect(e) and c:IsFaceup() then
+		local g=Duel.GetMatchingGroup(s.thfilter,tp,0,LOCATION_ONFIELD,nil,cg)
+		if #g>0 then
+			Duel.SendtoHand(g,nil,REASON_EFFECT)
+		end
+	end
+end
+function s.valcheck(e,c)
+	local g=c:GetMaterial()
+	local tc=g:GetFirst()
+	if e:GetLabel()==1 then
+		e:SetLabel(0)
+		while tc do
+			local e1=Effect.CreateEffect(c)
+			e1:SetType(EFFECT_TYPE_SINGLE)
+			e1:SetCode(EFFECT_TO_GRAVE_REDIRECT)
+			e1:SetValue(LOCATION_HAND)
+			e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+			tc:RegisterEffect(e1)
+			tc=g:GetNext()
+		end
+	end
+end
+function s.facechk(e,tp,eg,ep,ev,re,r,rp)
+	e:GetLabelObject():SetLabel(1)
+end


### PR DESCRIPTION
If control of "Fantastic Striborg" changes before its effect to return all cards in the same column as it resolves, it should also return itself to the owner's hand since it's now considered a card the opponent controls. (Currently all other cards the opponent controls in that column are returned to the hand.)

OCG db ruling: https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=21260&keyword=&tag=-1&request_locale=ja"