### PR TITLE
Fixed "Decode Destruction"

### DIFF
--- a/script/c33062423.lua
+++ b/script/c33062423.lua
@@ -3,31 +3,31 @@
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
-    --activate
-    local e1=Effect.CreateEffect(c)
-    e1:SetType(EFFECT_TYPE_ACTIVATE)
-    e1:SetCode(EVENT_FREE_CHAIN)
-    e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-    e1:SetCountLimit(1,id+EFFECT_COUNT_CODE_OATH)
-    e1:SetTarget(s.target)
-    e1:SetOperation(s.activate)
-    c:RegisterEffect(e1)
+	--activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCountLimit(1,id+EFFECT_COUNT_CODE_OATH)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.activate)
+	c:RegisterEffect(e1)
 end
 s.listed_names={1861629}
 function s.filter(c)
-    return c:IsFaceup() and c:IsCode(1861629) and c:GetLinkedGroupCount()>0
+	return c:IsFaceup() and c:IsCode(1861629) and c:GetLinkedGroupCount()>0
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-    if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and s.filter(chkc) end
-    if chk==0 then return Duel.IsExistingTarget(s.filter,tp,LOCATION_MZONE,0,1,nil) end
-    Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
-    Duel.SelectTarget(tp,s.filter,tp,LOCATION_MZONE,0,1,1,nil)
+	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_MZONE) and s.filter(chkc) end
+	if chk==0 then return Duel.IsExistingTarget(s.filter,tp,LOCATION_MZONE,0,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_FACEUP)
+	Duel.SelectTarget(tp,s.filter,tp,LOCATION_MZONE,0,1,1,nil)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-    local c=e:GetHandler()
-    local tc=Duel.GetFirstTarget()
-    if not tc:IsRelateToEffect(e) then return end
-    local lc=tc:GetLinkedGroupCount()
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if not tc:IsRelateToEffect(e) then return end
+	local lc=tc:GetLinkedGroupCount()
 	if tc then
 		local e0=Effect.CreateEffect(e:GetHandler())
 		e0:SetType(EFFECT_TYPE_SINGLE)
@@ -36,51 +36,58 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		e0:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e0)
 	end
-    if lc>=1 then
-        local e1=Effect.CreateEffect(c)
-        e1:SetType(EFFECT_TYPE_SINGLE)
-        e1:SetCode(EFFECT_UPDATE_ATTACK)
-        e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
-        e1:SetRange(LOCATION_MZONE)
-        e1:SetValue(s.atkval)
-        e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
-        tc:RegisterEffect(e1)
-    end
-    if lc>=2 then
-        local e2=Effect.CreateEffect(c)
-        e2:SetType(EFFECT_TYPE_SINGLE)
-        e2:SetCode(EFFECT_BATTLE_DESTROY_REDIRECT)
-        e2:SetValue(LOCATION_REMOVED)
-        e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
-        tc:RegisterEffect(e2)
-    end
-    if lc==3 then
-        local e3=Effect.CreateEffect(c)
-        e3:SetCategory(CATEGORY_DESTROY)
-        e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
-        e3:SetCode(EVENT_BATTLED)
-        e3:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
-        e3:SetCondition(s.descon)
-        e3:SetTarget(s.destg)
-        e3:SetOperation(s.desop)
-        tc:RegisterEffect(e3)
-    end
+	if lc>=1 then
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetCode(EFFECT_UPDATE_ATTACK)
+		e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+		e1:SetRange(LOCATION_MZONE)
+		e1:SetValue(s.atkval)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e1)
+	end
+	if lc>=2 then
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e2:SetCode(EVENT_ADJUST)
+		e2:SetRange(LOCATION_MZONE)
+		e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		e2:SetOperation(s.op)
+		tc:RegisterEffect(e2)
+	end
+	if lc==3 then
+		local e3=Effect.CreateEffect(c)
+		e3:SetCategory(CATEGORY_DESTROY)
+		e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_F)
+		e3:SetCode(EVENT_BATTLED)
+		e3:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		e3:SetCondition(s.descon)
+		e3:SetTarget(s.destg)
+		e3:SetOperation(s.desop)
+		tc:RegisterEffect(e3)
+	end
 end
 function s.atkval(e,c)
-    return c:GetLinkedGroupCount()*500
+	return c:GetLinkedGroupCount()*500
+end
+function s.op(e,tp,eg,ep,ev,re,r,rp)
+	local bc=e:GetHandler():GetBattleTarget()
+	if bc and bc:IsStatus(STATUS_BATTLE_DESTROYED)
+		then Duel.Remove(bc,bc:GetPosition(),REASON_EFFECT)
+	end
 end
 function s.descon(e,tp,eg,ep,ev,re,r,rp)
-    local c=e:GetHandler()
-    if c:IsStatus(STATUS_BATTLE_DESTROYED) then return false end
-    local bc=c:GetBattleTarget()
-    return bc and bc:IsStatus(STATUS_BATTLE_DESTROYED)
+	local c=e:GetHandler()
+	if c:IsStatus(STATUS_BATTLE_DESTROYED) then return false end
+	local bc=c:GetBattleTarget()
+	return bc and bc:IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk)
-    if chk==0 then return true end
-    local g=Duel.GetFieldGroup(tp,0,LOCATION_ONFIELD)
-    Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,#g,0,0)
+	if chk==0 then return true end
+	local g=Duel.GetFieldGroup(tp,0,LOCATION_ONFIELD)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,#g,0,0)
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
-    local g=Duel.GetFieldGroup(tp,0,LOCATION_ONFIELD)
-    Duel.Destroy(g,REASON_EFFECT)
+	local g=Duel.GetFieldGroup(tp,0,LOCATION_ONFIELD)
+	Duel.Destroy(g,REASON_EFFECT)
 end


### PR DESCRIPTION
Workaround to make it work according to rulings: if the "2+" and the "3+" effects both are applied, the monster destroyed by battle is banished first, then the effect triggers. Credits to Larry126