### PR TITLE
Fixes

### DIFF
--- a/script/c100255011.lua
+++ b/script/c100255011.lua
@@ -40,7 +40,7 @@ function s.setfilter2(c,tc)
 end
 function s.settg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	if chkc then return chkc:IsControler(tp) and chkc:IsOnField() and s.setfilter(chkc,tp) end
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0 and Duel.IsExistingTarget(s.setfilter,tp,LOCATION_ONFIELD,0,1,nil,tp) end
+	if chk==0 then return Duel.IsExistingTarget(s.setfilter,tp,LOCATION_ONFIELD,0,1,nil,tp) end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TARGET)
 	Duel.SelectTarget(tp,s.setfilter,tp,LOCATION_ONFIELD,0,1,1,nil,tp)
 end

--- a/script/c100255011.lua
+++ b/script/c100255011.lua
@@ -46,7 +46,7 @@ function s.settg(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=Duel.GetFirstTarget()
-	if not (tc:IsRelateToEffect(e) and tc:IsFaceup() and Duel.GetLocationCount(tp,LOCATION_SZONE)>0) then return end
+	if not (tc:IsRelateToEffect(e) and tc:IsFaceup()) then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
 	local g=Duel.SelectMatchingCard(tp,s.setfilter2,tp,LOCATION_DECK,0,1,1,nil,tc)
 	if #g>0 then
@@ -65,7 +65,6 @@ function s.settg2(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.setfilter3,tp,LOCATION_DECK,0,1,nil,tp) end
 end
 function s.setop2(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
 	local g=Duel.SelectMatchingCard(tp,s.setfilter3,tp,LOCATION_DECK,0,1,1,nil,tp)
 	if #g>0 then

--- a/script/c100255014.lua
+++ b/script/c100255014.lua
@@ -41,7 +41,7 @@ function s.setfilter(c)
 	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSSetable()
 end
 function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0 and Duel.IsExistingMatchingCard(s.setfilter,tp,LOCATION_DECK+LOCATION_GRAVE,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(s.setfilter,tp,LOCATION_DECK+LOCATION_GRAVE,0,1,nil) end
 end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)
 	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 then return end

--- a/script/c100255014.lua
+++ b/script/c100255014.lua
@@ -44,7 +44,6 @@ function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.IsExistingMatchingCard(s.setfilter,tp,LOCATION_DECK+LOCATION_GRAVE,0,1,nil) end
 end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
 	local g=Duel.SelectMatchingCard(tp,aux.NecroValleyFilter(s.setfilter),tp,LOCATION_DECK+LOCATION_GRAVE,0,1,1,nil)
 	if #g>0 then

--- a/script/c17475251.lua
+++ b/script/c17475251.lua
@@ -1,0 +1,51 @@
+--英炎星－ホークエイ
+--Brotherhood of the Fire Fist - Hawk
+local s,id=GetID()
+function s.initial_effect(c)
+	--set
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCode(EVENT_DESTROYED)
+	e1:SetCondition(s.setcon)
+	e1:SetTarget(s.settg)
+	e1:SetOperation(s.setop)
+	c:RegisterEffect(e1)
+	--atk/def
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(LOCATION_MZONE,0)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetCondition(s.atkcon)
+	e2:SetTarget(aux.TargetBoolFunction(Card.IsSetCard,0x79))
+	e2:SetValue(500)
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetCode(EFFECT_UPDATE_DEFENSE)
+	c:RegisterEffect(e3)
+end
+function s.setcon(e,tp,eg,ep,ev,re,r,rp)
+	return rp~=tp and e:GetHandler():GetPreviousControler()==tp
+end
+function s.filter(c)
+	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL) and c:IsSSetable()
+end
+function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
+end
+function s.setop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
+	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if #g>0 then
+		Duel.SSet(tp,g:GetFirst())
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function s.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function s.atkcon(e)
+	return Duel.IsExistingMatchingCard(s.cfilter,e:GetHandlerPlayer(),LOCATION_ONFIELD,0,1,nil)
+end

--- a/script/c20343502.lua
+++ b/script/c20343502.lua
@@ -57,7 +57,7 @@ function s.immop(e,tp,eg,ep,ev,re,r,rp)
     end
 end
 function s.efilter(e,te)
-    return te:IsActiveType(TYPE_MONSTER) and te:GetOwner()~=e:GetOwner()
+    return te:IsActiveType(TYPE_MONSTER) and te:GetOwner()~=e:GetHandler()
 end
 function s.tdcfilter(c,tp)
     return c:IsSetCard(0x71) and c:IsControler(tp)
@@ -76,4 +76,3 @@ function s.tdop(e,tp,eg,ep,ev,re,r,rp)
         Duel.SendtoDeck(g,nil,2,REASON_EFFECT)
     end
 end
-

--- a/script/c22586618.lua
+++ b/script/c22586618.lua
@@ -1,5 +1,5 @@
 --ダークネス・シムルグ
---Darkness Simorgh
+--Simorgh of Darkness
 --Scripted by ahtelel
 local s,id=GetID()
 function s.initial_effect(c)
@@ -58,7 +58,7 @@ function s.discon(e,tp,eg,ep,ev,re,r,rp)
 	return re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and Duel.IsChainNegatable(ev)
 end
 function s.cfilter(c)
-	return c:IsFaceup() and c:IsRace(RACE_WINDBEAST) and c:IsAttribute(ATTRIBUTE_WIND) 
+	return c:IsRace(RACE_WINDBEAST) and c:IsAttribute(ATTRIBUTE_WIND) 
 		 and not c:IsStatus(STATUS_BATTLE_DESTROYED)
 end
 function s.discost(e,tp,eg,ep,ev,re,r,rp,chk)

--- a/script/c2521011.lua
+++ b/script/c2521011.lua
@@ -1,0 +1,65 @@
+--威炎星－ヒエンシャク
+--Brotherhood of the Fire Fist - Swallow
+local s,id=GetID()
+function s.initial_effect(c)
+	--spsummon
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_FIELD)
+	e1:SetCode(EFFECT_SPSUMMON_PROC)
+	e1:SetProperty(EFFECT_FLAG_UNCOPYABLE+EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetRange(LOCATION_HAND)
+	e1:SetCondition(s.spcon)
+	e1:SetOperation(s.spop)
+	c:RegisterEffect(e1)
+	--set
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,0))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_SUMMON_SUCCESS)
+	e2:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
+	e2:SetCountLimit(1,id)
+	e2:SetTarget(s.settg)
+	e2:SetOperation(s.setop)
+	c:RegisterEffect(e2)
+	local e3=e2:Clone()
+	e3:SetCode(EVENT_SPSUMMON_SUCCESS)
+	c:RegisterEffect(e3)
+	--cannot be target
+	local e4=Effect.CreateEffect(c)
+	e4:SetType(EFFECT_TYPE_FIELD)
+	e4:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
+	e4:SetProperty(EFFECT_FLAG_IGNORE_IMMUNE)
+	e4:SetRange(LOCATION_MZONE)
+	e4:SetTargetRange(LOCATION_MZONE,0)
+	e4:SetTarget(aux.TargetBoolFunction(Card.IsRace,RACE_BEASTWARRIOR))
+	e4:SetValue(aux.tgoval)
+	c:RegisterEffect(e4)
+end
+function s.spfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToGraveAsCost()
+end
+function s.spcon(e,c)
+	if c==nil then return true end
+	local tp=c:GetControler()
+	local g=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_ONFIELD,0,nil)
+	return Duel.GetLocationCount(tp,LOCATION_MZONE)>-3 and g:GetCount()>2 and aux.SelectUnselectGroup(g,e,tp,3,3,aux.ChkfMMZ(1),0)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp,c)
+	local sg=Duel.GetMatchingGroup(s.spfilter,tp,LOCATION_ONFIELD,0,nil)
+	local g=aux.SelectUnselectGroup(sg,e,tp,3,3,aux.ChkfMMZ(1),1,tp,HINTMSG_TOGRAVE)
+	Duel.SendtoGrave(g,REASON_COST)
+end
+function s.filter(c)
+	return c:IsSetCard(0x7c) and c:IsType(TYPE_TRAP) and c:IsSSetable()
+end
+function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
+end
+function s.setop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
+	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if #g>0 then
+		Duel.SSet(tp,g:GetFirst())
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c30929786.lua
+++ b/script/c30929786.lua
@@ -1,4 +1,5 @@
 --立炎星－トウケイ
