### PR TITLE
Wicked Avatar and Scrap-Iron Signal Fixes

### DIFF
--- a/script/c100413027.lua
+++ b/script/c100413027.lua
@@ -22,7 +22,7 @@ function s.cfilter(c)
     return ct>0
 end
 function s.negcon(e,tp,eg,ep,ev,re,r,rp)
-    return re:IsActiveType(TYPE_MONSTER) and Duel.IsChainNegatable(ev) and Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil)
+    return ep==1-tp and re:IsActiveType(TYPE_MONSTER) and Duel.IsChainNegatable(ev) and Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil)
 end
 function s.negtg(e,tp,eg,ep,ev,re,r,rp,chk)
     if chk==0 then return true end

--- a/script/c21208154.lua
+++ b/script/c21208154.lua
@@ -1,4 +1,5 @@
 --邪神アバター
+--The Wicked Avatar
 local s,id=GetID()
 function s.initial_effect(c)
 	--summon with 3 tribute

--- a/script/c21208154.lua
+++ b/script/c21208154.lua
@@ -39,7 +39,7 @@ function s.initial_effect(c)
 	--atk check
 	local e7=Effect.CreateEffect(c)
 	e7:SetType(EFFECT_TYPE_SINGLE)
-	e7:SetCode(21208154)
+	e7:SetCode(id)
 	c:RegisterEffect(e7)
 end
 function s.ttcon(e,c,minc)
@@ -52,7 +52,7 @@ function s.ttop(e,tp,eg,ep,ev,re,r,rp,c)
 	Duel.Release(g,REASON_SUMMON+REASON_MATERIAL)
 end
 function s.filter(c)
-	return c:IsFaceup() and not c:IsHasEffect(21208154)
+	return c:IsFaceup() and not c:IsHasEffect(id)
 end
 function s.adval(e,c)
 	local g=Duel.GetMatchingGroup(s.filter,0,LOCATION_MZONE,LOCATION_MZONE,nil)

--- a/script/c21208154.lua
+++ b/script/c21208154.lua
@@ -36,6 +36,11 @@ function s.initial_effect(c)
 	e6:SetCode(EVENT_SUMMON_SUCCESS)
 	e6:SetOperation(s.regop)
 	c:RegisterEffect(e6)
+	--atk check
+	local e7=Effect.CreateEffect(c)
+	e7:SetType(EFFECT_TYPE_SINGLE)
+	e7:SetCode(21208154)
+	c:RegisterEffect(e7)
 end
 function s.ttcon(e,c,minc)
 	if c==nil then return true end
@@ -47,7 +52,7 @@ function s.ttop(e,tp,eg,ep,ev,re,r,rp,c)
 	Duel.Release(g,REASON_SUMMON+REASON_MATERIAL)
 end
 function s.filter(c)
-	return c:IsFaceup() and not c:IsCode(id)
+	return c:IsFaceup() and not c:IsHasEffect(21208154)
 end
 function s.adval(e,c)
 	local g=Duel.GetMatchingGroup(s.filter,0,LOCATION_MZONE,LOCATION_MZONE,nil)


### PR DESCRIPTION
* The Wicked Avatar Fix:
    - It is now ignoring any monster that copied Avatar effects even if it changed name (with hero mask for ex)
* Scrap-Iron Signal Fix:
    - It was not checking if the effect was activated by the opponent