### PR TITLE
fix for Saryuja Skull Dread

### DIFF
--- a/script/c74997493.lua
+++ b/script/c74997493.lua
@@ -119,6 +119,7 @@ function s.drop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.Draw(p,d,REASON_EFFECT)==4 then
 		local g=Duel.GetMatchingGroup(Card.IsAbleToDeck,p,LOCATION_HAND,0,nil)
 		if #g==0 then return end
+		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,p,HINTMSG_TODECK)
 		local sg=g:Select(p,3,3,nil)
 		Duel.SendtoDeck(sg,nil,0,REASON_EFFECT)


### PR DESCRIPTION
Drawing 4 cards and placing 3 on the bottom of the deck are not simultaneous.