### PR TITLE
Fix "Red-Eyes Fusion"

### DIFF
--- a/script/c6172122.lua
+++ b/script/c6172122.lua
@@ -85,19 +85,15 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tg=sg:Select(tp,1,1,nil)
 		local tc=tg:GetFirst()
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
-			-- local tmg=mg1:Filter(s.ffilter,nil,tc)
-			-- if #tmg>1 then tmg=tmg:Select(tp,1,1,nil) end
 			aux.FCheckAdditional=s.fcheck
-			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,tmg,tp)
+			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,tp)
 			aux.FCheckAdditional=nil
 			tc:SetMaterial(mat1)
 			Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			local tmg=mg3:Filter(s.ffilter,nil,tc)
-			if #tmg>1 then tmg=tmg:Select(tp,1,1,nil) end
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,tmg,tp)
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,tp)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end

--- a/script/c6172122.lua
+++ b/script/c6172122.lua
@@ -40,7 +40,7 @@ function s.filter1(c,e)
 	return not c:IsImmuneToEffect(e)
 end
 function s.filter2(c,e,tp,m,f)
-	return c:IsType(TYPE_FUSION) and aux.IsMaterialListSetCard(c,0x3b) and (not f or f(c))
+	return c:IsType(TYPE_FUSION) and m:IsExists(s.ffilter,1,nil,c) and (not f or f(c))
 		and c:IsCanBeSpecialSummoned(e,SUMMON_TYPE_FUSION,tp,false,false) and c:CheckFusionMaterial(m,nil,tp)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
@@ -48,7 +48,9 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		local mg1=Duel.GetFusionMaterial(tp)
 		local mg2=Duel.GetMatchingGroup(s.filter0,tp,LOCATION_DECK,0,nil)
 		mg1:Merge(mg2)
+		aux.FCheckAdditional=s.fcheck
 		local res=Duel.IsExistingMatchingCard(s.filter2,tp,LOCATION_EXTRA,0,1,nil,e,tp,mg1,nil)
+		aux.FCheckAdditional=nil
 		if not res then
 			local ce=Duel.GetChainMaterial(tp)
 			if ce~=nil then
@@ -83,13 +85,19 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		local tg=sg:Select(tp,1,1,nil)
 		local tc=tg:GetFirst()
 		if sg1:IsContains(tc) and (sg2==nil or not sg2:IsContains(tc) or not Duel.SelectYesNo(tp,ce:GetDescription())) then
-			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,nil,tp)
+			-- local tmg=mg1:Filter(s.ffilter,nil,tc)
+			-- if #tmg>1 then tmg=tmg:Select(tp,1,1,nil) end
+			aux.FCheckAdditional=s.fcheck
+			local mat1=Duel.SelectFusionMaterial(tp,tc,mg1,tmg,tp)
+			aux.FCheckAdditional=nil
 			tc:SetMaterial(mat1)
 			Duel.SendtoGrave(mat1,REASON_EFFECT+REASON_MATERIAL+REASON_FUSION)
 			Duel.BreakEffect()
 			Duel.SpecialSummon(tc,SUMMON_TYPE_FUSION,tp,tp,false,false,POS_FACEUP)
 		else
-			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,nil,tp)
+			local tmg=mg3:Filter(s.ffilter,nil,tc)
+			if #tmg>1 then tmg=tmg:Select(tp,1,1,nil) end
+			local mat2=Duel.SelectFusionMaterial(tp,tc,mg3,tmg,tp)
 			local fop=ce:GetOperation()
 			fop(ce,e,tp,tc,mat2)
 		end
@@ -102,4 +110,22 @@ function s.activate(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		tc:RegisterEffect(e1)
 	end
+end
+function s.fcheck(tp,sg,fc)
+	return sg:IsExists(s.ffilter,1,nil,fc)
+end
+function s.ffilter(c,fc)
+	local mat=fc.material
+	local set=fc.material_setcode
+	local res
+	if mat then
+		for _,code in ipairs(mat) do
+			res=res or (c:IsFusionCode(code) and c:IsFusionSetCard(0x3b))
+		end
+	elseif set then
+		res=res or (c:IsFusionSetCard(0x3b) and aux.IsMaterialListSetCard(fc,0x3b))
+	else
+		return false
+	end
+	return res
 end


### PR DESCRIPTION
You now must use a listed "Red-Eyes" monster as material, according to ruling. (i.e. Now Dragun of Red-Eyes must be summoned with Red-Eyes B. Dragon and Dark Magician when using Red-Eyes Fusion.)