### PR TITLE
A few fixes/updates

### DIFF
--- a/script/c100423033.lua
+++ b/script/c100423033.lua
@@ -65,6 +65,7 @@ function s.operation(e,tp,eg,ep,ev,re,r,rp)
 			if #og>0 then
 			    Duel.SendtoGrave(og,REASON_RULE)
 			end
+			g:GetFirst():CancelToGrave()
 		    Duel.Overlay(c,g)
 		end
 	end

--- a/script/c16984449.lua
+++ b/script/c16984449.lua
@@ -1,0 +1,42 @@
+--炎妖蝶ウィルプス
+--Blazewing Butterfly
+local s,id=GetID()
+function s.initial_effect(c)
+	aux.EnableDualAttribute(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_IGNITION)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetRange(LOCATION_MZONE)
+	e1:SetCondition(aux.IsDualState)
+	e1:SetCost(s.cost)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.operation)
+	c:RegisterEffect(e1)
+end
+function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return e:GetHandler():IsReleasable() end
+	Duel.Release(e:GetHandler(),REASON_COST)
+end
+function s.filter(c,e,sp)
+	return c:IsType(TYPE_DUAL) and c:GetCode()~=id and c:IsCanBeSpecialSummoned(e,0,sp,false,false)
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return chkc:IsLocation(LOCATION_GRAVE) and chkc:IsControler(tp) and s.filter(chkc,e,tp) end
+	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)
+	if e:GetHandler():GetSequence()<5 then ft=ft+1 end
+	if chk==0 then return ft>0 and Duel.IsExistingTarget(s.filter,tp,LOCATION_GRAVE,0,1,nil,e,tp) end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectTarget(tp,s.filter,tp,LOCATION_GRAVE,0,1,1,nil,e,tp)
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,g,1,0,0)
+end
+function s.operation(e,tp,eg,ep,ev,re,r,rp)
+	local tc=Duel.GetFirstTarget()
+	if tc and tc:IsRelateToEffect(e) and Duel.SpecialSummonStep(tc,0,tp,tp,false,false,POS_FACEUP) then
+		tc:EnableDualState()
+		tc:RegisterFlagEffect(0,RESET_EVENT+RESETS_STANDARD,EFFECT_FLAG_CLIENT_HINT,1,0,64)
+		Duel.SpecialSummonComplete()
+	end
+end

--- a/script/c69109764.lua
+++ b/script/c69109764.lua
@@ -16,7 +16,7 @@ function s.initial_effect(c)
 	local e2=e1:Clone()
 	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
 	c:RegisterEffect(e2)
-	-- special summon
+	--special summon
 	local e3=Effect.CreateEffect(c)
 	e3:SetDescription(aux.Stringid(id,1))
 	e3:SetCategory(CATEGORY_SPECIAL_SUMMON)
@@ -30,7 +30,6 @@ function s.initial_effect(c)
 	e3:SetOperation(s.spop)
 	c:RegisterEffect(e3)
 end
-
 function s.tgfilter(c)
 	return c:IsRace(RACE_DRAGON) and c:IsLevelBelow(4) and c:IsType(TYPE_MONSTER) and c:IsAbleToHand()
 end
@@ -48,19 +47,17 @@ function s.thop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.ConfirmCards(1-tp,tc)
 	end
 end
-function s.filter(c)
-	return c:IsType(TYPE_LINK) and c:IsFaceup()
-end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
-	return aux.exccon(e) and not Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_MZONE,0,1,nil)
+	return aux.exccon(e) and not Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsType,TYPE_LINK),tp,LOCATION_MZONE,0,1,nil)
 end
 function s.spfilter(c,e,tp)
 	return c:IsRace(RACE_DRAGON) and c:IsAttribute(ATTRIBUTE_DARK) and c:IsType(TYPE_LINK)
-	and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp)
+		and c:IsCanBeSpecialSummoned(e,0,tp,false,false,POS_FACEUP,tp)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsLocation(LOCATION_GRAVE) and s.spfilter(chkc,e,tp) end
-	if chk==0 then return Duel.IsExistingTarget(s.spfilter,tp,LOCATION_GRAVE,0,1,e:GetHandler(),e,tp) end
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingTarget(s.spfilter,tp,LOCATION_GRAVE,0,1,e:GetHandler(),e,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
 	local tg=Duel.SelectTarget(tp,s.spfilter,tp,LOCATION_GRAVE,0,1,1,e:GetHandler(),e,tp)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,tg,1,0,0)
@@ -71,4 +68,3 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummon(tc,0,tp,tp,false,false,POS_FACEUP)
 	end
 end
-


### PR DESCRIPTION
- Hibernation Dragon: Should not be able to use its GY effect if you don't have a free MMZ.
- Jormungandr, Generaid of Eternity: Updated its script so that if the card selected to be attached to it would be sent to the GY by game mechanics, it's actually attached to it (based on the ruling for "Infinitrack Fortress Megaclops").
- Blazewing Butterfly: Added a hint on the card Special Summoned with its effect that indicates that the monster has gained its Gemini effects. Also, updated its script to work with "Evocator Eveque".

The last 2 changes are about still unreleased cards, so they are subject to change when we get the official rulings upon their release.