### PR TITLE
Updated "Aleister the Invoker of Madness"

### DIFF
--- a/script/c97973962.lua
+++ b/script/c97973962.lua
@@ -66,7 +66,7 @@ function s.thop(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.thcon2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	return (c:GetReasonPlayer()~=tp and c:IsReason(REASON_EFFECT))	and c:IsPreviousPosition(POS_FACEUP)
+	return (c:GetReasonPlayer()~=tp and c:IsReason(REASON_EFFECT))	and c:IsPreviousPosition(POS_FACEUP) and c:GetPreviousControler()==tp
 end
 function s.thfilter2(c)
 	return c:IsCode(47457347) and c:IsAbleToHand()


### PR DESCRIPTION
The player was able to add "Omega Summon" if the card was under opponent's control and left the field because of the opponent's card effect.