### PR TITLE
"Marincess" fixes

### DIFF
--- a/script/c101010053.lua
+++ b/script/c101010053.lua
@@ -69,7 +69,7 @@ function s.efilter(e,re)
 	return e:GetOwnerPlayer()~=re:GetOwnerPlayer()
 end
 function s.eqcfilter(c,tp)
-	return c:IsSetCard(0x12b) and c:IsType(TYPE_LINK) and c:IsSummonType(SUMMON_TYPE_LINK) and c:GetSequence()>=5
+	return c:IsSetCard(0x12b) and c:IsType(TYPE_LINK) and c:IsSummonType(SUMMON_TYPE_LINK) and c:GetSequence()>=5 and c:IsSummonPlayer(tp) 
 end
 function s.eqfilter(c)
 	return c:IsSetCard(0x12b) and c:IsType(TYPE_LINK) and not c:IsForbidden()

--- a/script/c101010067.lua
+++ b/script/c101010067.lua
@@ -27,7 +27,7 @@ function s.filter(c,e,tp)
 		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_EXTRA,0,1,nil,e,tp,c:GetLink()) 
 end
 function s.spfilter(c,e,tp,lk)
-	return c:IsSetCard(0x12b) and c:IsType(TYPE_LINK) and c:IsLinkBelow(lk)
+	return c:IsSetCard(0x12b) and c:IsType(TYPE_LINK) and c:GetLink()<lk
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_LINK,tp,false,false)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)

--- a/script/c101010068.lua
+++ b/script/c101010068.lua
@@ -26,14 +26,18 @@ function s.cfilter(c,tp)
 	return c:IsFaceup() and c:IsType(TYPE_LINK) and c:IsSetCard(0x12b) and c:IsAbleToRemoveAsCost()
 		and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,c)
 end
+function s.rescon(sg,e,tp,mg)
+	return Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,sg)
+end
 function s.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil,tp) end
 	local ct=99
 	local tgct=Duel.GetTargetCount(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	local mct=Duel.GetMatchingGroupCount(s.cfilter,tp,LOCATION_MZONE,0,1,nil,tp)
 	if tgct==mct then ct=mct-1 end
-	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectMatchingCard(tp,s.cfilter,tp,LOCATION_MZONE,0,1,ct,nil,tp)
+	if ct==0 then ct=1 end
+	local mg=Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_MZONE,0,nil)
+	local g=aux.SelectUnselectGroup(mg,e,tp,1,ct,s.rescon,1,tp,HINTMSG_REMOVE,nil,nil)
 	if Duel.Remove(g,POS_FACEUP,REASON_COST+REASON_TEMPORARY)==#g then
 		g:KeepAlive()
 		e:SetLabelObject(g)

--- a/script/c101010068.lua
+++ b/script/c101010068.lua
@@ -22,13 +22,18 @@ function s.initial_effect(c)
 	c:RegisterEffect(e2)
 end
 s.listed_series={0x12b}
-function s.cfilter(c)
+function s.cfilter(c,tp)
 	return c:IsFaceup() and c:IsType(TYPE_LINK) and c:IsSetCard(0x12b) and c:IsAbleToRemoveAsCost()
+		and Duel.IsExistingTarget(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,1,c)
 end
 function s.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil,tp) end
+	local ct=99
+	local tgct=Duel.GetTargetCount(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
+	local mct=Duel.GetMatchingGroupCount(s.cfilter,tp,LOCATION_MZONE,0,1,nil,tp)
+	if tgct==mct then ct=mct-1 end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
-	local g=Duel.SelectMatchingCard(tp,s.cfilter,tp,LOCATION_MZONE,0,1,99,nil)
+	local g=Duel.SelectMatchingCard(tp,s.cfilter,tp,LOCATION_MZONE,0,1,ct,nil,tp)
 	if Duel.Remove(g,POS_FACEUP,REASON_COST+REASON_TEMPORARY)==#g then
 		g:KeepAlive()
 		e:SetLabelObject(g)

--- a/script/c101010068.lua
+++ b/script/c101010068.lua
@@ -33,10 +33,9 @@ function s.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil,tp) end
 	local ct=99
 	local tgct=Duel.GetTargetCount(Card.IsFaceup,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
-	local mct=Duel.GetMatchingGroupCount(s.cfilter,tp,LOCATION_MZONE,0,1,nil,tp)
-	if tgct==mct then ct=mct-1 end
+	local mg=Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_MZONE,0,nil,tp)
+	if tgct==#mg then ct=#mg-1 end
 	if ct==0 then ct=1 end
-	local mg=Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_MZONE,0,nil)
 	local g=aux.SelectUnselectGroup(mg,e,tp,1,ct,s.rescon,1,tp,HINTMSG_REMOVE,nil,nil)
 	if Duel.Remove(g,POS_FACEUP,REASON_COST+REASON_TEMPORARY)==#g then
 		g:KeepAlive()

--- a/script/c84430165.lua
+++ b/script/c84430165.lua
@@ -21,24 +21,25 @@ function s.initial_effect(c)
     e2:SetCondition(s.actcon)
     c:RegisterEffect(e2)
 end
-function s.cfilter(c)
-    return c:IsFaceup() and c:IsSetCard(0x12b) and c:IsType(TYPE_LINK)
+function s.cfilter(c,tp)
+    return c:IsFaceup() and c:IsSetCard(0x12b) and c:IsType(TYPE_LINK) and c:IsControler(tp)
 end
 function s.damcon(e,tp,eg,ep,ev,re,r,rp)
-    return s.cfilter(eg:GetFirst())
+    return s.cfilter(eg:GetFirst(),tp)
 end
 function s.damtg(e,tp,eg,ep,ev,re,r,rp,chk)
-    if chk==0 then return true end
+	if chk==0 then return eg:GetFirst():IsRelateToBattle() end
     Duel.SetTargetPlayer(1-tp)
-    Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,0)
+    Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,eg:GetFirst():GetLink()*400)
 end
 function s.damop(e,tp,eg,ep,ev,re,r,rp)
     local p=Duel.GetChainInfo(0,CHAININFO_TARGET_PLAYER)
     local ac=eg:GetFirst()
     Duel.Damage(p,ac:GetLink()*400,REASON_EFFECT)
-    if Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_MZONE,0,nil):IsExists(Card.IsLinkAbove,1,nil,2)
+    if Duel.GetMatchingGroup(s.cfilter,tp,LOCATION_MZONE,0,nil,tp):IsExists(Card.IsLinkAbove,1,nil,2)
         and ac:GetBattleTarget():IsType(TYPE_LINK) and ac:GetLink()>0 then
-        Duel.Damage(p,ac:GetBattleTarget():GetLink()*500,REASON_EFFECT)
+        Duel.BreakEffect()
+		Duel.Damage(p,ac:GetBattleTarget():GetLink()*500,REASON_EFFECT)
     end
 end
 function s.actfilter(c)


### PR DESCRIPTION
- Marincess Snow: Should not be able to summon a "Marincess" with equal Link Rating.
- Marincess Battle Ocean: Its equip effect should not trigger if the opponent summons the "Marincess" monster.
- Marincess Current: Should not be activatable if the opponent's "Marincess" Link Monster destroys a monster by battle or if your "Marincess" Link Monster is also destroyed in the battle.
- Marincess Cascade: Should not allow you to banish all your "Marincess" Link Monsters and leave you with no valid target for the effect.