### PR TITLE
Update for "Danger!" cards to match OCG rulings

### DIFF
--- a/script/c16209941.lua
+++ b/script/c16209941.lua
@@ -1,3 +1,4 @@
+--未み界かい域いきのチュパカブラ
 --Danger! Chupacabra!
 --Scripted by AlphaKretin
 local s,id=GetID()
@@ -38,8 +39,7 @@ function s.spfilter(c,e,tp)
 	return c:IsCode(id) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
@@ -50,6 +50,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:Select(1-tp,1,1,nil)
 	Duel.BreakEffect()
 	Duel.SendtoGrave(tc,REASON_EFFECT+REASON_DISCARD)
+	if not Duel.IsPlayerCanSpecialSummon(tp) or Duel.GetLocationCount(tp,LOCATION_MZONE)==0 then return end
 	if not tc:GetFirst():IsCode(id) then
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c26302107.lua
+++ b/script/c26302107.lua
@@ -1,3 +1,4 @@
+--未み界かい域いきのワーウルフ
 --Danger! Dogman!
 --Scripted by AlphaKretin
 local s,id=GetID()
@@ -38,8 +39,7 @@ function s.spfilter(c,e,tp)
 	return c:IsCode(id) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
@@ -50,6 +50,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:Select(1-tp,1,1,nil)
 	Duel.BreakEffect()
 	Duel.SendtoGrave(tc,REASON_EFFECT+REASON_DISCARD)
+	if not Duel.IsPlayerCanSpecialSummon(tp) or Duel.GetLocationCount(tp,LOCATION_MZONE)==0 then return end
 	if not tc:GetFirst():IsCode(id) then
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c43316238.lua
+++ b/script/c43316238.lua
@@ -1,3 +1,4 @@
+--未み界かい域いきのビッグフット
 --Danger! Bigfoot!
 --Scripted by AlphaKretin
 local s,id=GetID()
@@ -38,8 +39,7 @@ function s.spfilter(c,e,tp)
 	return c:IsCode(id) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
@@ -50,6 +50,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:Select(1-tp,1,1,nil)
 	Duel.BreakEffect()
 	Duel.SendtoGrave(tc,REASON_EFFECT+REASON_DISCARD)
+	if not Duel.IsPlayerCanSpecialSummon(tp) or Duel.GetLocationCount(tp,LOCATION_MZONE)==0 then return end
 	if not tc:GetFirst():IsCode(id) then
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c43694650.lua
+++ b/script/c43694650.lua
@@ -1,3 +1,4 @@
+--未み界かい域いきのジャッカロープ
 --Danger!? Jackalope?
 --Scripted by AlphaKretin
 local s,id=GetID()
@@ -38,8 +39,7 @@ function s.spfilter(c,e,tp)
 	return c:IsCode(id) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
@@ -50,6 +50,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:Select(1-tp,1,1,nil)
 	Duel.BreakEffect()
 	Duel.SendtoGrave(tc,REASON_EFFECT+REASON_DISCARD)
+	if not Duel.IsPlayerCanSpecialSummon(tp) or Duel.GetLocationCount(tp,LOCATION_MZONE)==0 then return end
 	if not tc:GetFirst():IsCode(id) then
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c52350806.lua
+++ b/script/c52350806.lua
@@ -1,3 +1,4 @@
+--未み界かい域いきのモスマン
 --Danger! Mothman!
 --Scripted by AlphaKretin
 local s,id=GetID()
@@ -38,8 +39,7 @@ function s.spfilter(c,e,tp)
 	return c:IsCode(id) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
@@ -50,6 +50,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:Select(1-tp,1,1,nil)
 	Duel.BreakEffect()
 	Duel.SendtoGrave(tc,REASON_EFFECT+REASON_DISCARD)
