### PR TITLE
Small fix for Union procedure

### DIFF
--- a/script/proc_union.lua
+++ b/script/proc_union.lua
@@ -90,7 +90,7 @@ end
 function Auxiliary.UnionSumTarget(oldrule)
 	return function (e,tp,eg,ep,ev,re,r,rp,chk)
 		local c=e:GetHandler()
-		local code=c:GetCode()
+		local code=c:GetOriginalCode()
 		local pos=POS_FACEUP
 		if oldrule then pos=POS_FACEUP_ATTACK end
 		if chk==0 then return c:GetFlagEffect(code)==0 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0


### PR DESCRIPTION
Previously, cards with current names different in the Spell & Trap Zone than their original name can use their effect to Equip and Special Summon once each.