### PR TITLE
Various fixes/updates

### DIFF
--- a/script/c100250008.lua
+++ b/script/c100250008.lua
@@ -18,7 +18,7 @@ function s.initial_effect(c)
 	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
 	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e2:SetCode(EVENT_BATTLE_DESTROYING)
-	e2:SetCountLimit(1,id)
+	e2:SetCountLimit(1,id+100)
 	e2:SetCondition(aux.bdocon)
 	e2:SetCost(s.spcost)
 	e2:SetTarget(s.sptg)
@@ -42,24 +42,24 @@ function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 	e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 	c:RegisterEffect(e1)
 end
-function s.filter(c,e,tp)
+function s.spfilter(c,e,tp)
 	return c:IsRace(RACE_FISH+RACE_SEASERPENT+RACE_AQUA) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
-function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsReleasable() end
 	Duel.Release(e:GetHandler(),REASON_COST)
 end
-function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
 	if e:GetHandler():GetSequence()<5 then ft=ft+1 end
-	if chk==0 then return ft>0 and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK+LOCATION_HAND,0,1,nil,e,tp) end
+	if chk==0 then return ft>0 and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,nil,e,tp) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK+LOCATION_HAND)
 end
-function s.operation(e,tp,eg,ep,ev,re,r,rp)
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
-	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,e,tp)
-	if g:GetCount()>0 then
+	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK+LOCATION_HAND,0,1,1,nil,e,tp)
+	if #g>0 then
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c28806532.lua
+++ b/script/c28806532.lua
@@ -1,0 +1,90 @@
+--曇天気スレット
+--The Weather Painter Cloud
+--Scripted by Eerie Code
+local s,id=GetID()
+function s.initial_effect(c)
+	--place
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_TO_GRAVE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET+EFFECT_FLAG_DELAY)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1,id)
+	e1:SetCondition(s.tfcon)
+	e1:SetTarget(s.tftg)
+	e1:SetOperation(s.tfop)
+	c:RegisterEffect(e1)
+	--spsummon
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e2:SetCode(EVENT_REMOVE)
+	e2:SetOperation(s.spreg)
+	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(id,1))
+	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e3:SetRange(LOCATION_REMOVED)
+	e3:SetCode(EVENT_PHASE+PHASE_STANDBY)
+	e3:SetCondition(s.spcon)
+	e3:SetTarget(s.sptg)
+	e3:SetOperation(s.spop)
+	e3:SetLabelObject(e2)
+	c:RegisterEffect(e3)
+end
+function s.tfcfilter(c,tp)
+	return c:IsPreviousPosition(POS_FACEUP) and c:IsPreviousControler(tp) and c:IsPreviousSetCard(0x109) and c:IsPreviousLocation(LOCATION_ONFIELD)
+end
+function s.tfcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.tfcfilter,1,e:GetHandler(),tp)
+end
+function s.tffilter(c,tp)
+	return c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSetCard(0x109) and not c:IsForbidden() and c:CheckUniqueOnField(tp)
+end
+function s.tftg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.tffilter(chkc,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and Duel.IsExistingTarget(s.tffilter,tp,LOCATION_GRAVE,0,1,nil,tp) end
+	local ct=math.min(Duel.GetLocationCount(tp,LOCATION_SZONE),2)
+	local g=Duel.SelectTarget(tp,s.tffilter,tp,LOCATION_GRAVE,0,1,ct,nil,tp)
+	Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,g,g:GetCount(),0,0)
+end
+function s.tfop(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS):Filter(Card.IsRelateToEffect,nil,e)
+	if g:GetCount()<=0 then return end
+	local ct=math.min(2,Duel.GetLocationCount(tp,LOCATION_SZONE))
+	if ct<1 then return end
+	if g:GetCount()>ct then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOFIELD)
+		g=g:Select(tp,1,ct,nil)
+	end
+	for tc in aux.Next(g) do
+		Duel.MoveToField(tc,tp,tp,LOCATION_SZONE,POS_FACEUP,true)
+	end
+end
+function s.spreg(e,tp,eg,ep,ev,re,r,rp)
+	if not re then return end
+	local c=e:GetHandler()
+	local rc=re:GetHandler()
+	if c:IsReason(REASON_COST) and rc:IsSetCard(0x109) then
+		e:SetLabel(Duel.GetTurnCount()+1)
+		c:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END,0,2)
+	end
+end
+function s.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetLabelObject():GetLabel()==Duel.GetTurnCount() and e:GetHandler():GetFlagEffect(id)>0
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
+	e:GetHandler():ResetFlagEffect(id)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) then
+		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
+	end
+end

