### PR TITLE
Updated "Loptr, Shadow of the Generaider Boss"

### DIFF
--- a/script/c101012028.lua
+++ b/script/c101012028.lua
@@ -33,7 +33,7 @@ function s.initial_effect(c)
 end
 s.listed_series={0x134}
 function s.atkcon(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.GetTurnPlayer()~=tp
+	return Duel.GetTurnPlayer()~=e:GetHandlerPlayer()
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return Duel.GetCurrentPhase()==PHASE_MAIN1 or Duel.GetCurrentPhase()==PHASE_MAIN2


### PR DESCRIPTION
ATK/DEF gain should only be during opponent's turn.