+--Brotherhood of the Fire Fist - Rooster
 local s,id=GetID()
 function s.initial_effect(c)
 	--search
@@ -20,7 +21,6 @@ function s.initial_effect(c)
 	e2:SetRange(LOCATION_MZONE)
 	e2:SetCountLimit(1)
 	e2:SetCost(s.setcost)
-	e2:SetTarget(s.settg)
 	e2:SetOperation(s.setop)
 	c:RegisterEffect(e2)
 end
@@ -44,26 +44,23 @@ function s.thop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.cfilter(c)
 	return c:IsFaceup() and c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsAbleToGraveAsCost()
+		and ((c:GetSequence()<5 and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil,true))
+		or (c:GetSequence()>4 and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil)))
+end
+function s.filter(c,ignore)
+	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSSetable(ignore)
 end
 function s.setcost(e,tp,eg,ep,ev,re,r,rp,chk)
 	local nc=Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_ONFIELD,0,1,nil) and Duel.GetLocationCount(tp,LOCATION_SZONE)>-1
-	if chk==0 then 
-		if Duel.IsPlayerAffectedByEffect(tp,CARD_FIRE_FIST_EAGLE) then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0 else return nc end
-	end
-	if nc and not (Duel.IsPlayerAffectedByEffect(tp,CARD_FIRE_FIST_EAGLE) and Duel.SelectYesNo(tp,aux.Stringid(CARD_FIRE_FIST_EAGLE,0))) then
+	if chk==0 then return nc or (Duel.IsPlayerAffectedByEffect(tp,CARD_FIRE_FIST_EAGLE) and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil)) end
+	if nc and not (Duel.IsPlayerAffectedByEffect(tp,CARD_FIRE_FIST_EAGLE) and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil)
+		and Duel.SelectYesNo(tp,aux.Stringid(CARD_FIRE_FIST_EAGLE,0))) then
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_TOGRAVE)
 		local g=Duel.SelectMatchingCard(tp,s.cfilter,tp,LOCATION_ONFIELD,0,1,1,nil)
 		Duel.SendtoGrave(g,REASON_COST)
 	end
 end
