### PR TITLE
Fixes/updates

### DIFF
--- a/script/c37480144.lua
+++ b/script/c37480144.lua
@@ -12,9 +12,6 @@ function s.initial_effect(c)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
 end
-function s.filter(c)
-	return c:GetSequence()<5
-end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsInMainMZone(tp) end
 	if chk==0 then return Duel.IsExistingTarget(Card.IsInMainMZone,tp,LOCATION_MZONE,0,1,nil)
@@ -28,4 +25,3 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOZONE)
 	Duel.MoveSequence(tc,math.log(Duel.SelectDisableField(tp,1,LOCATION_MZONE,0,0),2))
 end
-

--- a/script/c41999284.lua
+++ b/script/c41999284.lua
@@ -1,8 +1,9 @@
 --リンクリボー
+--Linkuriboh
 local s,id=GetID()
 function s.initial_effect(c)
 	c:EnableReviveLimit()
-	aux.AddLinkProcedure(c,s.matfilter,1)
+	aux.AddLinkProcedure(c,aux.FilterBoolFunctionEx(Card.IsLevel,1),1)
 	--atk to 0
 	local e1=Effect.CreateEffect(c)
 	e1:SetCategory(CATEGORY_ATKCHANGE)
@@ -19,14 +20,12 @@ function s.initial_effect(c)
 	e2:SetType(EFFECT_TYPE_QUICK_O)
 	e2:SetCode(EVENT_FREE_CHAIN)
 	e2:SetRange(LOCATION_GRAVE)
+	e2:SetHintTiming(0,TIMING_BATTLE_START)
 	e2:SetCountLimit(1,id)
 	e2:SetCost(s.spcost)
 	e2:SetTarget(s.sptg)
 	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
-end
-function s.matfilter(c)
-	return c:GetLevel()==1
 end
 function s.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return tp~=Duel.GetTurnPlayer() and aux.nzatk(Duel.GetAttacker())
@@ -47,8 +46,7 @@ function s.atkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.cfilter(c,ft,tp)
-	return c:GetLevel()==1 and c:IsControler(tp)
-		and (ft>0 or c:GetSequence()<5)
+	return c:IsLevel(1) and (ft>0 or c:GetSequence()<5)
 end
 function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ft=Duel.GetLocationCount(tp,LOCATION_MZONE)

--- a/script/c51993760.lua
+++ b/script/c51993760.lua
@@ -1,5 +1,5 @@
 --抹殺の邪悪霊
---Dark Spirit of Denial
+--Dark Spirit of the Denial
 --scripted by Hatter
 local s,id=GetID()
 function s.initial_effect(c)
@@ -66,36 +66,8 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		local a=Duel.GetAttacker()
 		if a:IsAttackable() and not a:IsImmuneToEffect(e) then
 			Duel.CalculateDamage(a,tc)
-			local e1=Effect.CreateEffect(e:GetHandler())
-			e1:SetType(EFFECT_TYPE_FIELD)
-			e1:SetCode(EFFECT_AVOID_BATTLE_DAMAGE)
-			e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-			e1:SetTargetRange(1,0)
-			e1:SetValue(1)
-			Duel.RegisterEffect(e1,tp)
-			local e2=Effect.CreateEffect(e:GetHandler())
-			e2:SetDescription(aux.Stringid(70074904,0))
-			e2:SetCategory(CATEGORY_REMOVE)
-			e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-			e2:SetCode(EVENT_BATTLED)
-			e2:SetLabelObject(e1)
-			e2:SetOperation(s.resop)
-			Duel.RegisterEffect(e2,tp)
 		end
 	end
