### PR TITLE
Updated OCG Forbidden/Limited from 2019.01 to 2019.04

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -1,4 +1,4 @@
-#[2019.01 TCG][2019.01 OCG][2019.01 Worlds][2019.01 Traditional][2019.01 Anime]
+#[2019.01 TCG][2019.04 OCG][2019.04 Worlds][2019.01 Traditional][2019.04 Anime]
 !2019.01 TCG
 #Forbidden TCG
 53804307 0 --Blaster, Dragon Ruler of Infernos			MAIN DECK MONSTERS
@@ -183,7 +183,7 @@
 28297833 2 --Necroface			
 9411399 2 --Destiny HERO - Malicious				
 73628505 2 --Terraforming
-!2019.01 OCG
+!2019.04 OCG
 #Forbidden OCG
 20663556 0 --イレカエル Substitoad												MAIN DECK MONSTERS
 44910027 0 --ヴィクトリー・ドラゴン Victory Dragon
@@ -213,6 +213,7 @@
 67441435 0 --Glow-up Bulb
 15341821 0 --Dandylion
 9047460 0 --Blackwing - Steam the Cloak
+88264978 0 --レッドアイズ·ダークネスメタルドラゴン Red-Eyes Darkness Dragon
 17412721 0 --旧神ノーデン Elder Entity Norden 						EXTRA DECK MONSTERS
 25862681 0 --Ancient Fairy Dragon
 34086406 0 --ラヴァルバル・チェイン Lavalval Chain
@@ -232,7 +233,6 @@
 42829885 0 --強引な番兵 The Forceful Sentry
 55144522 0 --強欲な壺 Pot of Greed
 4031928 0 --心変わり Change of Heart
-12580477 0 --サンダー·ボルト Raigeki
 60682203 0 --大寒波 Cold Wave
 42703248 0 --ハリケーン Giant Trunade
 79571449 0 --天使の施し Graceful Charity
@@ -272,13 +272,11 @@
 70903634 1 --封印されし者の右腕 Right Arm
 44519536 1 --封印されし者の左足 Left Leg 
 8124921 1 --封印されし者の右足 Right Leg
-88264978 1 --レッドアイズ·ダークネスメタルドラゴン Red-Eyes Darkness Dragon
 10802915 1 --魔界発現世行きデスガイド Tour Guide From the underworld
 33508719 1 --メタモルポット Morphing Jar
 89463537 1 --ユニコールの影霊衣 Nekroz of Unicore
 92746535 1 --竜剣士ラスターP Luster Pendulum
 78872731 1 --十二獣モルモラット Zoodiac Ratpier
-58984738 1 --Dinomight Knight, the True Dracofighter
 44335251 1 --Souleating Oviraptor
 36042004 1 --Babycerasaurus
 78080961 1 --SPYRAL Quik-Fix
@@ -293,9 +291,10 @@
 41386308 1 --Mathematician
 89399912 1 --嵐征竜－テンペスト Tempest, Dragon Ruler of Storms
 42790071 1 --オルターガイスト・マルチフェイカー Altergeist Multifaker
+28985331 1 --Armageddon Knight
+81275020 1 --SRベイゴマックス Speedroid Terrortop
 74586817 1 --PSYフレームロード・Ω PSY-Framelord Omega								EXTRA DECK MONSTERS
 90953320 1 --TG ハイパー·ライブラリアン TG Hyper Librarian
-90809975 1 --餅カエル Toadally Awesome
 70583986 1 --氷結界の虎王ドゥローレン Dewloren, Tiger king of the Ice Barrier
 52687916 1 --氷結界の龍 トリシューラ Trishula, Dragon of the Ice barrier
 6602300 1 --重爆撃禽 ボム・フェネクス  Blaze Fenix, The Burning Bombardment Bird
@@ -315,9 +314,9 @@
 32807846 1 --増援 Reinforcement of the Army
 54447022 1 --ソウル・チャージ Soul Charge
 58577036 1 --名推理 Reasoning
+12580477 1 --サンダー·ボルト Raigeki
 18144506 1 --ハーピィの羽根帚 Harpie's Feather Duster
 53208660 1 --ペンデュラム・コール Pendulum Call
-23171610 1 --リミッター解除 Limiter Removal
 14733538 1 --竜呼相打つ Draco Face-Off
 72892473 1 --手札抹殺 Card Destruction
 97211663 1 --影霊衣の反魂術 Nekroz Cycle
@@ -327,7 +326,6 @@
 15854426 1 --霞の谷の神風 Divine Wind of Mist Valley
 52340444 1 --Sky Striker Mecha - Hornet Drones
 73468603 1 -- Set Rotation