-function s.filter(c)
-	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSSetable(true)
-end
-function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
-end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)
-	if Duel.GetLocationCount(tp,LOCATION_SZONE)<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
 	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK,0,1,1,nil)
 	if #g>0 then

--- a/script/c39699564.lua
+++ b/script/c39699564.lua
@@ -1,4 +1,5 @@
 --速炎星－タイヒョウ
+--Brotherhood of the Fire Fist - Leopard
 local s,id=GetID()
 function s.initial_effect(c)
 	--set
@@ -34,8 +35,7 @@ function s.filter(c)
 	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSSetable()
 end
 function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
 end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)

--- a/script/c43748308.lua
+++ b/script/c43748308.lua
@@ -1,4 +1,5 @@
 --微炎星－リュウシシン
+--Brotherhood of the Fire Fist - Dragon
 local s,id=GetID()
 function s.initial_effect(c)
 	--set
@@ -42,7 +43,7 @@ function s.filter(c)
 end
 function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and e:GetHandler():IsFaceup()
-		and not e:GetHandler():IsStatus(STATUS_CHAINING) and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and not e:GetHandler():IsStatus(STATUS_CHAINING)
 		and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
 end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c44860890.lua
+++ b/script/c44860890.lua
@@ -1,0 +1,47 @@
+--捷炎星－セイヴン
+--Brotherhood of the Fire Fist - Raven
+local s,id=GetID()
+function s.initial_effect(c)
+	--set
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCode(EVENT_TO_GRAVE)
+	e1:SetCondition(s.setcon)
+	e1:SetTarget(s.settg)
+	e1:SetOperation(s.setop)
+	c:RegisterEffect(e1)
+	--protection
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_INDESTRUCTABLE_EFFECT)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(LOCATION_ONFIELD,0)
+	e2:SetTarget(s.indtg)
+	e2:SetValue(s.indval)
+	c:RegisterEffect(e2)
+end
+function s.setcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
+end
+function s.filter(c)
+	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL) and c:IsSSetable()
+end
+function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
+end
+function s.setop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
+	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if #g>0 then
+		Duel.SSet(tp,g:GetFirst())
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function s.indtg(e,c)
+	return c:IsFaceup() and c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function s.indval(e,re,tp)
+	return e:GetHandler():GetControler()~=tp
+end

