### PR TITLE
Fixed "Valkyrie’s Embrace"

### DIFF
--- a/script/c45584727.lua
+++ b/script/c45584727.lua
@@ -1,4 +1,4 @@
---
+--ワルキューレの抱ほう擁
 --Valkyrie's Embrace
 --scripted by Naim
 local s,id=GetID()
@@ -60,11 +60,11 @@ end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local ex1,tg1=Duel.GetOperationInfo(0,CATEGORY_POSITION)
 	local ex2,tg2=Duel.GetOperationInfo(0,CATEGORY_REMOVE)
-	if tg1:GetFirst() and tg1:GetFirst():IsRelateToEffect(e) then
-		Duel.ChangePosition(tg1,POS_FACEUP_DEFENSE,POS_FACEUP_ATTACK,POS_FACEUP_ATTACK,POS_FACEUP_ATTACK)
-	end
-	if tg2:GetFirst() and tg2:GetFirst():IsRelateToEffect(e) then
-		Duel.Remove(tg2,POS_FACEUP,REASON_EFFECT)
+	if tg1:GetFirst() and tg1:GetFirst():IsRelateToEffect(e) and
+		Duel.ChangePosition(tg1,POS_FACEUP_DEFENSE,POS_FACEUP_ATTACK,POS_FACEUP_ATTACK,POS_FACEUP_ATTACK)~=0 then
+			if tg2:GetFirst() and tg2:GetFirst():IsRelateToEffect(e) then
+				Duel.Remove(tg2,POS_FACEUP,REASON_EFFECT)
+			end
 	end
 end
 


### PR DESCRIPTION
Fixed a bug where the effect would still banish the second target even if the position of the "Valkyrie" monster was not changed.