### PR TITLE
"Gladiator Beast Darius" fix

### DIFF
--- a/script/c25924653.lua
+++ b/script/c25924653.lua
@@ -1,0 +1,113 @@
+--剣闘獣ダリウス
+--Gladiator Beast Darius
+local s,id=GetID()
+function s.initial_effect(c)
+	--grave special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(aux.gbspcon)
+	e1:SetTarget(s.spgtg)
+	e1:SetOperation(s.spgop)
+	c:RegisterEffect(e1)
+	--special summon
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,1))
+	e2:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_PHASE+PHASE_BATTLE)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCondition(s.spcon)
+	e2:SetCost(s.spcost)
+	e2:SetTarget(s.sptg)
+	e2:SetOperation(s.spop)
+	c:RegisterEffect(e2)
+	--leave field
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e3:SetCode(EVENT_LEAVE_FIELD)
+	e3:SetOperation(s.leave)
+	c:RegisterEffect(e3)
+end
+function s.spgfilter(c,e,tp)
+	return c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,104,tp,false,false)
+end
+function s.spgtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.spgfilter(chkc,e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(s.spgfilter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,s.spgfilter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function s.spgop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and Duel.SpecialSummon(tc,104,tp,tp,false,false,POS_FACEUP)>0
+		and c:IsFaceup() and c:IsRelateToEffect(e) then
+		c:SetCardTarget(tc)
+		tc:RegisterFlagEffect(id+1,RESET_EVENT+0x53e0000,0,1)
+		--negate
+		local e1=Effect.CreateEffect(c)
+		e1:SetType(EFFECT_TYPE_SINGLE)
+		e1:SetProperty(EFFECT_FLAG_OWNER_RELATE)
+		e1:SetCode(EFFECT_DISABLE)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e1:SetCondition(s.discon)
+		tc:RegisterEffect(e1)
+		local e2=Effect.CreateEffect(c)
+		e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+		e2:SetCode(EVENT_CHAIN_SOLVING)
+		e2:SetRange(LOCATION_MZONE)
+		e2:SetReset(RESET_EVENT+RESETS_STANDARD)
+		e2:SetLabelObject(tc)
+		e2:SetOperation(s.disop)
+		c:RegisterEffect(e2)
+	end
+end
+function s.discon(e)
+	return e:GetOwner():IsHasCardTarget(e:GetHandler())
+end
+function s.disop(e,tp,eg,ep,ev,re,r,rp)
+	Debug.Message(re:GetHandler()==e:GetLabelObject())
+	Debug.Message(re:GetHandler():GetFlagEffect(id+1)~=0)
+	if re:GetHandler()==e:GetLabelObject() and re:GetHandler():GetFlagEffect(id+1)~=0 then
+		Duel.NegateEffect(ev)
+	end
+end
+function s.leave(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	local tc=c:GetFirstCardTarget()
+	if tc and tc:IsLocation(LOCATION_MZONE) and tc:GetFlagEffect(id+1)~=0 then
+		Duel.SendtoDeck(tc,nil,2,REASON_EFFECT)
+	end
+end
+function s.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetBattledGroupCount()>0
+end
+function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsAbleToDeckAsCost() end
+	Duel.SendtoDeck(c,nil,2,REASON_COST)
+end
+function s.filter(c,e,tp)
+	return not c:IsCode(id) and c:IsSetCard(0x19) and c:IsCanBeSpecialSummoned(e,104,tp,false,false)
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>-1
+		and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	local tc=g:GetFirst()
+	if tc then
+		Duel.SpecialSummon(tc,104,tp,tp,false,false,POS_FACEUP)		
+		tc:RegisterFlagEffect(tc:GetOriginalCode(),RESET_EVENT+RESETS_STANDARD_DISABLE,0,0)
+	end
+end

--- a/script/c25924653.lua
+++ b/script/c25924653.lua
@@ -72,8 +72,6 @@ function s.discon(e)
 	return e:GetOwner():IsHasCardTarget(e:GetHandler())
 end
 function s.disop(e,tp,eg,ep,ev,re,r,rp)
-	Debug.Message(re:GetHandler()==e:GetLabelObject())
-	Debug.Message(re:GetHandler():GetFlagEffect(id+1)~=0)
 	if re:GetHandler()==e:GetLabelObject() and re:GetHandler():GetFlagEffect(id+1)~=0 then
 		Duel.NegateEffect(ev)
 	end


### PR DESCRIPTION
Fixed a bug where the negation effect would still be applied if the monster previously summoned with the effect of Darius was still on the field when the same copy of Darius used its revival effect again.