--- a/script/c50383626.lua
+++ b/script/c50383626.lua
@@ -58,7 +58,7 @@ function s.relval(e,c)
 	return c==e:GetHandler()
 end
 function s.spcfilter(c,tp)
-	return c:GetPreviousControler()==tp and c:GetPreviousAttributeOnField()==ATTRIBUTE_DARK
+	return c:GetPreviousControler()==tp and c:GetPreviousAttributeOnField()&ATTRIBUTE_DARK==ATTRIBUTE_DARK
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(s.spcfilter,1,nil,tp)

--- a/script/c51993760.lua
+++ b/script/c51993760.lua
@@ -65,41 +65,10 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummonComplete()
 		local a=Duel.GetAttacker()
 		if a:IsAttackable() and not a:IsImmuneToEffect(e) then
-			local atk_trgt_chk=0
-			if Duel.GetAttackTarget() then atk_trgt_chk=1 end
 			Duel.ChangeAttackTarget(tc)
 			Duel.CalculateDamage(a,tc)
-			local e1=Effect.CreateEffect(e:GetHandler())
-			e1:SetType(EFFECT_TYPE_FIELD)
-			e1:SetCode(EFFECT_AVOID_BATTLE_DAMAGE)
-			e1:SetProperty(EFFECT_FLAG_PLAYER_TARGET)
-			e1:SetTargetRange(1,0)
-			e1:SetValue(1)
-			Duel.RegisterEffect(e1,tp)
-			local e2=Effect.CreateEffect(e:GetHandler())
-			e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_CONTINUOUS)
-			e2:SetCode(EVENT_BATTLED)
-			e2:SetLabelObject(e1)
-			e2:SetValue(atk_trgt_chk)
-			e2:SetOperation(s.resop)
-			Duel.RegisterEffect(e2,tp)
 		end
 	end
-end
-function s.resop(e,tp)
-	local c=e:GetHandler()
-	if e:GetValue()==0 then
-		if not Duel.IsExistingMatchingCard(Card.IsStatus,tp,0,LOCATION_MZONE,1,nil,STATUS_BATTLE_DESTROYED) then
-			if c:GetFlagEffect(id)==0 then
-				c:RegisterFlagEffect(id,0,0,0)
-				return
-			end
-		end
-	end
-	c:ResetFlagEffect(id)
-	local e1=e:GetLabelObject()
-	e1:Reset()
-	e:Reset()
 end
 function s.cfilter(c,tp)
 	return c:IsLevel(8) and c:IsRace(RACE_FIEND) and c:IsControler(tp)

--- a/script/c6353603.lua
+++ b/script/c6353603.lua
@@ -1,4 +1,5 @@
 --暗炎星－ユウシ
+--Brotherhood of the Fire Fist - Bear
 local s,id=GetID()
 function s.initial_effect(c)
 	--set
@@ -30,8 +31,7 @@ function s.filter(c)
 	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL) and c:IsSSetable()
 end
 function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
 end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)

