### PR TITLE
"Fire Fist" fixes

### DIFF
--- a/script/c100255013.lua
+++ b/script/c100255013.lua
@@ -69,7 +69,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.repfilter(c,tp)
-	return c:IsControler(tp) and c:IsLocation(LOCATION_ONFIELD)
+	return c:IsControler(tp) and c:IsLocation(LOCATION_MZONE) and c:IsSetCard(0x79) and c:IsFaceup()
 		and c:IsReason(REASON_EFFECT) and not c:IsReason(REASON_REPLACE)
 		and c:GetReasonPlayer()~=tp
 end

--- a/script/c100255014.lua
+++ b/script/c100255014.lua
@@ -1,4 +1,4 @@
---Brotherhood of the Fire Fist - Antilope
+--Brotherhood of the Fire Fist - Eland
 --Scripted by Eerie Code
 local s,id=GetID()
 function s.initial_effect(c)
@@ -54,7 +54,7 @@ function s.setop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.negcon(e,tp,eg,ep,ev,re,r,rp)
 	return not e:GetHandler():IsStatus(STATUS_BATTLE_DESTROYED)
-		and ep~=tp and re:IsActiveType(TYPE_MONSTER) and Duel.IsChainNegatable(ev)
+		and ep~=tp and re:IsActiveType(TYPE_MONSTER) and Duel.IsChainDisablable(ev)
 end
 function s.cfilter(c)
 	return c:IsFaceup() and (c:IsSetCard(0x79) or c:IsSetCard(0x7c)) and not c:IsCode(id) and c:IsAbleToGraveAsCost()

--- a/script/c100255021.lua
+++ b/script/c100255021.lua
@@ -21,8 +21,8 @@ function s.filter2(c)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsHasType(EFFECT_TYPE_ACTIVATE) and Duel.IsChainNegatable(ev)
-		and Duel.IsExistingMatchingCard(s.cfilter1,tp,LOCATION_MZONE,0,1,nil)
-		and Duel.IsExistingMatchingCard(s.cfilter2,tp,LOCATION_SZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(s.filter1,tp,LOCATION_MZONE,0,1,nil)
+		and Duel.IsExistingMatchingCard(s.filter2,tp,LOCATION_SZONE,0,1,nil)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end


### PR DESCRIPTION
- Brotherhood of the Fire Fist - Eland: Should check if the effect can be negated, not if the activation can be negated.
- Brotherhood of the Fire Fist - Panda: Should only be able to protect your face-up "Fire Fist" monsters.
- Ultimate Fire Formation - Sinto: Fixed filter names.