### PR TITLE
Updated malefic territory according to rulings

### DIFF
--- a/script/c75223115.lua
+++ b/script/c75223115.lua
@@ -17,15 +17,38 @@ function s.initial_effect(c)
 	e2:SetTargetRange(1,1)
 	e2:SetRange(LOCATION_SZONE)
 	c:RegisterEffect(e2)
-	--disable
+	--adjust
 	local e3=Effect.CreateEffect(c)
-	e3:SetType(EFFECT_TYPE_FIELD)
-	e3:SetCode(EFFECT_DISABLE)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_ADJUST)
 	e3:SetRange(LOCATION_SZONE)
-	e3:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
-	e3:SetCondition(s.discon)
-	e3:SetTarget(aux.TargetBoolFunction(Card.IsSetCard,0x23))
+	e3:SetOperation(s.adjustop)
+	e3:SetCondition(function()return s.validitycheck()end)
 	c:RegisterEffect(e3)
+	--cannot summon,spsummon,flipsummon
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetRange(LOCATION_SZONE)
+	e4:SetCode(EFFECT_CANNOT_SPECIAL_SUMMON)
+	e4:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e4:SetTargetRange(1,1)
+	e4:SetTarget(s.sumlimit)
+	c:RegisterEffect(e4)
+	local e5=e4:Clone()
+	e5:SetCode(EFFECT_CANNOT_SUMMON)
+	c:RegisterEffect(e5)
+	local e6=e4:Clone()
+	e6:SetCode(EFFECT_CANNOT_FLIP_SUMMON)
+	c:RegisterEffect(e6)
+	--disable
+	local e7=Effect.CreateEffect(c)
+	e7:SetType(EFFECT_TYPE_FIELD)
+	e7:SetCode(EFFECT_DISABLE)
+	e7:SetRange(LOCATION_SZONE)
+	e7:SetTargetRange(LOCATION_MZONE,LOCATION_MZONE)
+	e7:SetCondition(s.discon)
+	e7:SetTarget(aux.TargetBoolFunction(Card.IsSetCard,0x23))
+	c:RegisterEffect(e7)
 end
 s.listed_names={27564031}
 function s.filter(c,tp)
@@ -64,4 +87,36 @@ end
 function s.discon(e)
 	local ph=Duel.GetCurrentPhase()
 	return ph>=PHASE_BATTLE_START and ph<=PHASE_BATTLE
+end
+function s.stuff(c)
+	local mt=c:GetMetatable()
+	return c:IsFaceup() and mt.has_malefic_unique and mt.has_malefic_unique[c]==true and not c:IsDisabled() and c:IsSetCard(0x23)
+end
+function s.validitycheck()
+	return Duel.IsExistingMatchingCard(s.stuff,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil)
+end
+function s.rmfilter(c,...)
+	return c:IsFaceup() and c:IsSetCard(0x23) and c:IsCode(...)
+end
+function s.rmfilter2(c,fieldid,...)
+	return c:GetFieldID()<fieldid and c:IsCode(...)
+end
+function s.sumlimit(e,c,sump,sumtype,sumpos,targetp)
+	if sumpos and (sumpos&POS_FACEDOWN)>0 or (not s.stuff(c) or not s.validitycheck()) then return false end
+	local tp=sump
+	if targetp then tp=targetp end
+	return Duel.IsExistingMatchingCard(s.rmfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,c,c:GetCode())
+end
+function s.checkok(c,group)
+	return group:IsExists(s.rmfilter2,1,c,c:GetFieldID(),c:GetCode())
+end
+function s.adjustop(e,tp,eg,ep,ev,re,r,rp)
+	local phase=Duel.GetCurrentPhase()
+	if (phase==PHASE_DAMAGE and not Duel.IsDamageCalculated()) or phase==PHASE_DAMAGE_CAL then return end
+	local g=Duel.GetMatchingGroup(aux.AND(Card.IsFaceup,Card.IsSetCard),0,LOCATION_MZONE,LOCATION_MZONE,nil,0x23)
+	local sg=g:Filter(s.checkok,nil,g)
+	if #sg>0 then
+		Duel.Destroy(sg,REASON_RULE)
+		Duel.Readjust()
+	end
 end

--- a/script/utility.lua
+++ b/script/utility.lua
@@ -1297,12 +1297,12 @@ function Auxiliary.FilterFaceupFunction(f,...)
 end
 --Filter for unique on field Malefic monsters
 function Auxiliary.MaleficUniqueFilter(cc)
+local mt=cc:GetMetatable()
+	local t= mt.has_malefic_unique or {}
+	t[cc]=true
+	mt.has_malefic_unique=t
 	return 	function(c)
-				if Duel.IsPlayerAffectedByEffect(0,75223115) then
-					return c:GetCode()==cc:GetCode()
-				else
-					return c:IsSetCard(0x23)
-				end
+				return not Duel.IsPlayerAffectedByEffect(c:GetControler(),75223115) and c:IsSetCard(0x23)
 			end
 end
 --Procedure for Malefic monsters' Special Summon (includes handling of Malefic Paradox Gear)

--- a/script/utility.lua
+++ b/script/utility.lua
@@ -1297,7 +1297,7 @@ function Auxiliary.FilterFaceupFunction(f,...)
 end
 --Filter for unique on field Malefic monsters
 function Auxiliary.MaleficUniqueFilter(cc)
-local mt=cc:GetMetatable()
+	local mt=cc:GetMetatable()
 	local t= mt.has_malefic_unique or {}
 	t[cc]=true
 	mt.has_malefic_unique=t


### PR DESCRIPTION
The changed effect of malefic monsters, should also affect other malefic mosnters that don't have the unique on field condition themselves (the 2 Malefic Gears are the only valid monsters).

> https://www.db.yugioh-card.com/yugiohdb/faq_search.action?ope=5&fid=22507
> Q.自分のフィールドゾーンに「Sin World」、自分の魔法＆罠ゾーンに「Sin Territory」がそれぞれ表側表示で存在し、自分のモンスターゾーンに「Sin パラレルギア」2体が表側表示で存在しています。
> 
> この状況で、自分は手札の「Sin 真紅眼の黒竜」を『デッキから「真紅眼の黒竜」１体を除外した場合に特殊召喚できる』方法によって特殊召喚する事はできますか？
> A.質問の状況の場合でも、自分は手札から「Sin 真紅眼の黒竜」を特殊召喚する事ができます。
> 
> 「Sin Territory」の『②：「Sin」モンスターの持つ、「「Sin」モンスターはフィールドに１体しか表側表示で存在できない」効果は、「「Sin」モンスターは１種類につきフィールドに１体しか表側表示で存在できない」として適用される』によって、特殊召喚された「Sin 真紅眼の黒竜」の『①：「Sin」モンスターはフィールドに１体しか表側表示で存在できない』モンスター効果は、『「Sin」モンスターは１種類につきフィールドに１体しか表側表示で存在できない』効果として適用されます。
> 
> この時、自分のモンスターゾーンには「Sin パラレルギア」2体が存在していますので、いずれか1体の「Sin パラレルギア」が破壊される事になります。