### PR TITLE
Fix for Number 26

### DIFF
--- a/script/c39622156.lua
+++ b/script/c39622156.lua
@@ -65,6 +65,14 @@ function s.btop(e,tp,eg,ep,ev,re,r,rp)
     e3:SetTargetRange(LOCATION_MZONE,0)
     e3:SetTarget(aux.TargetBoolFunction(Card.IsType,TYPE_MONSTER))
     Duel.RegisterEffect(e3,p)
+	--
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_SINGLE)
+	e4:SetCode(EFFECT_CANNOT_SELECT_BATTLE_TARGET)
+	e4:SetTargetRange(LOCATION_MZONE,0)
+	e4:SetValue(1)
+	e4:SetReset(RESET_PHASE+PHASE_END)
+	Duel.RegisterEffect(e4,p)
 end
 function s.atkcon(e)
     return Duel.GetFlagEffect(e:GetHandlerPlayer(),id)~=0


### PR DESCRIPTION
Fixed a bug with "Number 26: Octobypass the Dimensional Pathway"'s effect where the monster would still be allowed to attack other monsters