--- a/script/c3868277.lua
+++ b/script/c3868277.lua
@@ -1,0 +1,38 @@
+--ＴＧＸ３－ＤＸ２
+--TGX3-DX2
+local s,id=GetID()
+function s.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_TODECK+CATEGORY_DRAW)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.activate)
+	c:RegisterEffect(e1)
+end
+function s.filter(c)
+	return c:IsSetCard(0x27) and c:IsType(TYPE_MONSTER) and c:IsAbleToDeck()
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc) end
+	if chk==0 then return Duel.IsPlayerCanDraw(tp,2)
+		and Duel.IsExistingTarget(s.filter,tp,LOCATION_GRAVE,0,3,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TODECK)
+	local g=Duel.SelectTarget(tp,s.filter,tp,LOCATION_GRAVE,0,3,3,nil)
+	Duel.SetOperationInfo(0,CATEGORY_TODECK,g,g:GetCount(),0,0)
+	Duel.SetOperationInfo(0,CATEGORY_DRAW,nil,0,tp,2)
+end
+function s.activate(e,tp,eg,ep,ev,re,r,rp)
+	local tg=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	if not tg or tg:FilterCount(Card.IsRelateToEffect,nil,e)~=3 then return end
+	Duel.SendtoDeck(tg,nil,0,REASON_EFFECT)
+	local g=Duel.GetOperatedGroup()
+	if g:IsExists(Card.IsLocation,1,nil,LOCATION_DECK) then Duel.ShuffleDeck(tp) end
+	local ct=g:FilterCount(Card.IsLocation,nil,LOCATION_DECK+LOCATION_EXTRA)
+	if ct==3 then
+		Duel.BreakEffect()
+		Duel.Draw(tp,2,REASON_EFFECT)
+	end
+end

--- a/script/c74822425.lua
+++ b/script/c74822425.lua
@@ -1,4 +1,5 @@
 --エルシャドール・シェキナーガ
+--El Shaddoll Shekhinaga
 local s,id=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()
@@ -11,7 +12,7 @@ function s.initial_effect(c)
 	e2:SetRange(LOCATION_EXTRA)
 	e2:SetValue(aux.fuslimit)
 	c:RegisterEffect(e2)
-	--
+	--negate
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(id,0))
 	e3:SetCategory(CATEGORY_NEGATE+CATEGORY_DESTROY)
@@ -51,8 +52,7 @@ function s.distg(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function s.disop(e,tp,eg,ep,ev,re,r,rp)
-	Duel.NegateActivation(ev)
-	if re:GetHandler():IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)>0 then
+	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) and Duel.Destroy(eg,REASON_EFFECT)>0 then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local g=Duel.SelectMatchingCard(tp,Card.IsSetCard,tp,LOCATION_HAND,0,1,1,nil,0x9d)
 		if #g>0 then

--- a/script/c89662401.lua
+++ b/script/c89662401.lua
@@ -1,9 +1,7 @@
+--転生炎獣フォウル
 --Salamangreat Fowl
 --Logical Nonsense
-
---Substitute ID
 local s,id=GetID()
-
 function s.initial_effect(c)
 	--"Salamangreat" monster is normal summoned, optional trigger effect
 	local e1=Effect.CreateEffect(c)
@@ -35,7 +33,7 @@ function s.initial_effect(c)
 end
 	--If a "Salamangreat" monster is summoned to your field, besides "Salamangreat Fowl"
 function s.spfilter(c,tp)
-	return c:IsSetCard(0x119) and c:IsControler(tp) and not c:IsCode(id)
+	return c:IsSetCard(0x119) and c:IsControler(tp) and c:IsFaceup() and not c:IsCode(id)
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.spfilter,1,nil,tp)
@@ -81,4 +79,3 @@ function s.disop(e,tp,eg,ep,ev,re,r,rp)
 		tc:RegisterEffect(e1)
 	end
 end
-

--- a/script/c92015800.lua
+++ b/script/c92015800.lua
@@ -1,5 +1,5 @@
---No.76 諧調光師グラディエール
---Gladiyell the Melody Lumaestra
+--Ｎｏ．７６ 諧調光師グラディエール
+--Number 76: Gladiyell the Melody Lumaestra
 --Scripted by AlphaKretin
 local s,id=GetID()
 function s.initial_effect(c)
