### PR TITLE
Small fix "Trias Hierarchia"

### DIFF
--- a/script/c101012032.lua
+++ b/script/c101012032.lua
@@ -23,14 +23,14 @@ function s.spcon(e,tp,eg,ep,ev,re,r,rp)
 end
 function s.spcheck(sg,tp)
 	if not (Duel.GetLocationCount(tp,LOCATION_MZONE)>0 or sg:IsExists(Card.IsInMainMZone,1,nil,tp)) then return false end
-	local ct=Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)
-	if #sg==3 then return Duel.IsPlayerCanDraw(tp,2) end
-	if #sg==2 then return ct>0 end
+	-- local ct=Duel.GetFieldGroupCount(tp,0,LOCATION_MZONE)
+	-- if #sg==3 then return Duel.IsPlayerCanDraw(tp,2) end
+	-- if #sg==2 then return ct>0 end
 	return true
 end
 function s.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.CheckReleaseGroupCost(tp,Card.IsRace,1,false,nil,nil,RACE_FAIRY) end
-	local g=Duel.SelectReleaseGroupCost(tp,Card.IsRace,1,3,false,nil,nil,RACE_FAIRY)
+	if chk==0 then return Duel.CheckReleaseGroupCost(tp,Card.IsRace,1,false,s.spcheck,nil,RACE_FAIRY) end
+	local g=Duel.SelectReleaseGroupCost(tp,Card.IsRace,1,3,false,s.spcheck,nil,RACE_FAIRY)
 	local ct=Duel.Release(g,REASON_COST)
 	e:SetLabel(ct)
 end


### PR DESCRIPTION
The effect now checks if you have an open monster zone after tributing, for its Special Summon effect (for tributing just 1 from your Extra Monster Zone, just 1 via Lair of Darkness interaction, etc).
Removed forcibly applied check to an effect if you want to tribute that many monsters. (i.e. the effect will no longer check if the opponent controls cards by tributing 2 or more monsters, nor will it check if you can draw 2 cards for tributing 3 monsters.)