### PR TITLE
Fixes/updates

### DIFF
--- a/script/c39271553.lua
+++ b/script/c39271553.lua
@@ -1,3 +1,4 @@
+--F.A.カーナビゲーター
 --F.A. Auto Navigator
 --Scripted by Eerie Code
 local s,id=GetID()
@@ -58,9 +59,9 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 			tc:RegisterEffect(e1)
 			local e2=Effect.CreateEffect(c)
 			e2:SetType(EFFECT_TYPE_SINGLE)
-			e2:SetCode(EFFECT_CHANGE_LEVEL)
+			e2:SetCode(EFFECT_CHANGE_LEVEL_FINAL)
 			e2:SetValue(lv)
-			e2:SetReset(RESET_EVENT+RESETS_STANDARD)
+			e2:SetReset(RESET_EVENT+RESETS_STANDARD_DISABLE)
 			c:RegisterEffect(e2)
 		end
 	end

--- a/script/c7799906.lua
+++ b/script/c7799906.lua
@@ -95,10 +95,6 @@ function s.drcon(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetFieldGroup(tp,LOCATION_MZONE,0)
 	return #g>0 and g:FilterCount(s.drfilter,nil)==#g and s.filter(e:GetHandler())
 end
-	--Check for monsters' ATK higher than original ATK
-function s.atkfilter(c)
-	return Duel.IsExistingMatchingCard(s.filter,tp,LOCATION_MZONE,0,1,nil)
-end
 	--Activation legality
 function s.drtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	local ct=Duel.GetMatchingGroupCount(s.filter,tp,LOCATION_MZONE,0,nil)


### PR DESCRIPTION
- F.A. Auto Navigator: Fixed an issue where its Level would immediately get increased by the "F.A." Field Spells after it was changed because of its effect. Also, its Level now resets if its effects are negated, as according to rulings.
- Performapal Smile Sorcerer: Removed a now unused function.