### PR TITLE
"Destiny HERO - Drilldark" fix

### DIFF
--- a/script/c91691605.lua
+++ b/script/c91691605.lua
@@ -32,7 +32,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.operation(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 or not (c:IsFaceup() and c:IsLocation(LOCATION_MZONE)) then return end
 	if not c:IsRelateToEffect(e) then return end
 	local atk=e:GetHandler():GetAttack()
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)


### PR DESCRIPTION
Shouldn't be able to Special Summon a D-HERO from your hand if Drilldark is not face-up on the field when his effect resolves.