### PR TITLE
Fixed "Evil Eye Awakening"

### DIFF
--- a/script/c17616743.lua
+++ b/script/c17616743.lua
@@ -1,5 +1,5 @@
 --喚忌の呪眼
---Wails of the Evil Eye
+--Evil Eye Awakening
 --Scripted by AlphaKretin
 local s,id=GetID()
 function s.initial_effect(c)
@@ -21,8 +21,7 @@ function s.selchk(tp)
 	return Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsCode,CARD_EVIL_EYE_SELENE),tp,LOCATION_SZONE,0,1,nil)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local loc=LOCATION_HAND+LOCATION_GRAVE
-	if s.selchk(tp) then loc=loc+LOCATION_DECK end
+	local loc=LOCATION_HAND+LOCATION_GRAVE+LOCATION_DECK
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(s.spfilter,tp,loc,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,loc)
@@ -30,8 +29,7 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local loc=LOCATION_HAND+LOCATION_GRAVE
-	if s.selchk(tp) then loc=loc+LOCATION_DECK end
+	local loc=LOCATION_HAND+LOCATION_GRAVE+LOCATION_DECK
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.spfilter),tp,loc,0,1,1,nil,e,tp)
 	if #g>0 then 
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)

--- a/script/c17616743.lua
+++ b/script/c17616743.lua
@@ -29,7 +29,8 @@ end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local loc=LOCATION_HAND+LOCATION_GRAVE+LOCATION_DECK
+	local loc=LOCATION_HAND+LOCATION_GRAVE
+	if s.selchk(tp) then loc=loc+LOCATION_DECK end
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.spfilter),tp,loc,0,1,1,nil,e,tp)
 	if #g>0 then 
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)


### PR DESCRIPTION
As per "Shaddoll Fusion" rulings, "Ash Blossom & Joyous Spring" should be able to negate "Evil Eye Awakening" whether or not "Evil Eye of Selene" is in the Spell & Trap Zone.