### PR TITLE
Various fixes

### DIFF
--- a/script/c100255017.lua
+++ b/script/c100255017.lua
@@ -25,7 +25,6 @@ function s.initial_effect(c)
 	e2:SetProperty(EFFECT_FLAG_CARD_TARGET)
 	e2:SetCode(EVENT_ATTACK_ANNOUNCE)
 	e2:SetCountLimit(1,id)
-	--e2:SetCost(s.ctcost)
 	e2:SetTarget(s.cttg)
 	e2:SetOperation(s.ctop)
 	c:RegisterEffect(e2)
@@ -43,13 +42,14 @@ end
 	--Activation legality
 function s.cttg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local c=e:GetHandler()
-	if chkc then return chkc:GetLocation()==LOCATION_MZONE and chkc:GetControler()==1-tp and chkc:IsControlerCanBeChanged() end
+	local zone=c:GetLinkedZone()&0x1f
+	if chkc then return chkc:GetLocation()==LOCATION_MZONE and chkc:GetControler()==1-tp and chkc:IsControlerCanBeChanged(false,zone) end
 	local nc=Duel.IsExistingMatchingCard(s.ctfilter,tp,LOCATION_ONFIELD,0,1,nil)
-	if chk==0 then 
-		local zone=c:GetLinkedZone()&0x1f
+	local tgchk=Duel.IsExistingTarget(Card.IsControlerCanBeChanged,tp,0,LOCATION_MZONE,1,nil,false,zone)
+	if chk==0 then
 		if Duel.IsPlayerAffectedByEffect(tp,CARD_FIRE_FIST_EAGLE) then 
-			return Duel.IsExistingTarget(Card.IsControlerCanBeChanged,tp,0,LOCATION_MZONE,1,nil) 
-		else return nc end
+			return tgchk
+		else return nc and tgchk end
 	end
 	if nc and not (Duel.IsPlayerAffectedByEffect(tp,CARD_FIRE_FIST_EAGLE) and Duel.SelectYesNo(tp,aux.Stringid(CARD_FIRE_FIST_EAGLE,0))) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
@@ -57,7 +57,7 @@ function s.cttg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 		Duel.SendtoGrave(g1,REASON_COST)
 	end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_CONTROL)
-	local g2=Duel.SelectTarget(tp,Card.IsControlerCanBeChanged,tp,0,LOCATION_MZONE,1,1,nil)
+	local g2=Duel.SelectTarget(tp,Card.IsControlerCanBeChanged,tp,0,LOCATION_MZONE,1,1,nil,false,zone)
 	Duel.SetOperationInfo(0,CATEGORY_CONTROL,g2,1,0,0)
 end
 	--Take control of monster until end phase, it cannot attack

--- a/script/c100256013.lua
+++ b/script/c100256013.lua
@@ -8,7 +8,7 @@ function s.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_QUICK_O)
 	e1:SetCode(EVENT_FREE_CHAIN)
 	e1:SetRange(LOCATION_HAND)
-	e1:SetHintTiming(0,0x1e0)
+	e1:SetHintTiming(0,TIMING_MAIN_END+TIMING_SUMMON+TIMING_SPSUMMON)
 	e1:SetCountLimit(1,id)
 	e1:SetCondition(s.condition)
 	e1:SetTarget(s.target)
@@ -35,7 +35,7 @@ function s.checkop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetFlagEffect(1-tp,id)>=5
+	return Duel.GetFlagEffect(1-tp,id)>=5 and (Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	local c=e:GetHandler()

--- a/script/c72043279.lua
+++ b/script/c72043279.lua
@@ -1,5 +1,5 @@
--- 覇王城 
--- Supreme King Castle
+--覇王城 
+--Supreme King Castle
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -22,6 +22,7 @@ function s.initial_effect(c)
 	e3:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
 	e3:SetCode(EVENT_PRE_DAMAGE_CALCULATE)
 	e3:SetRange(LOCATION_FZONE)
+	e3:SetCountLimit(1)
 	e3:SetCondition(s.atkcon)
 	e3:SetCost(s.atkcost)
 	e3:SetOperation(s.atkop)
@@ -38,7 +39,7 @@ function s.atkcon(e,tp,eg,ep,ev,re,r,rp)
 	return bc:IsFaceup() and bc:IsRace(RACE_FIEND)
 end
 function s.atkcfilter(c)
-	return c:IsSetCard(0x6008) and c:IsAbleToGraveAsCost()
+	return c:IsType(TYPE_MONSTER) and c:IsSetCard(0x6008) and c:IsHasLevel() and c:IsAbleToGraveAsCost()
 end
 function s.atkcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.atkcfilter,tp,LOCATION_DECK+LOCATION_EXTRA,0,1,nil) end

