### PR TITLE
Fix Cross Rose Dragon

### DIFF
--- a/script/c72218246.lua
+++ b/script/c72218246.lua
@@ -75,7 +75,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.cfilter(c,tp)
-	return c:GetPreviousControler()==tp and c:IsReason(REASON_EFFECT) and c:IsType(TYPE_MONSTER)
+	return c:GetPreviousControler()==tp and c:IsReason(REASON_EFFECT) and c:GetPreviousTypeOnField()&TYPE_MONSTER)~=0
 end
 function s.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return not eg:IsContains(e:GetHandler()) and eg:IsExists(s.cfilter,1,nil,tp)
@@ -96,4 +96,3 @@ function s.spop2(e,tp,eg,ep,ev,re,r,rp)
 		Duel.SpecialSummon(g,0,tp,tp,false,false,POS_FACEUP)
 	end
 end
-

--- a/script/c72218246.lua
+++ b/script/c72218246.lua
@@ -75,7 +75,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.cfilter(c,tp)
-	return c:GetPreviousControler()==tp and c:IsReason(REASON_EFFECT) and c:GetPreviousTypeOnField()&TYPE_MONSTER)~=0
+	return c:GetPreviousControler()==tp and c:IsReason(REASON_EFFECT) and c:GetPreviousTypeOnField()&TYPE_MONSTER~=0
 end
 function s.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return not eg:IsContains(e:GetHandler()) and eg:IsExists(s.cfilter,1,nil,tp)

--- a/script/c72218246.lua
+++ b/script/c72218246.lua
@@ -75,7 +75,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 	end
 end
 function s.cfilter(c,tp)
-	return c:GetPreviousControler()==tp and c:IsReason(REASON_EFFECT)
+	return c:GetPreviousControler()==tp and c:IsReason(REASON_EFFECT) and c:IsType(TYPE_MONSTER)
 end
 function s.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return not eg:IsContains(e:GetHandler()) and eg:IsExists(s.cfilter,1,nil,tp)


### PR DESCRIPTION
Cross Rose Dragon should only trigger if a monster get destroyed by card effect.