### PR TITLE
Bug Fix Borrelend

### DIFF
--- a/script/c100259045.lua
+++ b/script/c100259045.lua
@@ -9,6 +9,8 @@ function s.initial_effect(c)
 	local e1=Effect.CreateEffect(c)
 	e1:SetType(EFFECT_TYPE_SINGLE)
 	e1:SetCode(EFFECT_CANNOT_BE_EFFECT_TARGET)
+	e1:SetProperty(EFFECT_FLAG_SINGLE_RANGE)
+	e1:SetRange(LOCATION_MZONE)
 	e1:SetValue(s.etg)
 	c:RegisterEffect(e1)
 	--indes


### PR DESCRIPTION
Player can now target Borrelend Dragon in the GY/Banished zone with Monster Effect