--- a/script/c75884822.lua
+++ b/script/c75884822.lua
@@ -47,7 +47,6 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if s.thcon(e,tp,eg,ep,ev,re,r,rp)
 		and s.thtg(e,tp,eg,ep,ev,re,r,rp,0)
 		and Duel.SelectYesNo(tp,94) then
-		Duel.RegisterFlagEffect(tp,id,RESET_PHASE+PHASE_END,0,0)
 		e:SetCategory(CATEGORY_TOHAND+CATEGORY_SEARCH+CATEGORY_HANDES)
 		e:SetOperation(s.thop)
 		s.thtg(e,tp,eg,ep,ev,re,r,rp,1)
@@ -63,10 +62,10 @@ end
 function s.thfilter(c)
 	return c:IsSetCard(0xf) and c:IsAbleToHand()
 end
-function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
-	if chkc then return false end
+function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetFlagEffect(tp,id)==0
 		and Duel.IsExistingMatchingCard(s.thfilter,tp,LOCATION_DECK,0,1,nil) end
+	Duel.RegisterFlagEffect(tp,id,RESET_PHASE+PHASE_END,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,nil,1,tp,LOCATION_DECK)
 end
 function s.thop(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c82257940.lua
+++ b/script/c82257940.lua
@@ -1,0 +1,62 @@
+--プレゼント交換
+--Gift Exchange
+local s,id=GetID()
+function s.initial_effect(c)
+	--Activate
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_REMOVE)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.activate)
+	c:RegisterEffect(e1)
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,LOCATION_DECK,0,1,nil)
+		and Duel.IsExistingMatchingCard(Card.IsAbleToRemove,tp,0,LOCATION_DECK,1,nil) end
+end
+function s.activate(e,tp,eg,ep,ev,re,r,rp)
+	local g1=Duel.GetMatchingGroup(Card.IsAbleToRemove,tp,LOCATION_DECK,0,nil)
+	local g2=Duel.GetMatchingGroup(Card.IsAbleToRemove,1-tp,LOCATION_DECK,0,nil)
+	if g1:GetCount()==0 or g2:GetCount()==0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_REMOVE)
+	local rg1=g1:Select(tp,1,1,nil)
+	Duel.Hint(HINT_SELECTMSG,1-tp,HINTMSG_REMOVE)
+	local rg2=g2:Select(1-tp,1,1,nil)
+	rg1:Merge(rg2)
+	local c=e:GetHandler()
+	local fid=c:GetFieldID()
+	Duel.Remove(rg1,POS_FACEDOWN,REASON_EFFECT)
+	rg1:GetFirst():RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD,0,0,fid)
+	rg1:GetNext():RegisterFlagEffect(id,RESET_EVENT+RESETS_STANDARD,0,0,fid)
+	rg1:KeepAlive()
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
+	e1:SetCode(EVENT_PHASE+PHASE_END)
+	e1:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e1:SetReset(RESET_PHASE+PHASE_END)
+	e1:SetCountLimit(1)
+	e1:SetLabel(fid)
+	e1:SetLabelObject(rg1)
+	e1:SetCondition(s.thcon)
+	e1:SetOperation(s.thop)
+	Duel.RegisterEffect(e1,tp)
+end
+function s.thfilter(c,fid)
+	return c:GetFlagEffectLabel(id)==fid
+end
+function s.thcon(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetLabelObject()
+	if g:Filter(s.thfilter,nil,e:GetLabel()):GetCount()<2 then
+		g:DeleteGroup()
+		return false
+	else return true end
+end
+function s.thop(e,tp,eg,ep,ev,re,r,rp)
+	local g=e:GetLabelObject()
+	local tc1=g:GetFirst()
+	local tc2=g:GetNext()
+	g:DeleteGroup()
+	Duel.SendtoHand(tc1,1-tc1:GetControler(),REASON_EFFECT)
+	Duel.SendtoHand(tc2,1-tc2:GetControler(),REASON_EFFECT)
+end


### PR DESCRIPTION
- Ojama Pajama: Updated the way the HOPT on its first "●" is handled.
- Gift Exchange: Removed wrong category which made it negatable by things like "Ash Blossom & the Joyous Spring".
- Nibiru, the Primal Being: Its effect can only be activated in the Main Phase.
- Supreme King Castle: Added once per turn to its ATK boosting effect and updated the filter used.
- Brotherhood of the Fire Fist - Peacock: Can no longer activate the effect without a valid target, also properly checks if the zone she points to is available now.