+	if not Duel.IsPlayerCanSpecialSummon(tp) or Duel.GetLocationCount(tp,LOCATION_MZONE)==0 then return end
 	if not tc:GetFirst():IsCode(id) then
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c70711847.lua
+++ b/script/c70711847.lua
@@ -1,3 +1,4 @@
+--未み界かい域いきのネッシー
 --Danger! Nessie!
 --Scripted by AlphaKretin
 local s,id=GetID()
@@ -38,8 +39,7 @@ function s.spfilter(c,e,tp)
 	return c:IsCode(id) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
@@ -50,6 +50,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:Select(1-tp,1,1,nil)
 	Duel.BreakEffect()
 	Duel.SendtoGrave(tc,REASON_EFFECT+REASON_DISCARD)
+	if not Duel.IsPlayerCanSpecialSummon(tp) or Duel.GetLocationCount(tp,LOCATION_MZONE)==0 then return end
 	if not tc:GetFirst():IsCode(id) then
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c83518674.lua
+++ b/script/c83518674.lua
@@ -1,3 +1,4 @@
+--未み界かい域いきのオゴポゴ
 --Danger! Ogopogo!
 --Scripted by AlphaKretin
 local s,id=GetID()
@@ -38,8 +39,7 @@ function s.spfilter(c,e,tp)
 	return c:IsCode(id) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
@@ -50,6 +50,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:Select(1-tp,1,1,nil)
 	Duel.BreakEffect()
 	Duel.SendtoGrave(tc,REASON_EFFECT+REASON_DISCARD)
+	if not Duel.IsPlayerCanSpecialSummon(tp) or Duel.GetLocationCount(tp,LOCATION_MZONE)==0 then return end
 	if not tc:GetFirst():IsCode(id) then
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c90807199.lua
+++ b/script/c90807199.lua
@@ -1,3 +1,4 @@
+--未み界かい域いきのサンダーバード
 --Danger! Thunderbird!
 local s,id=GetID()
 function s.initial_effect(c)
@@ -37,8 +38,7 @@ function s.spfilter(c,e,tp)
 	return c:IsCode(id) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
@@ -49,6 +49,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:Select(1-tp,1,1,nil)
 	Duel.BreakEffect()
 	Duel.SendtoGrave(tc,REASON_EFFECT+REASON_DISCARD)
+	if not Duel.IsPlayerCanSpecialSummon(tp) or Duel.GetLocationCount(tp,LOCATION_MZONE)==0 then return end
 	if not tc:GetFirst():IsCode(id) then
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)

--- a/script/c99745551.lua
+++ b/script/c99745551.lua
@@ -1,3 +1,4 @@
+--未み界かい域いきのツチノコ
 --Danger!? Tsuchinoko?
 --Scripted by AlphaKretin
 local s,id=GetID()
@@ -38,8 +39,7 @@ function s.spfilter(c,e,tp)
 	return c:IsCode(id) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)
 end
 function s.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
-		and Duel.IsExistingMatchingCard(s.spfilter,tp,LOCATION_HAND,0,1,nil,e,tp) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,nil,0,tp,1)
 end
 function s.spop(e,tp,eg,ep,ev,re,r,rp)
@@ -50,6 +50,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	local tc=g:Select(1-tp,1,1,nil)
 	Duel.BreakEffect()
 	Duel.SendtoGrave(tc,REASON_EFFECT+REASON_DISCARD)
+	if not Duel.IsPlayerCanSpecialSummon(tp) or Duel.GetLocationCount(tp,LOCATION_MZONE)==0 then return end
 	if not tc:GetFirst():IsCode(id) then
 		Duel.BreakEffect()
 		Duel.Hint(HINT_SELECTMSG,tp,HINTMSG_SPSUMMON)


### PR DESCRIPTION
-The effects in the hand can now be activated even if the player has no available monster zone OR is prevented from performing Special Summons, e.g. Vanity's Emptiness, as per OCG rulings.

-If the player is prevented from Special Summoning during resolution and the random card selected is a "Danger!" with the same name as the one that activated the effect, the card will stay in the hand, instead of being sent to the GY.