### PR TITLE
Update "Noble Knight Custennin"

### DIFF
--- a/script/c42472002.lua
+++ b/script/c42472002.lua
@@ -1,4 +1,4 @@
---聖せい騎き士しコルネウス
+--聖騎士コルネウス
 --Noble Knight Custennin
 --Scripted by Eerie Code
 local s,id=GetID()
@@ -38,6 +38,7 @@ function s.mtop(e,tp,eg,ep,ev,re,r,rp)
 	if not rc:IsSetCard(0x107a) then return end
 	--reg eff
 	local e1=Effect.CreateEffect(c)
+	e1:SetDescription(aux.Stringid(id,0))
 	e1:SetType(EFFECT_TYPE_SINGLE+EFFECT_TYPE_TRIGGER_O)
 	e1:SetCode(EVENT_SPSUMMON_SUCCESS)
 	e1:SetOperation(s.effop)


### PR DESCRIPTION
The activated effect it provides to an Extra Deck monster now has a description, so Isolde no longer displays a choice between "Search" and "???".