### PR TITLE
Fixes

### DIFF
--- a/script/c24101897.lua
+++ b/script/c24101897.lua
@@ -1,0 +1,66 @@
+--ゴーストリックの猫娘
+--Ghostrick Nekomusume
+local s,id=GetID()
+function s.initial_effect(c)
+	--summon limit
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_CANNOT_SUMMON)
+	e1:SetCondition(s.sumcon)
+	c:RegisterEffect(e1)
+	--turn set
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,0))
+	e2:SetCategory(CATEGORY_POSITION)
+	e2:SetType(EFFECT_TYPE_IGNITION)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTarget(s.postg)
+	e2:SetOperation(s.posop)
+	c:RegisterEffect(e2)
+	--change pos
+	local e3=Effect.CreateEffect(c)
+	e3:SetDescription(aux.Stringid(id,1))
+	e3:SetCategory(CATEGORY_POSITION)
+	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCondition(s.condition)
+	e3:SetTarget(s.target)
+	e3:SetOperation(s.operation)
+	c:RegisterEffect(e3)
+	local e4=e3:Clone()
+	e4:SetCode(EVENT_SUMMON_SUCCESS)
+	c:RegisterEffect(e4)
+end
+function s.sumcon(e)
+	return not Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsSetCard,0x8d),e:GetHandlerPlayer(),LOCATION_MZONE,0,1,nil)
+end
+function s.postg(e,tp,eg,ep,ev,re,r,rp,chk)
+	local c=e:GetHandler()
+	if chk==0 then return c:IsCanTurnSet() and c:GetFlagEffect(id)==0 end
+	c:RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD-RESET_TURN_SET+RESET_PHASE+PHASE_END,0,1)
+	Duel.SetOperationInfo(0,CATEGORY_POSITION,c,1,0,0)
+end
+function s.posop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsRelateToEffect(e) and c:IsFaceup() then
+		Duel.ChangePosition(c,POS_FACEDOWN_DEFENSE)
+	end
+end
+function s.condition(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsSetCard,0x8d),tp,LOCATION_MZONE,LOCATION_MZONE,1,e:GetHandler())
+end
+function s.filter(c,e)
+	return c:IsFaceup() and c:IsLevelAbove(4) and c:IsCanTurnSet() and (not e or c:IsRelateToEffect(e))
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return eg:IsExists(s.filter,1,nil) end
+	Duel.SetTargetCard(eg)
+	local g=eg:Filter(s.filter,nil)
+	Duel.SetOperationInfo(0,CATEGORY_POSITION,g,g:GetCount(),0,0)
+end
+function s.operation(e,tp,eg,ep,ev,re,r,rp)
+	if not Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsSetCard,0x8d),tp,LOCATION_MZONE,0,1,e:GetHandler()) then return end
+	local g=eg:Filter(s.filter,nil,e)
+	Duel.ChangePosition(g,POS_FACEDOWN_DEFENSE)
+end

--- a/script/c85909450.lua
+++ b/script/c85909450.lua
@@ -1,0 +1,60 @@
+--ハーピィズペット幻竜
+--Harpie's Pet Phantasmal Dragon
+local s,id=GetID()
+function s.initial_effect(c)
+	--xyz summon
+	aux.AddXyzProcedure(c,aux.FilterBoolFunction(Card.IsAttribute,ATTRIBUTE_WIND),4,3)
+	c:EnableReviveLimit()
+	--direct attack
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE)
+	e1:SetCode(EFFECT_DIRECT_ATTACK)
+	e1:SetCondition(s.effcon)
+	c:RegisterEffect(e1)
+	--cannot be target
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_CANNOT_SELECT_BATTLE_TARGET)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(0,LOCATION_MZONE)
+	e2:SetCondition(s.effcon)
+	e2:SetValue(s.atlimit)
+	c:RegisterEffect(e2)
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_FIELD)
+	e3:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
+	e3:SetProperty(EFFECT_FLAG_IGNORE_RANGE+EFFECT_FLAG_IGNORE_IMMUNE)
+	e3:SetRange(LOCATION_MZONE)
+	e3:SetCondition(s.effcon)
+	e3:SetTarget(s.efftg)
+	e3:SetValue(aux.tgoval)
+	c:RegisterEffect(e3)
+	--remove material
+	local e4=Effect.CreateEffect(c)
+	e4:SetDescription(aux.Stringid(id,0))
+	e4:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_F)
+	e4:SetCode(EVENT_PHASE+PHASE_END)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetCountLimit(1)
+	e4:SetCondition(s.rmcon)
+	e4:SetOperation(s.rmop)
+	c:RegisterEffect(e4)
+end
+function s.effcon(e)
+	return e:GetHandler():GetOverlayCount()>0
+end
+function s.atlimit(e,c)
+	return c:IsFaceup() and c:IsSetCard(0x64)
+end
+function s.efftg(e,c)
+	return c:IsSetCard(0x64) and c:IsType(TYPE_MONSTER)
+end
+function s.rmcon(e,tp,eg,ep,ev,re,r,rp)
+	return Duel.GetTurnPlayer()==tp
+end
+function s.rmop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:GetOverlayCount()>0 then
+		c:RemoveOverlayCard(tp,1,1,REASON_EFFECT)
+	end
+end

--- a/script/c91646304.lua
+++ b/script/c91646304.lua
@@ -1,5 +1,5 @@
 --神樹のパラディオン
---Palladion of the Sacred Tree
+--Crusadia Arboria
 --Scripted by ahtelel
 local s,id=GetID()
 function s.initial_effect(c)
@@ -39,7 +39,8 @@ function s.repfilter(c,tp)
 		and c:IsControler(tp) and c:IsReason(REASON_EFFECT+REASON_BATTLE) and not c:IsReason(REASON_REPLACE)
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetFlagEffect(tp,id)==0 and e:GetHandler():IsAbleToRemove() and eg:IsExists(s.repfilter,1,nil,tp) end
+	if chk==0 then return Duel.GetFlagEffect(tp,id)==0 and e:GetHandler():IsAbleToRemove()
+		and not e:GetHandler():IsStatus(STATUS_DESTROY_CONFIRMED) and eg:IsExists(s.repfilter,1,nil,tp) end
 	if Duel.SelectEffectYesNo(tp,e:GetHandler(),96) then
 		Duel.RegisterFlagEffect(tp,id,RESET_PHASE+PHASE_END,0,1)
 		return true
@@ -53,4 +54,3 @@ end
 function s.repop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Remove(e:GetHandler(),POS_FACEUP,REASON_EFFECT)
 end
-


### PR DESCRIPTION
- Crusadia Arboria: Shouldn't be able to apply her replacement effect if she would also be destroyed by the effect, as per rulings.
- Ghostrick Nekomusume: Her effect should activate even if the only other "Ghostrick" monster on the field is controlled by the opponent.
- Harpie's Pet Phantasmal Dragon: Should prevent the opponent from targeting "Harpie" monsters in other locations apart from the field (eg the GY).