### PR TITLE
Fix for Hop-Eared Flying Squad

### DIFF
--- a/script/c101010029.lua
+++ b/script/c101010029.lua
@@ -24,8 +24,8 @@ function s.sccon(e,tp,eg,ep,ev,re,r,rp)
 		and (ph==PHASE_MAIN1 or ph==PHASE_MAIN2)
 end
 function s.scfilter1(c,tp,mc)
-	return c:IsFaceup() and not c:IsType(TYPE_TUNER) 
-		and Duel.IsExistingMatchingCard(s.scfilter2,tp,LOCATION_EXTRA,0,1,nil,tp,mc,Group.FromCards(c))
+	return c:IsFaceup()
+		and Duel.IsExistingMatchingCard(s.scfilter2,tp,LOCATION_EXTRA,0,1,nil,tp,mc,Group.FromCards(c,e:GetHandler()))
 end
 function s.scfilter2(c,tp,tc,mg)
 	return Duel.GetLocationCountFromEx(tp,tp,mg,c)>0 and c:IsSynchroSummonable(tc,mg)

--- a/script/c101010029.lua
+++ b/script/c101010029.lua
@@ -25,7 +25,7 @@ function s.sccon(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.scfilter1(c,tp,mc)
 	return c:IsFaceup()
-		and Duel.IsExistingMatchingCard(s.scfilter2,tp,LOCATION_EXTRA,0,1,nil,tp,mc,Group.FromCards(c,e:GetHandler()))
+		and Duel.IsExistingMatchingCard(s.scfilter2,tp,LOCATION_EXTRA,0,1,nil,tp,mc,Group.FromCards(c))
 end
 function s.scfilter2(c,tp,tc,mg)
 	return Duel.GetLocationCountFromEx(tp,tp,mg,c)>0 and c:IsSynchroSummonable(tc,mg)


### PR DESCRIPTION
Previous Hop-Eared Flying Squad could not use Phantom Knight Hydride as material for a Synchro Summon.