### PR TITLE
Fixes/updates

### DIFF
--- a/script/c100200164.lua
+++ b/script/c100200164.lua
@@ -28,7 +28,8 @@ end
 function s.rmop(e,tp,eg,ep,ev,re,r,rp)
 	local ac=Duel.GetChainInfo(0,CHAININFO_TARGET_PARAM)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local tc=Duel.SelectMatchingCard(tp,s.rmfilter,tp,LOCATION_DECK,0,1,1,nil,ac)
+	local g=Duel.SelectMatchingCard(tp,s.rmfilter,tp,LOCATION_DECK,0,1,1,nil,ac)
+	local tc=g:GetFirst()
 	if tc and Duel.Remove(tc,POS_FACEUP,REASON_EFFECT)~=0 and tc:IsLocation(LOCATION_REMOVED) then
 		local c=e:GetHandler()
 		local e1=Effect.CreateEffect(c)

--- a/script/c31189536.lua
+++ b/script/c31189536.lua
@@ -1,5 +1,5 @@
 --ヴァンパイア・アウェイク
-
+--Vampire Awakening
 --Script by nekrozar
 local s,id=GetID()
 function s.initial_effect(c)
@@ -9,6 +9,7 @@ function s.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCountLimit(1,id+EFFECT_COUNT_CODE_OATH)
+	e1:SetHintTiming(TIMING_END_PHASE)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
@@ -51,4 +52,3 @@ end
 function s.desop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Destroy(e:GetLabelObject(),REASON_EFFECT)
 end
-

--- a/script/c4638410.lua
+++ b/script/c4638410.lua
@@ -1,4 +1,5 @@
 --暴君の威圧
+--Tyrant's Temper
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -17,13 +18,9 @@ function s.initial_effect(c)
 	e2:SetValue(s.efilter)
 	c:RegisterEffect(e2)
 end
-function s.cfilter(c,ft,tp)
-	return ft>0 or (c:IsControler(tp) and c:GetSequence()<5)
-end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
-	if chk==0 then return ft>-1 and Duel.CheckReleaseGroupCost(tp,s.cfilter,1,false,nil,nil,ft,tp) end
-	local g=Duel.SelectReleaseGroupCost(tp,s.cfilter,1,1,false,nil,nil,ft,tp)
+	if chk==0 then return Duel.CheckReleaseGroupCost(tp,aux.TRUE,1,false,nil,nil,tp) end
+	local g=Duel.SelectReleaseGroupCost(tp,aux.TRUE,1,1,false,nil,nil,tp)
 	Duel.Release(g,REASON_COST)
 end
 function s.etarget(e,c)

--- a/script/c74798297.lua
+++ b/script/c74798297.lua
@@ -1,5 +1,5 @@
 --不知火流 才華の陣
---Shiranui Style Skill
+--Shiranui Style Success
 --Logical Nonsense
 local s,id=GetID()
 function s.initial_effect(c)
@@ -9,6 +9,7 @@ function s.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetCountLimit(1,id)
+	e1:SetHintTiming(TIMING_END_PHASE)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
@@ -72,4 +73,3 @@ end
 function s.efilter(e,re)
 	return e:GetHandler()~=re:GetOwner()
 end
-


### PR DESCRIPTION
- Tyrant's Temper: Removed incorrect exclusion of the EMZ.
- Crossout Designator: Fixed a script error.
- Vampire Awakening: Added hint timing for the End Phase.
- Shiranui Style Success: Added hint timing for the End Phase.