### PR TITLE
Update c981540.lua

### DIFF
--- a/script/c981540.lua
+++ b/script/c981540.lua
@@ -1,23 +1,21 @@
 --ハーフ・アンブレイク
---Half Unbreak
-local s,id=GetID()
-function s.initial_effect(c)
+function c981540.initial_effect(c)
 	--Activate
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
-	e1:SetTarget(s.target)
-	e1:SetOperation(s.activate)
+	e1:SetTarget(c981540.target)
+	e1:SetOperation(c981540.activate)
 	c:RegisterEffect(e1)
 end
-function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+function c981540.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsLocation(LOCATION_MZONE) end
 	if chk==0 then return Duel.IsExistingTarget(nil,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	Duel.SelectTarget(tp,nil,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,nil)
 end
-function s.activate(e,tp,eg,ep,ev,re,r,rp)
+function c981540.activate(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	local tc=Duel.GetFirstTarget()
 	if tc:IsRelateToEffect(e) then
@@ -25,20 +23,20 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_INDESTRUCTABLE_BATTLE)
 		e1:SetValue(1)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		e1:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
 		tc:RegisterEffect(e1)
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
 		e2:SetCode(EVENT_PRE_BATTLE_DAMAGE)
-		e2:SetCondition(s.rdcon)
-		e2:SetOperation(s.rdop)
-		e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
-		Duel.RegisterEffect(e2,tp)
+		e2:SetCondition(c981540.rdcon)
+		e2:SetOperation(c981540.rdop)
+		e2:SetReset(RESET_EVENT+0x1fe0000+RESET_PHASE+PHASE_END)
+		tc:RegisterEffect(e2)
 	end
 end
-function s.rdcon(e,tp,eg,ep,ev,re,r,rp)
-	return ep==e:GetOwnerPlayer()
+function c981540.rdcon(e,tp,eg,ep,ev,re,r,rp)
+	return ep==e:GetOwnerPlayer() and e:GetHandler():IsRelateToBattle()
 end
-function s.rdop(e,tp,eg,ep,ev,re,r,rp)
+function c981540.rdop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.ChangeBattleDamage(ep,ev/2)
 end


### PR DESCRIPTION
Fixed the bug with Half Unbreak

Before fix: halved all battle damage the activator took that turn

After fix: fixed so that damage is only halved if the targeted monster was involved