### PR TITLE
"Rapid Trigger" fix

### DIFF
--- a/script/c67526112.lua
+++ b/script/c67526112.lua
@@ -24,7 +24,7 @@ end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then
 		local chkf=tp
-		local mg1=Duel.GetFusionMaterial(tp):Filter(Card.IsOnField,nil)
+		local mg1=Duel.GetFusionMaterial(tp):Filter(s.filter1,nil,e)
 		local res=Duel.IsExistingMatchingCard(s.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil,chkf)
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)


### PR DESCRIPTION
Was not using the filter for the Fusion Materials during the activation check (was only using it on resolution). As a result you could activate it in some scenarios where you should have been unable to do so.