-end
-function s.resop(e,tp)
-	local c=e:GetHandler()
-	if not Duel.IsExistingMatchingCard(Card.IsStatus,tp,0,LOCATION_MZONE,1,nil,STATUS_BATTLE_DESTROYED) then
-		if c:GetFlagEffect(id)==0 then
-			c:RegisterFlagEffect(id,0,0,0)
-			return
-		end
-	end
-	c:ResetFlagEffect(id)
-	local e1=e:GetLabelObject()
-	e1:Reset()
-	e:Reset()
 end
 function s.cfilter(c,tp)
 	return c:IsLevel(8) and c:IsRace(RACE_FIEND) and c:IsControler(tp)

--- a/script/c61818176.lua
+++ b/script/c61818176.lua
@@ -34,7 +34,7 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,tc,1,0,0)
 end
 function s.actfilter(c,tp)
-	return c:IsType(TYPE_FIELD) and c:GetActivateEffect():IsActivatable(tp)
+	return c:IsType(TYPE_FIELD) and c:GetActivateEffect():IsActivatable(tp,true,true)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()

--- a/script/c73468603.lua
+++ b/script/c73468603.lua
@@ -1,0 +1,62 @@
+--盆回し
+--Set Rotation
+local s,id=GetID()
+function s.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.operation)
+	c:RegisterEffect(e1)
+end
+function s.filter(c)
+	return c:IsType(TYPE_FIELD) and c:IsSSetable()
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_DECK,0,nil)
+	if chk==0 then return g:GetClassCount(Card.GetCode)>1 end
+end
+function s.operation(e,tp,eg,ep,ev,re,r,rp)
+	local g=Duel.GetMatchingGroup(s.filter,tp,LOCATION_DECK,0,nil)
+	if g:GetClassCount(Card.GetCode)<2 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(id,0))
+	local tg1=g:Select(tp,1,1,nil)
+	g:Remove(Card.IsCode,nil,tg1:GetFirst():GetCode())
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(id,1))
+	local tg2=g:Select(tp,1,1,nil)
+	Duel.SSet(tp,tg1)
+	Duel.SSet(tp,tg2,1-tp)
+	tg1:GetFirst():RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD,0,1)
+	tg2:GetFirst():RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD,0,1)
+	tg1:Merge(tg2)
+	Duel.ConfirmCards(1-tp,tg1)
+	local e1=Effect.CreateEffect(e:GetHandler())
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_CANNOT_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e1:SetTargetRange(1,1)
+	e1:SetCondition(s.con)
+	e1:SetValue(s.actlimit)
+	Duel.RegisterEffect(e1,tp)
+	local e2=Effect.CreateEffect(e:GetHandler())
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_CANNOT_SSET)
+	e2:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
+	e2:SetTargetRange(1,1)
+	e2:SetCondition(s.con)
+	e2:SetTarget(s.setlimit)
+	Duel.RegisterEffect(e2,tp)
+end
+function s.cfilter(c)
+	return c:IsFacedown() and c:GetFlagEffect(id)~=0
+end
+function s.con(e)
+	return Duel.IsExistingMatchingCard(s.cfilter,0,LOCATION_FZONE,LOCATION_FZONE,1,nil)
+end
+function s.actlimit(e,re,tp)
+	return re:IsActiveType(TYPE_FIELD) and re:IsHasType(EFFECT_TYPE_ACTIVATE) and re:GetHandler():GetFlagEffect(id)==0
+end
+function s.setlimit(e,c,tp)
+	return c:IsType(TYPE_FIELD) and c:GetFlagEffect(id)==0
+end


### PR DESCRIPTION
- Ghostrick Renovation: Fixed a bug where you would be unable to activate a Field Spell with its effect from your hand during the opponent's turn.
- Set Rotation: Fixed a bug where it wouldn't Set a Field Spell to a player's zone if that player had used an effect that prevented them from Setting Spells/Traps that turn (eg "Ancient Gear Wyvern").
- Linkuriboh: Added hint timing to the GY effect for the start of the Battle Phase, also, that effect now works with "Lair of Darkness", plus general script cleanup.
- Dark Spirit of the Denial: Removed some unnecessary code which sometimes made the player not take damage after using its effect in the hand.
- Column Switch: Removed unused code.