### PR TITLE
Various fixes

### DIFF
--- a/script/c100248004.lua
+++ b/script/c100248004.lua
@@ -48,7 +48,7 @@ function s.desop(e,tp,eg,ep,ev,re,r,rp)
 			Duel.BreakEffect()
 			local ct=Duel.Destroy(dg,REASON_EFFECT)
 			if ct>0 then
-				Duel.Recover(tp,ct*500)
+				Duel.Recover(tp,ct*500,REASON_EFFECT)
 			end
 		end
 	end

--- a/script/c50139096.lua
+++ b/script/c50139096.lua
@@ -69,40 +69,32 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetOperation(s.actop)
 		e1:SetLabelObject(tc)
 		Duel.RegisterEffect(e1,tp)
-		tc:RegisterFlagEffect(0,RESET_EVENT+RESETS_STANDARD,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(id,2))
-		--reset
-		local reset=Effect.CreateEffect(c)
-		reset:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-		reset:SetCode(EVENT_ADJUST)
-		reset:SetCondition(s.resco)
-		reset:SetOperation(s.resop)
-		reset:SetLabelObject(e1)
-		Duel.RegisterEffect(reset,tp)
+		tc:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_CONTROL,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(id,2))
 	end
 end
-function s.resco(e,tp,eg,ep,ev,re,r,rp)
-	local tc=e:GetLabelObject():GetLabelObject()
-	return not tc:IsLocation(LOCATION_MZONE) or tc:GetFlagEffect(0)==0
-end
-function s.resop(e,tp,eg,ep,ev,re,r,rp)
-	e:GetLabelObject():Reset()
-	e:Reset()
-end
 function s.actcon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	if tc:GetFlagEffect(id)==0 then
+		e:Reset()
+		return false
+	end
 	local ac=Duel.GetAttacker()
-	return ac and ac:IsControler(tp) and ac:IsType(TYPE_RITUAL)
+	return ac and ac:IsControler(tp) and ac:IsType(TYPE_RITUAL) and tc:GetFlagEffect(id)>0
 end
 function s.actop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_FIELD)
 	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
-	e1:SetRange(LOCATION_MZONE)
 	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
 	e1:SetTargetRange(0,1)
+	e1:SetCondition(s.actlimitcon)
 	e1:SetValue(s.actlimit)
 	e1:SetReset(RESET_PHASE+PHASE_DAMAGE)
 	Duel.RegisterEffect(e1,tp)
+end
+function s.actlimitcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.CheckEvent(EVENT_ATTACK_ANNOUNCE)
 end
 function s.actlimit(e,re,tp)
 	return not re:GetHandler():IsImmuneToEffect(e)

--- a/script/c78348934.lua
+++ b/script/c78348934.lua
@@ -1,4 +1,5 @@
 --破壊剣士の宿命
+--Karma of the Destruction Swordsman
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -49,6 +50,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
 		Duel.SelectTarget(tp,s.filter2,tp,0,LOCATION_MZONE+LOCATION_GRAVE,1,2,g1:GetFirst(),rc)
 	end
+	Duel.SetOperationInfo(0,CATEGORY_REMOVE,g1,1,0,LOCATION_GRAVE)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)

--- a/script/c86124104.lua
+++ b/script/c86124104.lua
@@ -1,5 +1,5 @@
 --終焉の悪魔デミス
---Demise, Fiend of Armageddon
+--Demise, Agent of Armageddon
 --Scripted by ahtelel
 local s,id=GetID()
 function s.initial_effect(c)
@@ -71,11 +71,20 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 		local e1=Effect.CreateEffect(e:GetHandler())
 		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
 		e1:SetCode(EVENT_CHAINING)
+		e1:SetCondition(s.actcon)
 		e1:SetOperation(s.actop)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e1:SetLabelObject(tc)
 		Duel.RegisterEffect(e1,tp)
-		tc:RegisterFlagEffect(0,RESET_EVENT+RESETS_STANDARD,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(id,2))
+		tc:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(id,2))
 	end
+end
+function s.actcon(e,tp,eg,ep,ev,re,r,rp)
+	local tc=e:GetLabelObject()
+	if tc:GetFlagEffect(id)==0 then
+		e:Reset()
+		return false
+	end
+	return tc:GetFlagEffect(id)>0
 end
 function s.actop(e,tp,eg,ep,ev,re,r,rp)
 	if re:IsActiveType(TYPE_RITUAL) and re:IsActiveType(TYPE_MONSTER) and ep==tp then
@@ -85,4 +94,3 @@ end
 function s.chainlm(e,rp,tp)
 	return tp==rp
 end
-

--- a/script/c86124104.lua
+++ b/script/c86124104.lua
@@ -75,7 +75,7 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetOperation(s.actop)
 		e1:SetLabelObject(tc)
 		Duel.RegisterEffect(e1,tp)
-		tc:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(id,2))
+		tc:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_CONTROL,EFFECT_FLAG_CLIENT_HINT,1,0,aux.Stringid(id,2))
 	end
 end
 function s.actcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
- Demise, Agent of Armageddon: His last effect was not resetting properly. Also, a small ruling update.
- Ruin, Angel of Oblivion: Her last effect should only prevent effects from being activated on attack declaration. Also, updated the reset handling.
- Gingerbread House: Fixed a small error in the LP gaining part of the effect.
- Karma of the Destruction Swordsman: Should be negatable by "Ghost Belle & Haunted Mansion".