--- a/script/c66762372.lua
+++ b/script/c66762372.lua
@@ -1,0 +1,76 @@
+--孤炎星－ロシシン
+--Brotherhood of the Fire Fist - Boar
+local s,id=GetID()
+function s.initial_effect(c)
+	--special summon
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_BATTLE_DESTROYED)
+	e1:SetCondition(s.spcon)
+	e1:SetTarget(s.sptg)
+	e1:SetOperation(s.spop)
+	c:RegisterEffect(e1)
+	--set
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,1))
+	e2:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+	e2:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetCountLimit(1)
+	e2:SetCondition(s.setcon)
+	e2:SetTarget(s.settg)
+	e2:SetOperation(s.setop)
+	c:RegisterEffect(e2)
+	--synlimit
+	local e3=Effect.CreateEffect(c)
+	e3:SetType(EFFECT_TYPE_SINGLE)
+	e3:SetCode(EFFECT_CANNOT_BE_SYNCHRO_MATERIAL)
+	e3:SetProperty(EFFECT_FLAG_CANNOT_DISABLE+EFFECT_FLAG_UNCOPYABLE)
+	e3:SetValue(s.synlimit)
+	c:RegisterEffect(e3)
+end
+function s.spcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsLocation(LOCATION_GRAVE) and e:GetHandler():IsReason(REASON_BATTLE)
+end
+function s.spfilter(c,e,tp)
+	return c:IsSetCard(0x79) and c:GetLevel()==4 and c:GetCode()~=id and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	if g:GetCount()>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function s.cfilter(c,tp)
+	return c:IsFaceup() and c:IsSetCard(0x79) and c:GetSummonLocation()==LOCATION_EXTRA and c:GetPreviousControler()==tp
+end
+function s.setcon(e,tp,eg,ep,ev,re,r,rp)
+	return eg:IsExists(s.cfilter,1,nil,tp)
+end
+function s.filter(c)
+	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL) and c:IsSSetable()
+end
+function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
+end
+function s.setop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
+	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SSet(tp,g:GetFirst())
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function s.synlimit(e,c)
+	if not c then return false end
+	return not c:IsAttribute(ATTRIBUTE_FIRE)
+end

--- a/script/c70355994.lua
+++ b/script/c70355994.lua
@@ -1,4 +1,5 @@
 --勇炎星－エンショウ
+--Brotherhood of the Fire Fist - Gorilla
 local s,id=GetID()
 function s.initial_effect(c)
 	--set
@@ -33,8 +34,7 @@ function s.filter(c)
 	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL) and c:IsSSetable()
 end
 function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
 end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)

--- a/script/c75132317.lua
+++ b/script/c75132317.lua
@@ -1,4 +1,5 @@
 --雄炎星－スネイリン
+--Brotherhood of the Fire Fist - Snake
 local s,id=GetID()
 function s.initial_effect(c)
 	--set
@@ -38,7 +39,7 @@ function s.filter(c)
 end
 function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsRelateToEffect(e) and e:GetHandler():IsFaceup()
-		and not e:GetHandler():IsStatus(STATUS_CHAINING) and Duel.GetLocationCount(tp,LOCATION_SZONE)>0
+		and not e:GetHandler():IsStatus(STATUS_CHAINING)
 		and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
 end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c89856523.lua
+++ b/script/c89856523.lua
@@ -1,0 +1,48 @@
+--罡炎星－リシュンキ
+--Brotherhood of the Fire Fist - Kirin
+local s,id=GetID()
+function s.initial_effect(c)
+	--synchro summon
+	aux.AddSynchroProcedure(c,aux.FilterBoolFunctionEx(Card.IsAttribute,ATTRIBUTE_FIRE),1,1,aux.NonTuner(Card.IsSetCard,0x79),1,99)
+	c:EnableReviveLimit()
+	--set
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
+	e1:SetCondition(s.setcon)
+	e1:SetTarget(s.settg)
+	e1:SetOperation(s.setop)
+	c:RegisterEffect(e1)
+	--atkdown
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_FIELD)
+	e2:SetCode(EFFECT_UPDATE_ATTACK)
+	e2:SetRange(LOCATION_MZONE)
+	e2:SetTargetRange(0,LOCATION_MZONE)
+	e2:SetValue(s.atkval)
+	c:RegisterEffect(e2)
+end
+function s.setcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():GetSummonType()==SUMMON_TYPE_SYNCHRO
+end
+function s.filter(c)
+	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSSetable()
+end
+function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
+end
+function s.setop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
+	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if #g>0 then
+		Duel.SSet(tp,g:GetFirst())
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function s.atkfilter(c)
+	return c:IsFaceup() and c:IsType(TYPE_SPELL+TYPE_TRAP)
+end
+function s.atkval(e,c)
+	return Duel.GetMatchingGroupCount(s.atkfilter,e:GetHandlerPlayer(),LOCATION_ONFIELD,0,nil)*-100
+end

