### PR TITLE
Small fix "Blackbeard, the Plunder Patroll Captain"

### DIFF
--- a/script/c101011089.lua
+++ b/script/c101011089.lua
@@ -68,7 +68,7 @@ function s.spop(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		e1:SetValue(s.eqlimit)
 		e1:SetLabelObject(tc)
-		c:RegisterEffect(e1)
+		tg:RegisterEffect(e1)
 		Duel.BreakEffect()
 		Duel.Draw(tp,1,REASON_EFFECT)
 	end


### PR DESCRIPTION
The equipped card from the first effect now does not self-destruct.