### PR TITLE
Fix "Evil Eye Awakening"

### DIFF
--- a/script/c17616743.lua
+++ b/script/c17616743.lua
@@ -21,16 +21,25 @@ function s.selchk(tp)
 	return Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsCode,CARD_EVIL_EYE_SELENE),tp,LOCATION_SZONE,0,1,nil)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	local loc=LOCATION_HAND+LOCATION_GRAVE+LOCATION_DECK
+	local loc=LOCATION_HAND+LOCATION_GRAVE
+	if s.selchk(tp) then loc=loc+LOCATION_DECK end
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and Duel.IsExistingMatchingCard(s.spfilter,tp,loc,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,loc)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	if not Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND+LOCATION_GRAVE,0,1,nil,e,tp) then
+		loc=LOCATION_DECK
+	else
+		if s.selchk(tp) and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp)
+			and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
+			loc=LOCATION_DECK
+		else
+			loc=LOCATION_HAND+LOCATION_GRAVE
+		end
+	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local loc=LOCATION_HAND+LOCATION_GRAVE
-	if s.selchk(tp) then loc=loc+LOCATION_DECK end
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.spfilter),tp,loc,0,1,1,nil,e,tp)
 	if #g>0 then 
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)


### PR DESCRIPTION
Now cannot be activated if the only "Evil Eye" monsters are in your Deck while you do not control "Evil Eye of Selene".
Will prompt separately if you want to Special Summon from the Deck (rather than just allowing it).