@@ -28,14 +28,15 @@ function s.initial_effect(c)
 	--attach material
 	local e4=Effect.CreateEffect(c)
 	e4:SetDescription(aux.Stringid(id,0))
-	e4:SetType(EFFECT_TYPE_IGNITION)
+	e4:SetType(EFFECT_TYPE_QUICK_O)
 	e4:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e4:SetCountLimit(1,id)
+	e4:SetCode(EVENT_FREE_CHAIN)
 	e4:SetRange(LOCATION_MZONE)
-	e4:SetCost(s.mtcost)
+	e3:SetHintTiming(TIMING_END_PHASE)
 	e4:SetTarget(s.mttg)
 	e4:SetOperation(s.mtop)
-	c:RegisterEffect(e4,false,REGISTER_FLAG_DETACH_XMAT)
+	c:RegisterEffect(e4)
 end
 s.xyz_number=76
 function s.attval(e,c)
@@ -53,13 +54,10 @@ function s.efindes(e,re,rp)
 	local c=e:GetHandler()
 	return re:GetHandler():IsAttribute(c:GetAttribute()) and re:IsActivated() and rp~=c:GetControler()
 end
-function s.mtcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
-	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
-end
 function s.mttg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(1-tp) and chkc:IsType(TYPE_MONSTER) end
-	if chk==0 then return Duel.IsExistingTarget(Card.IsType,tp,0,LOCATION_GRAVE,1,nil,TYPE_MONSTER) end
+	if chk==0 then return Duel.IsExistingTarget(Card.IsType,tp,0,LOCATION_GRAVE,1,nil,TYPE_MONSTER)
+		and e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_EFFECT) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	local g=Duel.SelectTarget(tp,Card.IsType,tp,0,LOCATION_GRAVE,1,1,nil,TYPE_MONSTER)
 	Duel.SetOperationInfo(0,CATEGORY_LEAVE_GRAVE,g,1,0,0)
@@ -67,7 +65,7 @@ end
 function s.mtop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
-	if c:IsRelateToEffect(e) and tc:IsRelateToEffect(e) then
+	if c:IsRelateToEffect(e) and c:RemoveOverlayCard(tp,1,1,REASON_EFFECT) and tc:IsRelateToEffect(e) then
 		Duel.Overlay(c,Group.FromCards(tc))
 	end
 end

--- a/script/c95113856.lua
+++ b/script/c95113856.lua
@@ -59,16 +59,16 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 	if off==1 then return end
 	local op=Duel.SelectOption(tp,table.unpack(ops))
-	if op==1 then
+	if op==0 then
 		local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)
 		Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,LOCATION_ONFIELD)
-	elseif op==2 then
+	elseif op==1 then
 		local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_HAND,nil)
 		Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,LOCATION_HAND)
-	elseif op==3 then
+	elseif op==2 then
 		local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_GRAVE,nil)
 		Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,LOCATION_GRAVE)
-	elseif op==4 then
+	elseif op==3 then
 		local g=Duel.GetDecktopGroup(1-tp,1)
 		Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,LOCATION_DECK)
 	end