-8949584 1 --ヒーローアライブ A Hero Lives
 75500286 1 --封印の黄金櫃 Gold Sarcophagus
 21076084 1 --Trickstar Reincarnation		TRAPS CARDS
 5851097 1 --虚無空間 Vanity's Emptiness
@@ -335,27 +333,25 @@
 #Semi Limited OCG
 40044918 2 --E·HERO エアーマン Elemental Hero Stratos
 14558127 2 --Ash Blossom & Joyous Spring
-81275020 2 --SRベイゴマックス Speedroid Terrortop
-68819554 2 --Emダメージ・ジャグラー Performage Damage Juggler
 61283655 2 --Trickstar Candina
-55623480 2 --妖精伝姫－シラユキ Fairy Tail - Snow
-65536818 2 --Denglong, First of the Yang Zing
-066399653 2 --ユニオン格納庫 Union Hangar
+58984738 2 --Dinomight Knight, the True Dracofighter
+90809975 2 --餅カエル Toadally Awesome
 73915051 2 --Scapegoat
 47325505 2 --Fossil Dig
 23314220 2 --Spellbook of Knowledge
+8949584 2 --ヒーローアライブ A Hero Lives
 91623717 2 --連鎖爆撃 Chain Strike
 67723438 2 --緊急テレポート Emergency teleporter
+23171610 2 --リミッター解除 Limiter Removal
 98338152 2 --閃刀機－ウィドウアンカー Sky Striker Mecha - Widow Anchor
 63166095 2 --閃刀起動－エンゲージ Sky Striker Mobilize - Engage!
 48130397 2 --超融合 Super Polymerization
 11110587 2 --隣の芝刈り That Grass Looks Greener
 40605147 2 --Solemn Strike
-84749824 2 --神の警告 Solemn Warning
 41420027 2 --神の宣告 Solemn Judgment
 36468556 2 --停戦協定 Ceasefire
 53936268 2 --Personal Spoofing
-!2019.01 Worlds
+!2019.04 Worlds
 #Forbidden worlds
 03078576 0 --Yata-Garasu
 05592689 0 --Samsara Lotus
@@ -399,6 +395,7 @@
 55623480 0 --Fairy Tail - Snow
 09047460 0 --Blackwing - Steam the Cloak
 75732622 0 --Grinder Golem
+88264978 0 --Red-Eyes Darkness Metal Dragon
 00581014 0 --Daigusto Emeral
 04423206 0 --M-X-Saber Invoker
 17412721 0 --Elder Entity Norden
@@ -421,7 +418,6 @@
 10389142 0 --Number 42: Galaxy Tomahawk
 04031928 0 --Change of Heart
 11110587 0 --That Grass Looks Greener
-12580477 0 --Raigeki
 13035077 0 --Dragonic Diagram
 17375316 0 --Confiscation
 18144506 0 --Harpie's Feather Duster
@@ -499,7 +495,6 @@
 78868119 1 --Deep Sea Diva
 78872731 1 --Zoodiac Ratpier
 81275020 1 --Speedroid Terrortop
-88264978 1 --Red-eyes Darkness Metal Dragon
 89463537 1 --Nekroz of Unicore
 92746535 1 --Luster Pendulum the Dracoslayer
 96570609 1 --Ether the Heavenly monarch
@@ -524,7 +519,6 @@
 18239909 1 --Ignister Prominence, the Blasting Dracoslayer 
 27552504 1 --Beatrice, Lady of Eternal
 48063985 1 --Ritual Beast Ulti-Cannahawk
-90809975 1 --Toadally Awesome
 24094258 1 --Heavymetalfoes Electrumite
 50588353 1 --Crystron Needlefiber
 63288573 1 -Sky Striker Ace - Kagari
@@ -534,7 +528,6 @@
 14733538 1 --Draco Face-off
 15854426 1 --Divine Wind of the Mist Valley
 22842126 1 --Phanteism of the Monarchs
-23171610 1 --Limiter Removal
 23701465 1 --Primal Seed
 27970830 1 --Gateway of the Six
 32807846 1 --Reinforcement of the Army
@@ -544,6 +537,7 @@
 48130397 1 --Super Polymerization
 52340444 1 --Sky Striker Mecha - Hornet Drones
 53129443 1 --Dark Hole
+12580477 1 --Raigeki
 53208660 1 --Pendulum Call
 54631665 1 --SPYRAL Resort
 58577036 1 --Reasoning
@@ -581,13 +575,14 @@
 #Semi Limited Worlds
 9411399 2 --Destiny HERO - Malicious
 14558127 2 --Ash Blossom & Joyous Spring
