### PR TITLE
Fixed Wild-fire

### DIFF
--- a/script/c68815401.lua
+++ b/script/c68815401.lua
@@ -1,4 +1,5 @@
 --クレイジー・ファイヤー
+--Wild Fire
 local s,id=GetID()
 function s.initial_effect(c)
 	--Activate
@@ -23,14 +24,11 @@ function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)
 	e1:SetReset(RESET_PHASE+PHASE_END)
 	Duel.RegisterEffect(e1,tp)
 end
-function s.filter1(c)
-	return c:IsFaceup() and c:IsSetCard(0xb9)
-end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(s.filter1,tp,LOCATION_SZONE,0,1,nil)
+	if chk==0 then return Duel.IsExistingMatchingCard(aux.FilterFaceupFunction(Card.IsSetCard,0xb9),tp,LOCATION_ONFIELD,0,1,nil)
 		and Duel.IsExistingMatchingCard(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,1,nil)
 		and Duel.IsPlayerCanSpecialSummonMonster(tp,id+1,0,TYPES_TOKEN,1000,1000,3,RACE_PYRO,ATTRIBUTE_FIRE) end
-	local dg1=Duel.GetMatchingGroup(s.filter1,tp,LOCATION_SZONE,0,nil)
+	local dg1=Duel.GetMatchingGroup(aux.FilterFaceupFunction(Card.IsSetCard,0xb9),tp,LOCATION_ONFIELD,0,nil)
 	local dg2=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	dg1:Merge(dg2)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,dg1,#dg1,0,0)
@@ -38,8 +36,8 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,0)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	local dg1=Duel.GetMatchingGroup(s.filter1,tp,LOCATION_ONFIELD,0,nil)
-	if Duel.Destroy(dg1,REASON_COST)>0 then
+	local dg1=Duel.GetMatchingGroup(aux.FilterFaceupFunction(Card.IsSetCard,0xb9),tp,LOCATION_ONFIELD,0,nil)
+	if Duel.Destroy(dg1,REASON_EFFECT)>0 then
 		local dg2=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 		if Duel.Destroy(dg2,REASON_EFFECT)>0
 			and Duel.IsPlayerCanSpecialSummonMonster(tp,id+1,0,TYPES_TOKEN,1000,1000,3,RACE_PYRO,ATTRIBUTE_FIRE) then

--- a/script/c68815401.lua
+++ b/script/c68815401.lua
@@ -38,8 +38,8 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,0)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	local dg1=Duel.GetMatchingGroup(s.filter1,tp,LOCATION_SZONE,0,nil)
-	if Duel.Destroy(dg1,REASON_EFFECT)>0 then
+	local dg1=Duel.GetMatchingGroup(s.filter1,tp,LOCATION_ONFIELD,0,nil)
+	if Duel.Destroy(dg1,REASON_COST)>0 then
 		local dg2=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 		if Duel.Destroy(dg2,REASON_EFFECT)>0
 			and Duel.IsPlayerCanSpecialSummonMonster(tp,id+1,0,TYPES_TOKEN,1000,1000,3,RACE_PYRO,ATTRIBUTE_FIRE) then


### PR DESCRIPTION
It can also be activated when Blaze Cannon, which has been treated as a monster in Magical Top Hat , is face-up in the monster zone .
Blaze Cannon of destruction is cost rather than the effect is, at the time effect processing to the destruction carried out.
[Source](http://yugioh-wiki.net/index.php?cmd=read&page=%A1%D4%A5%AF%A5%EC%A5%A4%A5%B8%A1%BC%A1%A6%A5%D5%A5%A1%A5%A4%A5%E4%A1%BC%A1%D5&word=%20%A5%AF%A5%EC%A5%A4%A5%B8%A1%BC%A1%A6%A5%D5%A5%A1%A5%A4%A5%E4%A1%BC%EF%BC%B1%EF%BC%9A%E3%80%8C%E3%83%96%E3%83%AC%E3%82%A4%E3%82%BA%E3%83%BB%E3%82%AD%E3%83%A3%E3%83%8E%E3%83%B3%E3%80%8D%E3%81%A8%E5%90%8D%E3%81%AE%E3%81%A4%E3%81%8F%E3%82%AB%E3%83%BC%E3%83%89%E3%81%8C%E8%A4%87%E6%95%B0%E5%AD%98%E5%9C%A8%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88%E3%81%AF%E3%81%A9%E3%81%86%E3%81%AA%E3%82%8A%E3%81%BE%E3%81%99%E3%81%8B%EF%BC%9F)