### PR TITLE
Various fixes

### DIFF
--- a/script/c24557335.lua
+++ b/script/c24557335.lua
@@ -46,19 +46,17 @@ function s.cfilter(c,e,tp)
 	return c:IsReason(REASON_BATTLE+REASON_EFFECT) and c:IsPreviousLocation(LOCATION_MZONE)
 		and c:GetPreviousControler()==tp and c:IsPreviousPosition(POS_FACEUP) and not c:IsType(TYPE_TOKEN) 
 		and c:IsNonEffectMonster() and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
-		and not c:IsLocation(LOCATION_EXTRA)
+		and c:IsCanBeEffectTarget(e) and not c:IsLocation(LOCATION_EXTRA)
 end
 function s.destg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return s.cfilter(chkc,e,tp) end
-	if chk==0 then return eg:IsExists(s.cfilter,1,nil,e,tp) end
+	if chk==0 then return eg:IsExists(s.cfilter,1,nil,e,tp)
+		and ((not eg:IsContains(e:GetHandler())) 
+		or e:GetHandler():IsLocation(LOCATION_HAND)) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local g=eg:FilterSelect(tp,s.cfilter,1,1,nil,e,tp)
 	Duel.SetTargetCard(g:GetFirst())
-	if g:GetFirst():IsLocation(LOCATION_GRAVE) then
-		Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,g,1,0,0)
-	end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_DESTROY,nil,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,g:GetFirst():GetLocation())
 end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/script/c3611830.lua
+++ b/script/c3611830.lua
@@ -1,5 +1,5 @@
 --創聖魔導王 エンディミオン
---Endymion, the Founding Sorcerer Supreme
+--Endymion, the Mighty Master of Magic
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
@@ -66,6 +66,8 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 		and c:IsCanAddCounter(COUNTER_SPELL,1,false,LOCATION_MZONE) end
+	local g=Duel.GetMatchingGroup(nil,tp,LOCATION_ONFIELD,LOCATION_ONFIELD,nil)
+	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c4055337.lua
+++ b/script/c4055337.lua
@@ -1,5 +1,5 @@
 --オルフェゴール・トロイメア
---Orcustrated Knightmare
+--Orcust Knightmare
 --Scripted by AlphaKretin
 local s,id=GetID()
 function s.initial_effect(c)
@@ -38,6 +38,7 @@ function s.atkcon1(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.atkcon2(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.IsPlayerAffectedByEffect(tp,CARD_ORPHEGEL_BABEL)
+		and (Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated())
 end
 function s.filter(c)
 	return c:IsRace(RACE_MACHINE) and c:IsAttribute(ATTRIBUTE_DARK) and not c:IsCode(id) and c:IsAbleToGrave()

--- a/script/c4055337.lua
+++ b/script/c4055337.lua
@@ -26,7 +26,7 @@ function s.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetCode(EVENT_FREE_CHAIN)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DAMAGE_STEP)
-	e2:SetHintTiming(0,TIMING_END_PHASE)
+	e2:SetHintTiming(TIMING_DAMAGE_STEP,TIMING_DAMAGE_STEP+TIMING_END_PHASE)
 	e2:SetCondition(s.atkcon2)
 	c:RegisterEffect(e2)
 end

--- a/script/c72700231.lua
+++ b/script/c72700231.lua
@@ -5,7 +5,7 @@ function s.initial_effect(c)
 	--spsummon
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,0))
-	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON+CATEGORY_TOGRAVE)
 	e1:SetType(EFFECT_TYPE_IGNITION)
 	e1:SetRange(LOCATION_GRAVE+LOCATION_HAND)
 	e1:SetCountLimit(1,id)
@@ -35,6 +35,7 @@ function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 	and Duel.IsExistingMatchingCard(s.tgfilter,tp,LOCATION_DECK,0,1,nil)	end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,c,1,0,0)
+	Duel.SetOperationInfo(0,CATEGORY_TOGRAVE,nil,1,tp,LOCATION_DECK)
 end
 function s.spfilter(c,e,tp)
 	return c:IsCanBeSpecialSummoned(e,0,tp,false,false)

--- a/script/c94620082.lua
+++ b/script/c94620082.lua
@@ -59,12 +59,8 @@ function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP_DEFENSE) end
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
-	local g=Duel.GetFieldGroup(tp,0,LOCATION_SZONE)
-	if #g>0 then
-		Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,1,0,0)
-	end
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,LOCATION_GRAVE)
 end
 function s.desfilter(c)
 	return c:IsFaceup() and c:IsType(TYPE_SPELL+TYPE_TRAP)
@@ -81,4 +77,3 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		end
 	end
 end
-


### PR DESCRIPTION
- Endymion, the Mighty Master of Magic: Fixed interaction with "Stardust Dragon", etc.
- Tenyi Dragon Sthana: Should not be able to use its effect from the GY if it and a non-Effect Monster are destroyed at the same time.
- Salamangreat Foxy: Its GY effect should not be negatable with "Stardust Dragon", etc.
- Orcust Knightmare: Should not be able to use its GY effect after damage calculation and at the end of the Damage Step.
- Yuki-Musume, the Ice Mayakashi: Her effect should be negatable by Ash Blossom.