### PR TITLE
Updated "Borrelend Dragon"

### DIFF
--- a/script/c100259045.lua
+++ b/script/c100259045.lua
@@ -72,7 +72,7 @@ function s.disop(e,tp,eg,ep,ev,re,r,rp)
 	local g=Duel.GetTargetCards(e)
 	local tc2=g:GetFirst()
 	if tc2==tc1 then tc2=g:GetNext() end
-	if tc1 and tc1:IsFaceup() then
+	if tc1 and tc1:IsFaceup() and tc1:IsRelateToEffect(e) and not tc1:IsDisabled() then
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_DISABLE)
@@ -83,7 +83,8 @@ function s.disop(e,tp,eg,ep,ev,re,r,rp)
 		e2:SetCode(EFFECT_DISABLE_EFFECT)
 		e2:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc1:RegisterEffect(e2)
-		if tc1:IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
+		if tc1:IsImmuneToEffect(e1) or tc1:IsImmuneToEffect(e2) or not tc2:IsRelateToEffect(e) then return end
+		if Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
 			Duel.SpecialSummon(tc2,0,tp,tp,false,false,POS_FACEUP)
 		end
 	end

--- a/script/c100259045.lua
+++ b/script/c100259045.lua
@@ -76,14 +76,14 @@ function s.disop(e,tp,eg,ep,ev,re,r,rp)
 		local e1=Effect.CreateEffect(c)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_DISABLE)
-		e1:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc1:RegisterEffect(e1)
 		local e2=Effect.CreateEffect(c)
 		e2:SetType(EFFECT_TYPE_SINGLE)
 		e2:SetCode(EFFECT_DISABLE_EFFECT)
-		e2:SetReset(RESET_EVENT+RESETS_STANDARD+RESET_PHASE+PHASE_END)
+		e2:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc1:RegisterEffect(e2)
-		if tc2 and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
+		if tc1:IsRelateToEffect(e) and Duel.GetLocationCount(tp,LOCATION_MZONE)>0 then
 			Duel.SpecialSummon(tc2,0,tp,tp,false,false,POS_FACEUP)
 		end
 	end


### PR DESCRIPTION
If the targeted monster wasn't negated, then shouldn't be able to special summon the "Rokket" monster. Also, negation should be indefinite, not until end phase.