### PR TITLE
Fix for "Shooting Riser Dragon"

### DIFF
--- a/script/c68431965.lua
+++ b/script/c68431965.lua
@@ -73,7 +73,7 @@ function s.lvop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.aclimit(e,re,tp)
 	local tc=e:GetLabelObject()
-	return re:GetHandler():IsCode(tc:GetCode()) and not re:GetHandler():IsImmuneToEffect(e)
+	return re:GetHandler():IsCode(tc:GetCode()) and re:IsActiveType(TYPE_MONSTER) and not re:GetHandler():IsImmuneToEffect(e)
 end
 function s.sccon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetTurnPlayer()~=tp and (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)


### PR DESCRIPTION
Fixed a bug where the player would be unable to activate a Pendulum Monster in the Pendulum Zone with the same name as the monster sent to the graveyard with Shooting Riser Dragon's effect.