--- a/script/c93294869.lua
+++ b/script/c93294869.lua
@@ -34,18 +34,19 @@ function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
 	end
 end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)
-	local ft=Duel.GetLocationCount(tp,LOCATION_SZONE)
-	if ft<=0 then return end
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
 	local g=Duel.SelectMatchingCard(tp,s.filter1,tp,LOCATION_DECK,0,1,1,nil)
-	local sg=Duel.GetMatchingGroup(s.filter2,tp,LOCATION_DECK,0,nil)
-	if e:GetLabel()==1 and sg:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
-		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
-		g:AddCard(sg:Select(tp,1,1,nil):GetFirst())
-	end
 	if #g>0 then
 		Duel.SSet(tp,g)
 		Duel.ConfirmCards(1-tp,g)
+		local sg=Duel.GetMatchingGroup(s.filter2,tp,LOCATION_DECK,0,nil)
+		if e:GetLabel()==1 and #sg>0 and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
+			Duel.BreakEffect()
+			Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
+			local tg=sg:Select(tp,1,1,nil)
+			Duel.SSet(tp,tg)
+			Duel.ConfirmCards(1-tp,tg)
+		end
 	end
 end
 function s.flipop(e,tp,eg,ep,ev,re,r,rp)

--- a/script/c93294869.lua
+++ b/script/c93294869.lua
@@ -1,0 +1,53 @@
+--傷炎星－ウルブショウ
+--Brotherhood of the Fire Fist - Wolf
+local s,id=GetID()
+function s.initial_effect(c)
+	--set
+	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e1:SetProperty(EFFECT_FLAG_DELAY+EFFECT_FLAG_DAMAGE_STEP)
+	e1:SetCode(EVENT_FLIP)
+	e1:SetTarget(s.settg)
+	e1:SetOperation(s.setop)
+	c:RegisterEffect(e1)
+	local e2=Effect.CreateEffect(c)
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e2:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e2:SetCode(EVENT_FLIP_SUMMON_SUCCESS)
+	e2:SetOperation(s.flipop)
+	c:RegisterEffect(e2)
+end
+function s.filter1(c)
+	return c:IsSetCard(0x7c) and c:IsType(TYPE_TRAP) and c:IsSSetable()
+end
+function s.filter2(c)
+	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL) and c:IsSSetable()
+end
+function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter1,tp,LOCATION_DECK,0,1,nil) end
+	if e:GetHandler():GetFlagEffect(id)~=0 then
+		e:SetLabel(1)
+		e:GetHandler():ResetFlagEffect(id)
+	else
+		e:SetLabel(0)
+	end
+end
+function s.setop(e,tp,eg,ep,ev,re,r,rp)
+	local ft=Duel.GetLocationCount(tp,LOCATION_SZONE)
+	if ft<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
+	local g=Duel.SelectMatchingCard(tp,s.filter1,tp,LOCATION_DECK,0,1,1,nil)
+	local sg=Duel.GetMatchingGroup(s.filter2,tp,LOCATION_DECK,0,nil)
+	if e:GetLabel()==1 and sg:GetCount()>0 and Duel.SelectYesNo(tp,aux.Stringid(id,1)) then
+		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
+		g:AddCard(sg:Select(tp,1,1,nil):GetFirst())
+	end
+	if #g>0 then
+		Duel.SSet(tp,g)
+		Duel.ConfirmCards(1-tp,g)
+	end
+end
+function s.flipop(e,tp,eg,ep,ev,re,r,rp)
+	e:GetHandler():RegisterFlagEffect(id,0,0,0)
+end

