### PR TITLE
Fix for Trap Cards that set themselves after resolving

### DIFF
--- a/script/c100413027.lua
+++ b/script/c100413027.lua
@@ -33,13 +33,10 @@ function s.negop(e,tp,eg,ep,ev,re,r,rp)
     Duel.NegateActivation(ev)
 	Duel.BreakEffect()
     if not c:IsRelateToEffect(e) then return end
-    --if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
     if c:IsSSetable(true) and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
 		Duel.BreakEffect()
         c:CancelToGrave()
         Duel.ChangePosition(c,POS_FACEDOWN)
         Duel.RaiseEvent(c,EVENT_SSET,e,REASON_EFFECT,tp,tp,0)
-    else
-        c:CancelToGrave(false)
     end
 end

--- a/script/c48497555.lua
+++ b/script/c48497555.lua
@@ -40,6 +40,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsRelateToEffect(e) then return end
 	if c:IsSSetable(true) and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
 		Duel.BreakEffect()
+		c:CancelToGrave()
 		Duel.ChangePosition(c,POS_FACEDOWN)
 		Duel.RaiseEvent(c,EVENT_SSET,e,REASON_EFFECT,tp,tp,0)
 	end

--- a/script/c48497555.lua
+++ b/script/c48497555.lua
@@ -1,4 +1,5 @@
 --くず鉄の像
+--Scrap-Iron Statue
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -8,7 +9,6 @@ function s.initial_effect(c)
 	e1:SetCode(EVENT_CHAINING)
 	e1:SetCountLimit(1,id)
 	e1:SetCondition(s.condition)
-	e1:SetCost(s.cost)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
@@ -23,15 +23,10 @@ function s.initial_effect(c)
 	e2:SetOperation(s.spop)
 	c:RegisterEffect(e2)
 end
+s.listed_series={0x43}
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	local rc=re:GetHandler()
 	return rc:IsOnField() and rc:IsControler(1-tp) and re:IsActiveType(TYPE_SPELL+TYPE_TRAP) and not re:IsHasType(EFFECT_TYPE_ACTIVATE)
-end
-function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then
-		aux.RemainFieldCost(e,tp,eg,ep,ev,re,r,rp,1)
-	end
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return true end
@@ -42,13 +37,11 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.Destroy(eg,REASON_EFFECT)
 	end
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	if not c:IsRelateToEffect(e) then return end
 	if c:IsSSetable(true) and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
 		Duel.BreakEffect()
 		Duel.ChangePosition(c,POS_FACEDOWN)
 		Duel.RaiseEvent(c,EVENT_SSET,e,REASON_EFFECT,tp,tp,0)
-	else
-		c:CancelToGrave(false)
 	end
 end
 function s.spfilter(c,e,tp)

--- a/script/c73575650.lua
+++ b/script/c73575650.lua
@@ -115,7 +115,7 @@ function s.thop2(e,tp,eg,ep,ev,re,r,rp)
 			Duel.ConfirmCards(1-tp,g)
 		end
 	end
-	if c:IsRelateToEffect(e) and c:IsCanTurnSet() and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+	if c:IsRelateToEffect(e) and c:IsSSetable(true) and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
 		Duel.BreakEffect()
 		c:CancelToGrave()
 		Duel.ChangePosition(c,POS_FACEDOWN)

--- a/script/c74640994.lua
+++ b/script/c74640994.lua
@@ -113,6 +113,7 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	if not c:IsRelateToEffect(e) then return end
 	if c:IsSSetable(true) then
 		Duel.BreakEffect()
+		c:CancelToGrave()
 		Duel.ChangePosition(c,POS_FACEDOWN)
 		Duel.RaiseEvent(c,EVENT_SSET,e,REASON_EFFECT,tp,tp,0)
 	end

--- a/script/c74640994.lua
+++ b/script/c74640994.lua
@@ -9,19 +9,13 @@ function s.initial_effect(c)
 	e1:SetProperty(EFFECT_FLAG_DAMAGE_STEP)
 	e1:SetHintTiming(TIMING_DAMAGE_STEP)
 	e1:SetCondition(s.condition)
-	e1:SetCost(s.cost)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
 end
+s.listed_series={0xed}
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()~=PHASE_DAMAGE or not Duel.IsDamageCalculated()
-end
-function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then
-		aux.RemainFieldCost(e,tp,eg,ep,ev,re,r,rp,1)
-	end
 end
 function s.filter(c)
 	return c:IsFaceup() and c:IsSetCard(0xed)
@@ -116,13 +110,11 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		Duel.RegisterEffect(e1,tp)
 		Duel.RegisterFlagEffect(tp,id,RESET_PHASE+PHASE_END,0,1)
 	end
-	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
-	if c:IsSSetable(true) and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
+	if not c:IsRelateToEffect(e) then return end
+	if c:IsSSetable(true) then
 		Duel.BreakEffect()
 		Duel.ChangePosition(c,POS_FACEDOWN)
 		Duel.RaiseEvent(c,EVENT_SSET,e,REASON_EFFECT,tp,tp,0)
-	else
-		c:CancelToGrave(false)
 	end
 end
 function s.effectfilter(e,ct)

--- a/script/c98427577.lua
+++ b/script/c98427577.lua
@@ -1,4 +1,5 @@
 --くず鉄のかかし 
+--Scrap-Iron Scarecrow
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -7,19 +8,12 @@ function s.initial_effect(c)
 	e1:SetType(EFFECT_TYPE_ACTIVATE)
 	e1:SetCode(EVENT_ATTACK_ANNOUNCE)
 	e1:SetCondition(s.condition)
-	e1:SetCost(s.cost)
 	e1:SetTarget(s.target)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
 end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
 	return tp~=Duel.GetTurnPlayer()
-end
-function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return true end
-	if e:IsHasType(EFFECT_TYPE_ACTIVATE) then
-		aux.RemainFieldCost(e,tp,eg,ep,ev,re,r,rp,1)
-	end
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
 	local tg=Duel.GetAttacker()
@@ -30,12 +24,11 @@ end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
 	Duel.NegateAttack()
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) or c:IsStatus(STATUS_LEAVE_CONFIRMED) then return end
+	if not c:IsRelateToEffect(e) then return end
 	if c:IsSSetable(true) and e:IsHasType(EFFECT_TYPE_ACTIVATE) then
 		Duel.BreakEffect()
+		c:CancelToGrave()
 		Duel.ChangePosition(c,POS_FACEDOWN)
 		Duel.RaiseEvent(c,EVENT_SSET,e,REASON_EFFECT,tp,tp,0)
-	else
-		c:CancelToGrave(false)
 	end
 end


### PR DESCRIPTION
Should not be treated as a "persistent" Trap e.g. Altergeist Manifestation for interactions with e.g. Phoenix Wing Wind Blast. Trap of Darkness will now Set itself when copying.

* Fix "Scrap-Iron Statue"
* Fix "Subterror Succession"
* Fix "Subterror Final Battle"
* Fix "Scrap-Iron Scarecrow"
* Fix "Scrap-Iron Signal"