### PR TITLE
Fixed "Abyss Playhouse – Fantastic Theater"

### DIFF
--- a/script/c77297908.lua
+++ b/script/c77297908.lua
@@ -21,7 +21,7 @@ function s.initial_effect(c)
 	--change effect
 	local e3=Effect.CreateEffect(c)
 	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-	e3:SetCode(EVENT_CHAINING)
+	e3:SetCode(EVENT_CHAIN_SOLVING)
 	e3:SetRange(LOCATION_FZONE)
 	e3:SetCountLimit(1,id+1)
 	e3:SetCondition(s.chcon1)


### PR DESCRIPTION
Fixed a bug where if multiples effects of the opponent were activated while the conditions were meet, the lowest chain link would be negated instead of the highest one. Credits to Andre