### PR TITLE
Fix for "Linkmail Archfiend"

### DIFF
--- a/script/c68295149.lua
+++ b/script/c68295149.lua
@@ -80,7 +80,7 @@ function s.tgval(e,re,rp)
 	return re:IsActiveType(TYPE_MONSTER) and rp~=e:GetHandlerPlayer()
 end
 function s.repfilter(c,e)
-	return c:IsType(TYPE_FRSX) and c:IsAbleToRemove()
+	return c:IsType(TYPE_FRSX) and c:IsType(TYPE_MONSTER) and c:IsAbleToRemove()
 end
 function s.reptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()


### PR DESCRIPTION
Should not be able to banish a Ritual Spell from the GY to prevent its destruction