### PR TITLE
Fix Dragonmaid Strahl

### DIFF
--- a/script/c101012041.lua
+++ b/script/c101012041.lua
@@ -71,12 +71,12 @@ function s.negop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
 		Duel.Destroy(eg,REASON_EFFECT)
-		Duel.BreakEffect()
-		Duel.SendtoDeck(c,nil,0,REASON_EFFECT)
-		if c:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCountFromEx(tp)>0
-			and Duel.IsExistingMatchingCard(s.house_filter,tp,LOCATION_EXTRA,0,1,nil,e,tp) then
-			local tg=Duel.GetFirstMatchingCard(s.house_filter,tp,LOCATION_EXTRA,0,nil,e,tp)
-			Duel.SpecialSummon(tg,0,tp,tp,false,false,POS_FACEUP)
-		end
+	end
+	Duel.BreakEffect()
+	Duel.SendtoDeck(c,nil,0,REASON_EFFECT)
+	if c:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCountFromEx(tp)>0
+		and Duel.IsExistingMatchingCard(s.house_filter,tp,LOCATION_EXTRA,0,1,nil,e,tp) then
+		local tg=Duel.GetFirstMatchingCard(s.house_filter,tp,LOCATION_EXTRA,0,nil,e,tp)
+		Duel.SpecialSummon(tg,0,tp,tp,false,false,POS_FACEUP)
 	end
 end

--- a/script/c101012041.lua
+++ b/script/c101012041.lua
@@ -69,14 +69,16 @@ function s.house_filter(c,e,tp)
 end
 function s.negop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if Duel.NegateActivation(ev) and re:GetHandler():IsRelateToEffect(re) then
-		Duel.Destroy(eg,REASON_EFFECT)
-	end
-	Duel.BreakEffect()
-	Duel.SendtoDeck(c,nil,0,REASON_EFFECT)
-	if c:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCountFromEx(tp)>0
-		and Duel.IsExistingMatchingCard(s.house_filter,tp,LOCATION_EXTRA,0,1,nil,e,tp) then
-		local tg=Duel.GetFirstMatchingCard(s.house_filter,tp,LOCATION_EXTRA,0,nil,e,tp)
-		Duel.SpecialSummon(tg,0,tp,tp,false,false,POS_FACEUP)
+	if Duel.NegateActivation(ev) then 
+		if re:GetHandler():IsRelateToEffect(re) then
+			Duel.Destroy(eg,REASON_EFFECT)
+		end
+		Duel.BreakEffect()
+		Duel.SendtoDeck(c,nil,0,REASON_EFFECT)
+		if c:IsLocation(LOCATION_EXTRA) and Duel.GetLocationCountFromEx(tp)>0
+			and Duel.IsExistingMatchingCard(s.house_filter,tp,LOCATION_EXTRA,0,1,nil,e,tp) then
+			local tg=Duel.GetFirstMatchingCard(s.house_filter,tp,LOCATION_EXTRA,0,nil,e,tp)
+			Duel.SpecialSummon(tg,0,tp,tp,false,false,POS_FACEUP)
+		end
 	end
 end


### PR DESCRIPTION
Dragonmaid Strahl will be send to the Extra Deck if she actually negate the card, regardless if she destroy the negated card or not