### PR TITLE
Fix for "Bangpoline"

### DIFF
--- a/script/c14839621.lua
+++ b/script/c14839621.lua
@@ -23,8 +23,8 @@ function s.initial_effect(c)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(1-tp,LOCATION_MZONE,nil,LOCATION_REASON_COUNT)+Duel.GetLocationCount(tp,LOCATION_MZONE,nil,LOCATION_REASON_COUNT)>0 end
-	local zone=Duel.SelectDisableField(tp,1,LOCATION_MZONE,LOCATION_MZONE,0)
-	Duel.SelectDisableField(1-tp,1,LOCATION_MZONE,LOCATION_MZONE,~(zone<<16)>>16)
+	local zone=Duel.SelectDisableField(tp,1,LOCATION_MZONE,LOCATION_MZONE,0,true)
+	Duel.SelectDisableField(1-tp,1,LOCATION_MZONE,LOCATION_MZONE,(~(zone<<16)>>16),true)
 	e:SetLabel(zone)
 end
 function s.thfilter(c,tp,zone)


### PR DESCRIPTION
According to rulings, it should allow the player to select an unused Extra Monster Zone