--- a/script/c95113856.lua
+++ b/script/c95113856.lua
@@ -1,0 +1,110 @@
+--幻子力空母エンタープラズニル
+--Phantom Fortress Enterblathnir
+local s,id=GetID()
+function s.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,nil,9,2)
+	c:EnableReviveLimit()
+	--remove
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCountLimit(1)
+	e1:SetCost(s.cost)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.operation)
+	c:RegisterEffect(e1,false,1)
+end
+function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():CheckRemoveOverlayCard(tp,1,REASON_COST) end
+	e:GetHandler():RemoveOverlayCard(tp,1,1,REASON_COST)
+end
+function s.rmfilter(c)
+	return c:IsAbleToRemove() and (not c:IsLocation(LOCATION_GRAVE) or aux.SpElimFilter(c))
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.rmfilter,tp,0,LOCATION_ONFIELD+LOCATION_HAND+LOCATION_GRAVE+LOCATION_DECK,1,nil) end
+	local off=1
+	local ops={}
+	local opval={}
+	if Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD,1,nil) then
+		ops[off]=aux.Stringid(id,1)
+		opval[off-1]=1
+		off=off+1
+	end
+	if Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_HAND,1,nil) then
+		ops[off]=aux.Stringid(id,2)
+		opval[off-1]=2
+		off=off+1
+	end
+	if Duel.IsPlayerAffectedByEffect(1-tp,69832741) then
+		if Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_MZONE,1,nil) then
+			ops[off]=aux.Stringid(id,3)
+			opval[off-1]=3
+			off=off+1
+		end
+	else
+		if Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,nil) then
+			ops[off]=aux.Stringid(id,3)
+			opval[off-1]=3
+			off=off+1
+		end
+	end
+	if Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_DECK,1,nil) then
+		ops[off]=aux.Stringid(id,4)
+		opval[off-1]=4
+		off=off+1
+	end
+	if off==1 then return end
+	local op=Duel.SelectOption(tp,table.unpack(ops))
+	if op==1 then
+		local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_ONFIELD,nil)
+		Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,LOCATION_ONFIELD)
+	elseif op==2 then
+		local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_HAND,nil)
+		Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,LOCATION_HAND)
+	elseif op==3 then
+		local g=Duel.GetMatchingGroup(aux.TRUE,tp,0,LOCATION_GRAVE,nil)
+		Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,LOCATION_GRAVE)
+	elseif op==4 then
+		local g=Duel.GetDecktopGroup(1-tp,1)
+		Duel.SetOperationInfo(0,CATEGORY_REMOVE,g,1,0,LOCATION_DECK)
+	end
+	e:SetLabel(opval[op])
+end
+function s.operation(e,tp,eg,ep,ev,re,r,rp)
+	local op=e:GetLabel()
+	if op==1 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+		local g=Duel.SelectMatchingCard(tp,Card.IsAbleToRemove,tp,0,LOCATION_ONFIELD,1,1,nil)
+		if g:GetCount()>0 then
+			Duel.HintSelection(g)
+			Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
+		end
+	elseif op==2 then
+		local g=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,0,LOCATION_HAND,nil)
+		if g:GetCount()>0 then
+			local sg=g:RandomSelect(tp,1)
+			Duel.Remove(sg,POS_FACEUP,REASON_EFFECT)
+		end
+	elseif op==3 then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+		local g
+		if Duel.IsPlayerAffectedByEffect(1-tp,69832741) then
+			g=Duel.SelectMatchingCard(tp,Card.IsAbleToRemove,tp,0,LOCATION_MZONE,1,1,nil)
+		else
+			g=Duel.SelectMatchingCard(tp,Card.IsAbleToRemove,tp,0,LOCATION_GRAVE,1,1,nil)
+		end
+		if g:GetCount()>0 then
+			Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
+		end
+	elseif op==4 then
+		local g=Duel.GetDecktopGroup(1-tp,1)
+		if g:GetCount()>0 then
+			Duel.DisableShuffleCheck()
+			Duel.Remove(g,POS_FACEUP,REASON_EFFECT)
+		end
+	end
+end

--- a/script/c96220350.lua
+++ b/script/c96220350.lua
@@ -1,4 +1,4 @@
--- 覇勝星イダテン
+--覇勝星イダテン
 --Idaten the Conquer Star
 local s,id=GetID()
 function s.initial_effect(c)
@@ -42,7 +42,7 @@ end
 function s.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local bc=c:GetBattleTarget()
-	return bc and bc:IsLevelBelow(c:GetLevel()) and bc:IsControler(1-tp)
+	return bc and bc:IsLevelBelow(c:GetLevel()) and bc:GetAttack()>0 and bc:IsControler(1-tp)
 end
 function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 	local bc=e:GetHandler():GetBattleTarget()
@@ -89,4 +89,3 @@ function s.thop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,g)
 	end
 end
-


### PR DESCRIPTION
- Salamangreat Fowl: Its 1st effect should not trigger if the "Salamangreat" monster is summoned face-down.
- The Weather Painter Cloud: His 1st effect should not trigger if a "The Weather" card is sent to the GY from the opponent's field.
- TGX3-DX2: Should not be able to target "T.G." Spells/Traps.
- Number 76: Gladiyell the Melody Lumaestra: Her last effect should be a Quick Effect. Also, it should detach the Xyz Material as part of the effect and not as a cost.
- Idaten the Conqueror Star: Shouldn't be able to use his effect to make the monster's ATK 0 if it's already 0.
- Flying Carp: Fixed some typos in its second effect that caused script errors.
- El Shaddoll Shekhinaga: The negation effect should not destroy the monster if the activation of the effect was not negated successfully.
- Phantom Fortress Enterblathnir: Added operation info depending on the effect used.