### PR TITLE
Fix for "always" adding setcode for certain checks

### DIFF
--- a/script/proc_workaround.lua
+++ b/script/proc_workaround.lua
@@ -626,3 +626,31 @@ function Auxiliary.GetRaceStrings(v)
 	end
 	return pairs(res)
 end
+
+--change "always" adding setcode for checks like Gogogo Aristera & Dexia's overlay
+local creg=Card.RegisterEffect
+function Card.RegisterEffect(c,e,...)
+	if Duel.GetTurnCount()~=0 then return creg(c,e,...) end
+	if e:GetCode()==EFFECT_ADD_SETCODE then
+		local s=_G["c"..c:GetOriginalCode()]
+		s.sets=s.sets or {}
+		table.insert(s.sets,e:GetValue())
+	end
+	return creg(c,e,...)
+end
+local issetcard=Card.IsSetCard
+function Card.IsSetCard(c,n,...)
+	if issetcard(c,n,...) then return true end
+	local res
+	local s=_G["c"..c:GetOriginalCode()]
+	if s.sets then
+		for i=1,#s.sets do
+			local set=s.sets[i]
+			--do setcode check with previously added values
+			if n&0xfff==set&0xfff then
+				res=res or ((n&0xf000)&(set&0xf000)==(n&0xf000))
+			end
+		end
+	end
+	return res
+end


### PR DESCRIPTION
An example is "Gogogo Aristera & Dexia" used with "Utopic Onomatopoeia" as Xyz Material.

old PR was on expired patch; needed to reopen for fix