+90809975 2 --Toadally Awesome
 61283655 2 --Trickstar Candina
 40605147 2 --Solemn Strike
 47325505 2 --Fossil Dig
 23314220 2 --Spellbook of Knowledge
 63166095 2 --Sky Striker Mobilize - Engage!
+23171610 2 --Limiter Removal
 98338152 2 --Sky Striker Mecha - Widow Anchor
-066399653 2 --Union Hangar
 36468556 2 --Ceasefire
 53936268 2 --Personal Spoofing
 !2019.01 Traditional
@@ -819,6 +814,7 @@
 55623480 0 --Fairy Tail - Snow
 09047460 0 --Blackwing - Steam the Cloak
 75732622 0 --Grinder Golem
+88264978 0 --Red-Eyes Darkness Metal Dragon
 00581014 0 --Daigusto Emeral
 04423206 0 --M-X-Saber Invoker
 17412721 0 --Elder Entity Norden
@@ -841,7 +837,6 @@
 10389142 0 --Number 42: Galaxy Tomahawk
 04031928 0 --Change of Heart
 11110587 0 --That Grass Looks Greener
-12580477 0 --Raigeki
 13035077 0 --Dragonic Diagram
 17375316 0 --Confiscation
 18144506 0 --Harpie's Feather Duster
@@ -919,9 +914,8 @@
 78868119 1 --Deep Sea Diva
 78872731 1 --Zoodiac Ratpier
 81275020 1 --Speedroid Terrortop
-88264978 1 --Red-eyes Darkness Metal Dragon
 89463537 1 --Nekroz of Unicore
-92746535 1 --P Luster Pendulum
+92746535 1 --Luster Pendulum the Dracoslayer
 96570609 1 --Ether the Heavenly monarch
 99177923 1 --Infernity Archfiend
 28985331 1 --Armageddon Knight
@@ -930,6 +924,7 @@
 41386308 1 --Mathematician
 82301904 1 --Chaos Emperor Dragon - Envoy of the End
 69015963 1 --Cyber Stein
+14536035 1 --Dark Grepher
 90307777 1 --Shurit, Strategist of the Nekroz
 01561110 1 --ABC-Dragon Buster
 06602300 1 --Blaze Fenix, The Burning Bombardment Bird
@@ -943,7 +938,6 @@
 18239909 1 --Ignister Prominence, the Blasting Dracoslayer 
 27552504 1 --Beatrice, Lady of Eternal
 48063985 1 --Ritual Beast Ulti-Cannahawk
-90809975 1 --Toadally Awesome
 24094258 1 --Heavymetalfoes Electrumite
 50588353 1 --Crystron Needlefiber
 63288573 1 -Sky Striker Ace - Kagari
@@ -953,7 +947,6 @@
 14733538 1 --Draco Face-off
 15854426 1 --Divine Wind of the Mist Valley
 22842126 1 --Phanteism of the Monarchs
-23171610 1 --Limiter Removal
 23701465 1 --Primal Seed
 27970830 1 --Gateway of the Six
 32807846 1 --Reinforcement of the Army
@@ -963,6 +956,7 @@
 48130397 1 --Super Polymerization
 52340444 1 --Sky Striker Mecha - Hornet Drones
 53129443 1 --Dark Hole
+12580477 1 --Raigeki
 53208660 1 --Pendulum Call
 54631665 1 --SPYRAL Resort
 58577036 1 --Reasoning
@@ -1000,13 +994,14 @@
 #Semi Limited Worlds
 9411399 2 --Destiny HERO - Malicious
 14558127 2 --Ash Blossom & Joyous Spring
+90809975 2 --Toadally Awesome
 61283655 2 --Trickstar Candina
 40605147 2 --Solemn Strike
 47325505 2 --Fossil Dig
 23314220 2 --Spellbook of Knowledge
 63166095 2 --Sky Striker Mobilize - Engage!
+23171610 2 --Limiter Removal
 98338152 2 --Sky Striker Mecha - Widow Anchor
-066399653 2 --Union Hangar
 36468556 2 --Ceasefire
 53936268 2 --Personal Spoofing
 #Anime entries


### PR DESCRIPTION
The cards changed are: Red-Eyes Darkness Metal Dragon, Armageddon Knight, Speedroid Terrortop, Raigeki, Dinomight Knight, the True Dracofighter, Toadally Awesome, A Hero Lives, Limiter Removal, Fairy Tail – Snow, Performage Damage Juggler, Denglong, First of the Yang Zing, Union Hangar and  Solemn Warning.

This patch also includes an update to Worlds and Anime Forbidden/Limited lists to match the OCG changes.