--- a/script/c93751476.lua
+++ b/script/c93751476.lua
@@ -1,0 +1,72 @@
+--猛炎星－テンレイ
+--Brotherhood of the Fire Fist - Caribou
+local s,id=GetID()
+function s.initial_effect(c)
+	--to grave
+	local e1=Effect.CreateEffect(c)
+	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_CONTINUOUS)
+	e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
+	e1:SetCode(EVENT_TO_GRAVE)
+	e1:SetOperation(s.regop)
+	c:RegisterEffect(e1)
+	--set
+	local e2=Effect.CreateEffect(c)
+	e2:SetDescription(aux.Stringid(id,1))
+	e2:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
+	e2:SetProperty(EFFECT_FLAG_DELAY)
+	e2:SetCode(EVENT_BE_MATERIAL)
+	e2:SetCondition(s.setcon)
+	e2:SetTarget(s.settg)
+	e2:SetOperation(s.setop)
+	c:RegisterEffect(e2)
+end
+function s.regop(e,tp,eg,ep,ev,re,r,rp)
+	local c=e:GetHandler()
+	if c:IsReason(REASON_EFFECT) and c:IsReason(REASON_DESTROY) then
+		local e1=Effect.CreateEffect(c)
+		e1:SetDescription(aux.Stringid(id,0))
+		e1:SetCategory(CATEGORY_SPECIAL_SUMMON)
+		e1:SetType(EFFECT_TYPE_FIELD+EFFECT_TYPE_TRIGGER_O)
+		e1:SetCode(EVENT_PHASE+PHASE_END)
+		e1:SetCountLimit(1)
+		e1:SetRange(LOCATION_GRAVE)
+		e1:SetTarget(s.sptg)
+		e1:SetOperation(s.spop)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		c:RegisterEffect(e1)
+	end
+end
+function s.spfilter(c,e,tp)
+	return c:IsSetCard(0x79) and c:GetLevel()==4 and c:GetCode()~=id and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
+end
+function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
+		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_DECK,0,1,nil,e,tp) end
+	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_DECK)
+end
+function s.spop(e,tp,eg,ep,ev,re,r,rp)
+	if Duel.GetLocationCount(tp,LOCATION_MZONE)<=0 then return end
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)
+	local g=Duel.SelectMatchingCard(tp,s.spfilter,tp,LOCATION_DECK,0,1,1,nil,e,tp)
+	if #g>0 then
+		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
+	end
+end
+function s.setcon(e,tp,eg,ep,ev,re,r,rp)
+	return e:GetHandler():IsLocation(LOCATION_GRAVE) and r==REASON_SYNCHRO
+		and e:GetHandler():GetReasonCard():IsSetCard(0x79)
+end
+function s.filter(c)
+	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL) and c:IsSSetable()
+end
+function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
+end
+function s.setop(e,tp,eg,ep,ev,re,r,rp)
+	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)
+	local g=Duel.SelectMatchingCard(tp,s.filter,tp,LOCATION_DECK,0,1,1,nil)
+	if g:GetCount()>0 then
+		Duel.SSet(tp,g:GetFirst())
+		Duel.ConfirmCards(1-tp,g)
+	end
+end

--- a/script/c96381979.lua
+++ b/script/c96381979.lua
@@ -1,4 +1,5 @@
 --魁炎星王－ソウコ
+--Brotherhood of the Fire Fist - Tiger King
 local s,id=GetID()
 function s.initial_effect(c)
 	--xyz summon
@@ -44,8 +45,7 @@ function s.filter(c)
 	return c:IsSetCard(0x7c) and c:IsType(TYPE_SPELL+TYPE_TRAP) and c:IsSSetable()
 end
 function s.settg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_SZONE)>0
-		and Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
+	if chk==0 then return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_DECK,0,1,nil) end
 end
 function s.setop(e,tp,eg,ep,ev,re,r,rp)
 	Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SET)


### PR DESCRIPTION
- Dark Spirit of the Denial: Cleaned up script and removed some now unneeded code.
- Simorgh of Darkness: Can now Tribute face-down monsters as the cost for its negation effect.
- Darkest Diabolos, Lord of the Lair: Updated the handling of the condition for its Special Summon effect to work correctly with monsters that have multiple attributes.
- "Fire Fist" updates : Updated how the effects of "Fire Fist" monsters that Set a Spell/Trap from the Deck are handled in terms of your available zones, now taking into account the newly revealed Field Spell.
- Madolche Teacher Glassouffle: The target should be unaffected by its own effects, not by Glassouffle's effects.