### PR TITLE
Update banlist for TCG and anime fix

### DIFF
--- a/lflist.conf
+++ b/lflist.conf
@@ -1,5 +1,5 @@
-#[2019.10 TCG][2020.01 OCG][2019.10 Worlds][2019.10 Traditional][2019.10 Anime][2020.01 TCG]
-!2019.10 TCG
+#[2020.01 TCG][2020.01 OCG][2020.01 Worlds][2020.01 Traditional][2020.01 Anime]
+!2020.01 TCG
 #Forbidden TCG
 53804307 0 --Blaster, Dragon Ruler of Infernos			MAIN DECK MONSTERS
 34124316 0 --Cyber Jar
@@ -11,16 +11,13 @@
 31178212 0 --Majespecter Unicorn - Kirin
 21593977 0 --Makyura the Destructor
 96782886 0 --Mind Master
-79106360 0 --Morphing Jar #2
 7563579 0 --Performage PlushFire
 17330916 0 --Performapal Monkeyboard
 90411554 0 --Redox, Dragon Ruler of Boulders
 20663556 0 --Substitoad
 88071625 0 --The Tyrant Neptune
 26400609 0 --Tidal, Dragon Ruler of Waterfalls
-33184167 0 --Tribe-Infecting Virus
 44910027 0 --Victory Dragon
-30539496 0 --True King Lithosagym, the Disaster
 3078576 0 --Yata-Garasu
 9929398 0 --Blackwing - Gofu the Vague Shadow
 15341821 0 --Dandylion
@@ -34,11 +31,15 @@
 5592689 0 --Samsara Lotus
 75732622 0 --Grinder Golem
 55623480 0 --Fairy Tail – Snow
+57835716 0 --Orcust Harp Horror
 17412721 0 --Elder Entity Norden			EXTRA DECK MONSTERS
 43387895 0 --Supreme King Dragon Starving Venom
+15291624 0 --Thunder Dragon Colossus
 65536818 0 --Denglong, First of the Yang Zing
 25862681 0 --Ancient Fairy Dragon
 34086406 0 --Lavalval Chain
+94677445 0 --Ib the World Chalice Justiciar
+63101919 0 --Tempest Magician
 18326736 0 --Tellarknight Ptolomaeus
 81122844 0 --Wind-Up Carrier Zenmaity
 48905153 0 --Zoodiac Drident
@@ -47,6 +48,8 @@
 10389142 0 --Number 42: Galaxy Tomahawk
 63504681 0 --Number 86: Heroic Champion – Rhongomyniad
 58820923 0 --Number 95: Galaxy-Eyes Dark Matter Dragon
+34945480 0 --Outer Entity Azathot
+87327776 0 --Salamangreat Miragestallio
 39064822 0 --Knightmare Goblin
 4423206 0 --M-X-Saber Invoker
 5043010 0 --Firewall Dragon
@@ -55,6 +58,7 @@
 61665245 0 --Summon Sorceress
 3679218 0 --Knightmare Mermaid
 59537380 0 --Guardragon Agarpain
+24094258 0 --Heavymetalfoes Electrumite
 69243953 0 --Butterfly Dagger - Elma						SPELLS CARDS
 57953380 0 --Card of Safe Return
 4031928 0 --Change of Heart
@@ -72,17 +76,17 @@
 85602018 0 --Last Will
 46411259 0 --Metamorphosis
 74191942 0 --Painful Choice
-67169062 0 --Pot of Avarice
+63166095 0 -Sky Striker Mobilize – Engage!
 55144522 0 --Pot of greed
 34906152 0 --Mass Driver
 41482598 0 --Mirage of Nightmare
+7394770 0 --Brilliant Fusion
 70828912 0 --Premature Burial
 45986603 0 --Snatch Steal
 46448938 0 --Spellbook of Judgement
 42829885 0 --The Forceful Sentry
 11110587 0 --That Grass Looks Greener
 94220427 0 --Rank-Up-Magic Argent Chaos Force
-3298689 0 --The Phantom Knights' Rank-Up-Magic Launch
 54447022 0 --Soul Charge
 28566710 0 --Last Turn											TRAPS CARDS
 27174286 0 --Return from the Different Dimension
@@ -103,7 +107,6 @@
 61901281 1 --Black Dragon Collapserpent
 57143342 1 --Cir, Malebranche of the Burning Abyss
 33396948 1 --Exodia the Forbidden One
-78868119 1 --Deep Sea Diva
 64034255 1 --Genex Ally birdman
 20758643 1 --Graff, Malembrance of the Burning Abyss
 99177923 1 --Infernity Archfiend
@@ -111,7 +114,6 @@
 88264978 1 --Red-Eyes Darkness Metal Dragon
 61740673 1 --Imperial Order
 89399912 1 --Tempest, Dragon Ruler of Storms
-10802915 1 --Tour Guide From the Underworld
 26889158 1 --Salamangreat Gazelle
 81275020 1 --Speedroid Terrortop
 99234526 1 --White Dragon Wyverburster
@@ -126,19 +128,19 @@
 28985331 1 --Armageddon Knight
 14536035 1 --Dark Grepher
 69015963 1 --Cyber Stein
-16188701 1 --Lady Debug
 12958919 1 --Phantom Skyblaster
+70711847 1 --Danger! Nessie!
+82385847 1 --Dinowrestler Pankratops
+92559258 1 --Servant of Endymion
+30539496 1 --True King Lithosagym, the Disaster
 18239909 1 --Ignister Prominence, the Blasting Dracoslayer 		EXTRA DECK MONSTERS
 48063985 1 --Ritual Beast Ulti-Cannahawk
 39512984 1 --Gem-Knight Master Diamond
 70583986 1 --Dewloren, Tiger King of the Ice Barrier
 27552504 1 --Beatrice, Lady of Eternal
 581014 1 --Daigusto Emeral
-24094258 1 --Heavymetalfoes Electrumite
 74586817 1 --Psy-Framelord Omega
-63288573 1 --Sky Striker Ace - Kagari
-14087893 1 --Book of Moon  										SPELLS CARDS
-81674782 1 --Dimensional Fissure
+81674782 1 --Dimensional Fissure                                SPELL CARDS
 95308449 1 --Final Countdown
 81439173 1 --Foolish Burial
 66957584 1 --Infernity Launcher
@@ -155,17 +157,21 @@
 35371948 1 --Trickstar Light Stage
 58577036 1 --Reasoning
 27970830 1 --Gateway of the Six
-7394770 1 --Brilliant Fusion
 70368879 1 --Upstart Goblin
 83764718 1 --Monster Reborn
 83764719 1 --Monster Reborn
 71344451 1 --Slash Draw
 75500286 1 --Gold Sarcophagus
+59750328 1 --Card of Demise
+93946239 1 --Into the Void
+67169062 1 --Pot of Avarice
+24940422 1 --Sekka's Light
 67723438 1 --Emergency Teleporter
 22842126 1 --Pantheism of the Monarchs
 15854426 1 --Divine Wind of the Mist Valley
 54631665 1 --SPYRAL Resort
 71650854 1 --Magical Mid-Breaker Field
+13035077 1 --Dragonic Diagram
 91623717 1 --Chain Strike
 8949584 1 --A Hero Lives
 72892473 1 --Card Destruction
@@ -175,18 +181,17 @@
 32723153 1 --Magical Explosion			--TRAP CARDS
 35125879 1 --True King's Return
 82732705 1 --Skill Drain
-73599290 1 --Soul Drain
 30241314 1 --Macro Cosmos
 89208725 1 --Metaverse
 17078030 1 --Wall of Revealing light
-84749824 1 --Solemn Warning
+23002292 1 --Red Reboot
 #Semi limited TCG
-70711847 2 --Danger! Nessie!
+10802915 2 --Tour Guide From the Underworld
+78868119 2 --Deep Sea Diva
 43694650 2 --Danger!? Jackalope?
 99745551 2 --Danger!? Tsuchinoko?
 28297833 2 --Necroface
-65192027 2 --Dark Armed Dragon
-68819554 2 --Performage Damage Juggler
+37520316 2 --Mind Control
 !2020.01 OCG
 #Forbidden OCG
 20663556 0 --Substitoad											MAIN DECK MONSTERS
@@ -364,8 +369,8 @@
 23002292 2 --Red Reboot
 !2020.01 Worlds
 #Forbidden Worlds
+57835716 0 --Orcust Harp Horror
 26692769 0 --The Phantom Knights of Rusty Bardiche
-51858306 0 --Eclipse Wyvern
 03078576 0 --Yata-Garasu
 05592689 0 --Samsara Lotus
 07563579 0 --Performage PlushFire
@@ -382,9 +387,7 @@
 23434538 0 --Maxx "C"
 23558733 0 --Phoenixian Cluster Amaryllis
 26400609 0 --Tidal, Dragon Ruler of Waterfalls
-30539496 0 --True King Lithosagym, the Disaster
 31178212 0 --Majespecter Unicorn - Kirin
-33184167 0 --Tribe-Infecting Virus
 34124316 0 --Cyber Jar
 34206604 0 --Magical Scientist
 40318957 0 --Performapal Skullcrobat Joker
@@ -394,7 +397,6 @@
 57421866 0 --Level Eater
 76794549 0 --Astrograph Sorcerer
 78706415 0 --Fiber Jar
-79106360 0 --Morphing Jar #2
 79875176 0 --Toon Cannon Soldier
 88071625 0 --The Tyrant Neptune
 90411554 0 --Redox, Dragon Ruler of Boulders
@@ -408,6 +410,11 @@
 88264978 0 --Red-Eyes Darkness Metal Dragon
 71525232 0 --Gandora-X the Dragon of Demolition
 51858306 0 --Eclipse Wyvern
+15291624 0 --Thunder Dragon Colossus
+24094258 0 --Heavymetalfoes Electrumite
+94677445 0 --Ib the World Chalice Justiciar
+63101919 0 --Tempest Magician
+87327776 0 --Salamangreat Miragestallio
 04423206 0 --M-X-Saber Invoker
 17412721 0 --Elder Entity Norden
 18326736 0 --Tellarknight Ptolomaeus
@@ -429,6 +436,8 @@
 85115440 0 --Zoodiac Broadbull
 63504681 0 --Number 86: Heroic Champion – Rhongomyniad
 10389142 0 --Number 42: Galaxy Tomahawk
+7394770 0 --Brilliant Fusion
+63166095 0 --Sky Striker Mobilize - Engage!
 04031928 0 --Change of Heart
 11110587 0 --That Grass Looks Greener
 17375316 0 --Confiscation
@@ -446,11 +455,9 @@
 31423101 0 --Divine Sword - Phoenix Blade
 46411259 0 --Metamorphosis
 46448938 0 --Spellbook of Judgement
-3298689 0 --The Phantom Knights' Rank-Up-Magic Launch
 55144522 0 --Pot of greed
 57953380 0 --Card of Safe Return
 60682203 0 --Cold Wave
-67169062 0 --Pot of Avarice
 67616300 0 --Chicken Game
 69243953 0 --Butterfly Dagger - Elma
 70828912 0 --Premature Burial
@@ -472,6 +479,10 @@
 80604092 0 --Ultimate Offering
 93016201 0 --Royal Oppression
 #Limited Worlds
+92559258 1 --Servant of Endymion
+30539496 1 --True King Lithosagym, the Disaster
+70711847 1 --Danger! Nessie!
+82385847 1 --Dinowrestler Pankratops
 00581014 1 --Daigusto Emeral
 61901281 1 --Black Dragon Collapserpent
 99234526 1 --White Dragon Wyverburster
@@ -479,7 +490,6 @@
 04474060 1 --SPYRAL Gear - Drone
 07902349 1 --Left Arm of the forbidden one
 08124921 1 --Right Leg of the forbidden one
-10802915 1 --Tour Guide From the Underworld
 11877465 1 --Evigishki Mind Augus
 16226786 1 --Night Assailant
 20758643 1 --Graff, Malembrance of the Burning Abyss
@@ -496,12 +506,10 @@
 26889158 1 --Salamangreat Gazelle
 83107873 1 --Thunder Dragonhawk
 64034255 1 --Genex Ally Birdman
-68819554 1 --Performage Damage Juggler
 69610326 1 --Supreme King Dragon Darkwurm
 70903634 1 --Right Arm of the forbidden one
 73941492 1 --Harmonizing Magician
 78080961 1 --SPYRAL Quik-Fix
-78868119 1 --Deep Sea Diva
 78872731 1 --Zoodiac Ratpier
 81275020 1 --Speedroid Terrortop
 89463537 1 --Nekroz of Unicore
@@ -513,26 +521,26 @@
 41386308 1 --Mathematician
 69015963 1 --Cyber Stein
 14536035 1 --Dark Grepher
-16188701 1 --Lady Debug
 12958919 1 --Phantom Skyblaster
 62706865 1 --Draconnet
 99234526 1 --White Dragon Wyverburster
 06602300 1 --Blaze Fenix, The Burning Bombardment Bird
 39512984 1 --Gem-Knight Master Diamond
-15291624 1 --Thunder Dragon Colossus
 28297833 1 --Necroface
 70583986 1 --Dewloren, Tiger King of the Ice Barrier
 74586817 1 --Psy-Framelord Omega
 18239909 1 --Ignister Prominence, the Blasting Dracoslayer 
 27552504 1 --Beatrice, Lady of Eternal
 48063985 1 --Ritual Beast Ulti-Cannahawk
-24094258 1 --Heavymetalfoes Electrumite
 50588353 1 --Crystron Needlefiber
 63288573 1 --Sky Striker Ace - Kagari
 74997493 1 --Saryuja Skull Dread
+59750328 1 --Card of Demise
+93946239 1 --Into the Void
+24940422 1 --Sekka’s Light
+67169062 1 --Pot of Avarice
 02295440 1 --One for One
 08949584 1 --A Hero Lives
-14087893 1 --Book of Moon  
 14733538 1 --Draco Face-off
 15854426 1 --Divine Wind of the Mist Valley
 22842126 1 --Pantheism of the Monarchs
@@ -551,7 +559,6 @@
 54631665 1 --SPYRAL Resort
 58577036 1 --Reasoning
 66957584 1 --Infernity Launcher
-7394770 1 --Brilliant Fusion
 13035077 1 --Dragonic Diagram
 76375976 1 --Mystic Mine
 71344451 1 --Slash Draw
@@ -578,39 +585,33 @@
 61740673 1 --Imperial Order
 35125879 1 --True King's Return
 82732705 1 --Skill Drain
-73599290 1 --Soul Drain
 30241314 1 --Macro Cosmos
 17078030 1 --Wall of Revealing light
-84749824 1 --Solemn Warning
+23002292 1 --Red Reboot
 #Semi Limited Worlds
-70711847 2 --Danger! Nessie!
+16188701 2 --Lady Debug
+78868119 2 --Deep Sea Diva
+10802915 2 --Tour Guide From the Underworld
 43694650 2 --Danger!? Jackalope?
 99745551 2 --Danger!? Tsuchinoko?
 68819554 2 --Performage Damage Juggler
-65192027 2 --Dark Armed Dragon
 14558127 2 --Ash Blossom & Joyous Spring
-82385847 2 --Dinowrestler Pankratops
 61283655 2 --Trickstar Candina
 35272499 2 --Predaplant Ophrys Scorpio
 25533642 2 --Altergeist Meluseek
-57835716 2 --Orcust Harp Horror
 36042004 2 --Babycerasaurus
 41386308 2 --Mathematician
 89463537 2 --Nekroz of Unicore
 29596581 2 --Thunder Dragonroar
 30741503 2 --Galatea, the Orcusted Automaton
 47325505 2 --Fossil Dig
-63166095 2 --Sky Striker Mobilize - Engage!
 1475311 2 --Allure of Darkness
 37520316 2 --Mind Control
 48130397 2 --Super Polymerization
 53936268 2 --Personal Spoofing
-23002292 2 --Red Reboot
-!2019.10 Traditional
+!2020.01 Traditional
 #Forbidden TCG Traditional
 #Limited TCG Traditional
-42790071 1 --Altergeist Multifaker
-61901281 1 --Black Dragon Collapserpent
 53804307 1 --Blaster, Dragon Ruler of Infernos			MAIN DECK MONSTERS
 34124316 1 --Cyber Jar
 8903700 1 --Djinn Releaser of Rituals
@@ -621,17 +622,13 @@
 31178212 1 --Majespecter Unicorn - Kirin
 21593977 1 --Makyura the Destructor
 96782886 1 --Mind Master
-79106360 1 --Morphing Jar #2
 7563579 1 --Performage PlushFire
 17330916 1 --Performapal Monkeyboard
 90411554 1 --Redox, Dragon Ruler of Boulders
 20663556 1 --Substitoad
-89399912 1 --Tempest, Dragon Ruler of Storms
 88071625 1 --The Tyrant Neptune
 26400609 1 --Tidal, Dragon Ruler of Waterfalls
-33184167 1 --Tribe-Infecting Virus
 44910027 1 --Victory Dragon
-30539496 1 --True King Lithosagym, the Disaster
 3078576 1 --Yata-Garasu
 9929398 1 --Blackwing - Gofu the Vague Shadow
 15341821 1 --Dandylion
@@ -645,100 +642,35 @@
 5592689 1 --Samsara Lotus
 75732622 1 --Grinder Golem
 55623480 1 --Fairy Tail – Snow
-7902349 1 --Left Arm of the forbidden one
-44519536 1 --Left Leg of the forbidden one
-70903634 1 --Right Arm of the forbidden one
-8124921 1 --Right Leg of the forbidden one
-33396948 1 --Exodia the Forbidden One
-78868119 1 --Deep Sea Diva
-64034255 1 --Genex Ally Birdman
-20758643 1 --Graff, Malembrance of the Burning Abyss
-99177923 1 --Infernity Archfiend
-16226786 1 --Night Assailant
-88264978 1 --Red-Eyes Darkness Metal Dragon
-61740673 1 --Imperial Order
-10802915 1 --Tour Guide From the Underworld
-26889158 1 --Salamangreat Gazelle
-81275020 1 --Speedroid Terrortop
-99234526 1 --White Dragon Wyverburster
-57143342 1 --Cir, Malebranche of the Burning Abyss
-78872731 1 --Zoodiac Ratpier
-4474060 1 --SPYRAL Gear - Drone
-78080961 1 --SPYRAL Quik-Fix
-58984738 1 --Dinomight Knight, the True Dracofighter
-45222299 1 --Evigishki Gustkraken
-11877465 1 --Evigishki Mind Augus
-89463537 1 --Nekroz of Unicore
-33508719 1 --Morphing Jar
-28985331 1 --Armageddon Knight
-14536035 1 --Dark Grepher
-69015963 1 --Cyber Stein
-16188701 1 --Lady Debug
-12958919 1 --Phantom Skyblaster
-18239909 1 --Ignister Prominence, the Blasting Dracoslayer 		EXTRA DECK MONSTERS
-17412721 1 --Elder Entity Norden
+57835716 1 --Orcust Harp Horror
+17412721 1 --Elder Entity Norden			EXTRA DECK MONSTERS
 43387895 1 --Supreme King Dragon Starving Venom
+15291624 1 --Thunder Dragon Colossus
 65536818 1 --Denglong, First of the Yang Zing
 25862681 1 --Ancient Fairy Dragon
 34086406 1 --Lavalval Chain
-54719828 1 --Number 16: Shock Master
+94677445 1 --Ib the World Chalice Justiciar
+63101919 1 --Tempest Magician
 18326736 1 --Tellarknight Ptolomaeus
-26692769 1 --The Phantom Knights of Rusty Bardiche
 81122844 1 --Wind-Up Carrier Zenmaity
-581014 1 --Daigusto Emeral
 48905153 1 --Zoodiac Drident
 85115440 1 --Zoodiac Broadbull
-63504681 1 --Number 86: Heroic Champion – Rhongomyniad
+54719828 1 --Number 16: Shock Master
 10389142 1 --Number 42: Galaxy Tomahawk
+63504681 1 --Number 86: Heroic Champion – Rhongomyniad
 58820923 1 --Number 95: Galaxy-Eyes Dark Matter Dragon
+34945480 1 --Outer Entity Azathot
+87327776 1 --Salamangreat Miragestallio
 39064822 1 --Knightmare Goblin
 4423206 1 --M-X-Saber Invoker
 5043010 1 --Firewall Dragon
+26692769 1 --The Phantom Knights of Rusty Bardiche
 22593417 1 --Topologic Gumblar Dragon
-48063985 1 --Ritual Beast Ulti-Cannahawk
-39512984 1 --Gem-Knight Master Diamond
-70583986 1 --Dewloren, Tiger King of the Ice Barrier
-27552504 1 --Beatrice, Lady of Eternal
-24094258 1 --Heavymetalfoes Electrumite
 61665245 1 --Summon Sorceress
-63288573 1 --Sky Striker Ace - Kagari
-74586817 1 --Psy-Framelord Omega
 3679218 1 --Knightmare Mermaid
 59537380 1 --Guardragon Agarpain
-14087893 1 --Book of Moon  										SPELLS CARDS
-81674782 1 --Dimensional Fissure
-95308449 1 --Final Countdown
-81439173 1 --Foolish Burial
-66957584 1 --Infernity Launcher
-33782437 1 --One Day of Peace
-2295440 1 --One for One
-12580477 1 --Raigeki
-32807846 1 --Reinforcement of the Army
-45305419 1 --Symbol of Heritage
-14733538 1 --Draco Face-off
-73468603 1 --Set Rotation
-58577036 1 --Reasoning
-27970830 1 --Gateway of the Six
-7394770 1 --Brilliant Fusion
-70368879 1 --Upstart Goblin
-83764718 1 --Monster Reborn
-83764719 1 --Monster Reborn
-52155219 1 --Salamangreat Circle
-24010609 1 --Sky Striker Mecha Modules - Multirole
-71344451 1 --Slash Draw
-35371948 1 --Trickstar Light Stage
-75500286 1 --Gold Sarcophagus
-67723438 1 --Emergency Teleporter
-22842126 1 --Pantheism of the Monarchs
-15854426 1 --Divine Wind of the Mist Valley
-54631665 1 --SPYRAL Resort
-71650854 1 --Magical Mid-Breaker Field
-91623717 1 --Chain Strike
-8949584 1 --A Hero Lives
-72892473 1 --Card Destruction
-52340444 1 --Sky Striker Mecha - Hornet Drones
-73915051 1 --Scapegoat
-69243953 1 --Butterfly Dagger - Elma
+24094258 1 --Heavymetalfoes Electrumite
+69243953 1 --Butterfly Dagger - Elma						SPELLS CARDS
 57953380 1 --Card of Safe Return
 4031928 1 --Change of Heart
 67616300 1 --Chicken Game
@@ -755,49 +687,126 @@
 85602018 1 --Last Will
 46411259 1 --Metamorphosis
 74191942 1 --Painful Choice
-67169062 1 --Pot of Avarice
+63166095 1 -Sky Striker Mobilize – Engage!
 55144522 1 --Pot of greed
 34906152 1 --Mass Driver
 41482598 1 --Mirage of Nightmare
+7394770 1 --Brilliant Fusion
 70828912 1 --Premature Burial
 45986603 1 --Snatch Steal
 46448938 1 --Spellbook of Judgement
-73628505 1 --Terraforming
-3298689 1 --The Phantom Knights' Rank-Up-Magic Launch
 42829885 1 --The Forceful Sentry
 11110587 1 --That Grass Looks Greener
 94220427 1 --Rank-Up-Magic Argent Chaos Force
 54447022 1 --Soul Charge
-98338152 1 --Sky Striker Mecha - Widow Anchor
-32723153 1 --Magical Explosion				--TRAP CARDS
-35125879 1 --True King's Return
-82732705 1 --Skill Drain
-73599290 1 --Soul Drain
-30241314 1 --Macro Cosmos
-17078030 1 --Wall of Revealing light
-84749824 1 --Solemn Warning
-28566710 1 --Last Turn
+28566710 1 --Last Turn											TRAPS CARDS
 27174286 1 --Return from the Different Dimension
 93016201 1 --Royal Oppression
 57585212 1 --Self-Destruct Button
 3280747 1 --Sixth Sense
-89208725 1 --Metaverse
 35316708 1 --Time Seal
 64697231 1 --Trap Dustshot
 80604091 1 --Ultimate Offering
 80604092 1 --Ultimate Offering
 5851097 1 --Vanity's Emptiness
-#Semi Limited TCG Traditional
-70711847 2 --Danger! Nessie!
+7902349 1 --Left Arm of the forbidden one						MAIN DECK MONSTERS
+44519536 1 --Left Leg of the forbidden one
+70903634 1 --Right Arm of the forbidden one
+8124921 1 --Right Leg of the forbidden one
+42790071 1 --Altergeist Multifaker
+61901281 1 --Black Dragon Collapserpent
+57143342 1 --Cir, Malebranche of the Burning Abyss
+33396948 1 --Exodia the Forbidden One
+64034255 1 --Genex Ally birdman
+20758643 1 --Graff, Malembrance of the Burning Abyss
+99177923 1 --Infernity Archfiend
+16226786 1 --Night Assailant
+88264978 1 --Red-Eyes Darkness Metal Dragon
+61740673 1 --Imperial Order
+89399912 1 --Tempest, Dragon Ruler of Storms
+26889158 1 --Salamangreat Gazelle
+81275020 1 --Speedroid Terrortop
+99234526 1 --White Dragon Wyverburster
+78872731 1 --Zoodiac Ratpier
+4474060 1 --SPYRAL Gear - Drone
+78080961 1 --SPYRAL Quik-Fix
+58984738 1 --Dinomight Knight, the True Dracofighter
+45222299 1 --Evigishki Gustkraken
+11877465 1 --Evigishki Mind Augus
+89463537 1 --Nekroz of Unicore
+33508719 1 --Morphing Jar
+28985331 1 --Armageddon Knight
+14536035 1 --Dark Grepher
+69015963 1 --Cyber Stein
+12958919 1 --Phantom Skyblaster
+70711847 1 --Danger! Nessie!
+82385847 1 --Dinowrestler Pankratops
+92559258 1 --Servant of Endymion
+30539496 1 --True King Lithosagym, the Disaster
+18239909 1 --Ignister Prominence, the Blasting Dracoslayer 		EXTRA DECK MONSTERS
+48063985 1 --Ritual Beast Ulti-Cannahawk
+39512984 1 --Gem-Knight Master Diamond
+70583986 1 --Dewloren, Tiger King of the Ice Barrier
+27552504 1 --Beatrice, Lady of Eternal
+581014 1 --Daigusto Emeral
+74586817 1 --Psy-Framelord Omega
+81674782 1 --Dimensional Fissure                                SPELL CARDS
+95308449 1 --Final Countdown
+81439173 1 --Foolish Burial
+66957584 1 --Infernity Launcher
+33782437 1 --One Day of Peace
+2295440 1 --One for One
+12580477 1 --Raigeki
+32807846 1 --Reinforcement of the Army
+52155219 1 --Salamangreat Circle
+24010609 1 --Sky Striker Mecha Modules - Multirole
+45305419 1 --Symbol of Heritage
+14733538 1 --Draco Face-off
+73468603 1 --Set Rotation
+73628505 1 --Terraforming
+35371948 1 --Trickstar Light Stage
+58577036 1 --Reasoning
+27970830 1 --Gateway of the Six
+70368879 1 --Upstart Goblin
+83764718 1 --Monster Reborn
+83764719 1 --Monster Reborn
+71344451 1 --Slash Draw
+75500286 1 --Gold Sarcophagus
+59750328 1 --Card of Demise
+93946239 1 --Into the Void
+67169062 1 --Pot of Avarice
+24940422 1 --Sekka's Light
+67723438 1 --Emergency Teleporter
+22842126 1 --Pantheism of the Monarchs
+15854426 1 --Divine Wind of the Mist Valley
+54631665 1 --SPYRAL Resort
+71650854 1 --Magical Mid-Breaker Field
+13035077 1 --Dragonic Diagram
+91623717 1 --Chain Strike
+8949584 1 --A Hero Lives
+72892473 1 --Card Destruction
+52340444 1 --Sky Striker Mecha - Hornet Drones
+73915051 1 --Scapegoat
+98338152 1 --Sky Striker Mecha - Widow Anchor
+32723153 1 --Magical Explosion			--TRAP CARDS
+35125879 1 --True King's Return
+82732705 1 --Skill Drain
+30241314 1 --Macro Cosmos
+89208725 1 --Metaverse
+17078030 1 --Wall of Revealing light
+23002292 1 --Red Reboot
+#Semi limited TCG
+10802915 2 --Tour Guide From the Underworld
+78868119 2 --Deep Sea Diva
 43694650 2 --Danger!? Jackalope?
 99745551 2 --Danger!? Tsuchinoko?
 28297833 2 --Necroface
-68819554 2 --Performage Damage Juggler
+37520316 2 --Mind Control
 !2020.01 Anime
 #Worlds entries
 #Forbidden Worlds
+57835716 0 --Orcust Harp Horror
 26692769 0 --The Phantom Knights of Rusty Bardiche
-51858306 0 --Eclipse Wyvern
 03078576 0 --Yata-Garasu
 05592689 0 --Samsara Lotus
 07563579 0 --Performage PlushFire
@@ -814,9 +823,7 @@
 23434538 0 --Maxx "C"
 23558733 0 --Phoenixian Cluster Amaryllis
 26400609 0 --Tidal, Dragon Ruler of Waterfalls
-30539496 0 --True King Lithosagym, the Disaster
 31178212 0 --Majespecter Unicorn - Kirin
-33184167 0 --Tribe-Infecting Virus
 34124316 0 --Cyber Jar
 34206604 0 --Magical Scientist
 40318957 0 --Performapal Skullcrobat Joker
@@ -826,7 +833,6 @@
 57421866 0 --Level Eater
 76794549 0 --Astrograph Sorcerer
 78706415 0 --Fiber Jar
-79106360 0 --Morphing Jar #2
 79875176 0 --Toon Cannon Soldier
 88071625 0 --The Tyrant Neptune
 90411554 0 --Redox, Dragon Ruler of Boulders
@@ -840,6 +846,11 @@
 88264978 0 --Red-Eyes Darkness Metal Dragon
 71525232 0 --Gandora-X the Dragon of Demolition
 51858306 0 --Eclipse Wyvern
+15291624 0 --Thunder Dragon Colossus
+24094258 0 --Heavymetalfoes Electrumite
+94677445 0 --Ib the World Chalice Justiciar
+63101919 0 --Tempest Magician
+87327776 0 --Salamangreat Miragestallio
 04423206 0 --M-X-Saber Invoker
 17412721 0 --Elder Entity Norden
 18326736 0 --Tellarknight Ptolomaeus
@@ -861,6 +872,8 @@
 85115440 0 --Zoodiac Broadbull
 63504681 0 --Number 86: Heroic Champion – Rhongomyniad
 10389142 0 --Number 42: Galaxy Tomahawk
+7394770 0 --Brilliant Fusion
+63166095 0 --Sky Striker Mobilize - Engage!
 04031928 0 --Change of Heart
 11110587 0 --That Grass Looks Greener
 17375316 0 --Confiscation
@@ -878,11 +891,9 @@
 31423101 0 --Divine Sword - Phoenix Blade
 46411259 0 --Metamorphosis
 46448938 0 --Spellbook of Judgement
-3298689 0 --The Phantom Knights' Rank-Up-Magic Launch
 55144522 0 --Pot of greed
 57953380 0 --Card of Safe Return
 60682203 0 --Cold Wave
-67169062 0 --Pot of Avarice
 67616300 0 --Chicken Game
 69243953 0 --Butterfly Dagger - Elma
 70828912 0 --Premature Burial
@@ -904,6 +915,10 @@
 80604092 0 --Ultimate Offering
 93016201 0 --Royal Oppression
 #Limited Worlds
+92559258 1 --Servant of Endymion
+30539496 1 --True King Lithosagym, the Disaster
+70711847 1 --Danger! Nessie!
+82385847 1 --Dinowrestler Pankratops
 00581014 1 --Daigusto Emeral
 61901281 1 --Black Dragon Collapserpent
 99234526 1 --White Dragon Wyverburster
@@ -911,7 +926,6 @@
 04474060 1 --SPYRAL Gear - Drone
 07902349 1 --Left Arm of the forbidden one
 08124921 1 --Right Leg of the forbidden one
-10802915 1 --Tour Guide From the Underworld
 11877465 1 --Evigishki Mind Augus
 16226786 1 --Night Assailant
 20758643 1 --Graff, Malembrance of the Burning Abyss
@@ -928,12 +942,10 @@
 26889158 1 --Salamangreat Gazelle
 83107873 1 --Thunder Dragonhawk
 64034255 1 --Genex Ally Birdman
-68819554 1 --Performage Damage Juggler
 69610326 1 --Supreme King Dragon Darkwurm
 70903634 1 --Right Arm of the forbidden one
 73941492 1 --Harmonizing Magician
 78080961 1 --SPYRAL Quik-Fix
-78868119 1 --Deep Sea Diva
 78872731 1 --Zoodiac Ratpier
 81275020 1 --Speedroid Terrortop
 89463537 1 --Nekroz of Unicore
@@ -945,26 +957,25 @@
 41386308 1 --Mathematician
 69015963 1 --Cyber Stein
 14536035 1 --Dark Grepher
-16188701 1 --Lady Debug
 12958919 1 --Phantom Skyblaster
 62706865 1 --Draconnet
 99234526 1 --White Dragon Wyverburster
 06602300 1 --Blaze Fenix, The Burning Bombardment Bird
 39512984 1 --Gem-Knight Master Diamond
-15291624 1 --Thunder Dragon Colossus
 28297833 1 --Necroface
 70583986 1 --Dewloren, Tiger King of the Ice Barrier
 74586817 1 --Psy-Framelord Omega
 18239909 1 --Ignister Prominence, the Blasting Dracoslayer 
 27552504 1 --Beatrice, Lady of Eternal
 48063985 1 --Ritual Beast Ulti-Cannahawk
-24094258 1 --Heavymetalfoes Electrumite
 50588353 1 --Crystron Needlefiber
 63288573 1 --Sky Striker Ace - Kagari
 74997493 1 --Saryuja Skull Dread
+93946239 1 --Into the Void
+24940422 1 --Sekka’s Light
+67169062 1 --Pot of Avarice
 02295440 1 --One for One
 08949584 1 --A Hero Lives
-14087893 1 --Book of Moon  
 14733538 1 --Draco Face-off
 15854426 1 --Divine Wind of the Mist Valley
 22842126 1 --Pantheism of the Monarchs
@@ -983,7 +994,6 @@
 54631665 1 --SPYRAL Resort
 58577036 1 --Reasoning
 66957584 1 --Infernity Launcher
-7394770 1 --Brilliant Fusion
 13035077 1 --Dragonic Diagram
 76375976 1 --Mystic Mine
 71344451 1 --Slash Draw
@@ -1010,34 +1020,29 @@
 61740673 1 --Imperial Order
 35125879 1 --True King's Return
 82732705 1 --Skill Drain
-73599290 1 --Soul Drain
 30241314 1 --Macro Cosmos
 17078030 1 --Wall of Revealing light
-84749824 1 --Solemn Warning
+23002292 1 --Red Reboot
 #Semi Limited Worlds
-70711847 2 --Danger! Nessie!
+16188701 2 --Lady Debug
+78868119 2 --Deep Sea Diva
+10802915 2 --Tour Guide From the Underworld
 43694650 2 --Danger!? Jackalope?
 99745551 2 --Danger!? Tsuchinoko?
 68819554 2 --Performage Damage Juggler
-65192027 2 --Dark Armed Dragon
 14558127 2 --Ash Blossom & Joyous Spring
-82385847 2 --Dinowrestler Pankratops
 61283655 2 --Trickstar Candina
 35272499 2 --Predaplant Ophrys Scorpio
 25533642 2 --Altergeist Meluseek
-57835716 2 --Orcust Harp Horror
 36042004 2 --Babycerasaurus
 41386308 2 --Mathematician
 89463537 2 --Nekroz of Unicore
 29596581 2 --Thunder Dragonroar
 30741503 2 --Galatea, the Orcusted Automaton
 47325505 2 --Fossil Dig
-63166095 2 --Sky Striker Mobilize - Engage!
 1475311 2 --Allure of Darkness
-37520316 2 --Mind Control
 48130397 2 --Super Polymerization
 53936268 2 --Personal Spoofing
-23002292 2 --Red Reboot
 #Anime entries
 #Forbidden Anime
 110000110 0 --Big Bang Blow
@@ -1369,196 +1374,3 @@
 511002878 2 --Gagaga Academy Emergency Network (Anime)
 21715135 2 --Gagaga Academy Emergency Network (Anime) (OCG Alias)
 511003002 2 --Dis-swing Fusion
-!2020.01 TCG
-#Forbidden TCG
-53804307 0 --Blaster, Dragon Ruler of Infernos			MAIN DECK MONSTERS
-34124316 0 --Cyber Jar
-8903700 0 --Djinn Releaser of Rituals
-51858306 0 --Eclipse Wyvern
-78706415 0 --Fiber Jar
-93369354 0 --Fishborg Blaster
-34206604 0 --Magical Scientist
-31178212 0 --Majespecter Unicorn - Kirin
-21593977 0 --Makyura the Destructor
-96782886 0 --Mind Master
-7563579 0 --Performage PlushFire
-17330916 0 --Performapal Monkeyboard
-90411554 0 --Redox, Dragon Ruler of Boulders
-20663556 0 --Substitoad
-88071625 0 --The Tyrant Neptune
-26400609 0 --Tidal, Dragon Ruler of Waterfalls
-44910027 0 --Victory Dragon
-3078576 0 --Yata-Garasu
-9929398 0 --Blackwing - Gofu the Vague Shadow
-15341821 0 --Dandylion
-49684352 0 --Double Iris Magician
-40318957 0 --Performapal Skullcrobat Joker
-57421866 0 --Level Eater
-23434538 0 --Maxx "C"
-76794549 0 --Astrograph Sorcerer
-21377582 0 --Master Peace, The True Dracoslaying King
-23558733 0 --Phoenixian Cluster Amaryllis
-5592689 0 --Samsara Lotus
-75732622 0 --Grinder Golem
-55623480 0 --Fairy Tail – Snow
-57835716 0 --Orcust Harp Horror
-17412721 0 --Elder Entity Norden			EXTRA DECK MONSTERS
-43387895 0 --Supreme King Dragon Starving Venom
-15291624 0 --Thunder Dragon Colossus
-65536818 0 --Denglong, First of the Yang Zing
-25862681 0 --Ancient Fairy Dragon
-34086406 0 --Lavalval Chain
-94677445 0 --Ib the World Chalice Justiciar
-63101919 0 --Tempest Magician
-18326736 0 --Tellarknight Ptolomaeus
-81122844 0 --Wind-Up Carrier Zenmaity
-48905153 0 --Zoodiac Drident
-85115440 0 --Zoodiac Broadbull
-54719828 0 --Number 16: Shock Master
-10389142 0 --Number 42: Galaxy Tomahawk
-63504681 0 --Number 86: Heroic Champion – Rhongomyniad
-58820923 0 --Number 95: Galaxy-Eyes Dark Matter Dragon
-34945480 0 --Outer Entity Azathot
-87327776 0 --Salamangreat Miragestallio
-39064822 0 --Knightmare Goblin
-4423206 0 --M-X-Saber Invoker
-5043010 0 --Firewall Dragon
-26692769 0 --The Phantom Knights of Rusty Bardiche
-22593417 0 --Topologic Gumblar Dragon
-61665245 0 --Summon Sorceress
-3679218 0 --Knightmare Mermaid
-59537380 0 --Guardragon Agarpain
-24094258 0 --Heavymetalfoes Electrumite
-69243953 0 --Butterfly Dagger - Elma						SPELLS CARDS
-57953380 0 --Card of Safe Return
-4031928 0 --Change of Heart
-67616300 0 --Chicken Game
-60682203 0 --Cold Wave
-17375316 0 --Confiscation
-44763025 0 --Deliquent Duo
-23557835 0 --Dimension Fusion
-42703248 0 --Giant Trunade
-79571449 0 --Graceful Charity
-18144507 0 --Harpie's Feather Duster
-18144506 0 --Harpie's Feather Duster
-35059553 0 --Kaiser Colloseum
-19613556 0 --Heavy Storm
-85602018 0 --Last Will
-46411259 0 --Metamorphosis
-74191942 0 --Painful Choice
-63166095 0 -Sky Striker Mobilize – Engage!
-55144522 0 --Pot of greed
-34906152 0 --Mass Driver
-41482598 0 --Mirage of Nightmare
-7394770 0 --Brilliant Fusion
-70828912 0 --Premature Burial
-45986603 0 --Snatch Steal
-46448938 0 --Spellbook of Judgement
-42829885 0 --The Forceful Sentry
-11110587 0 --That Grass Looks Greener
-94220427 0 --Rank-Up-Magic Argent Chaos Force
-54447022 0 --Soul Charge
-28566710 0 --Last Turn											TRAPS CARDS
-27174286 0 --Return from the Different Dimension
-93016201 0 --Royal Oppression
-57585212 0 --Self-Destruct Button
-3280747 0 --Sixth Sense
-35316708 0 --Time Seal
-64697231 0 --Trap Dustshot
-80604091 0 --Ultimate Offering
-80604092 0 --Ultimate Offering
-5851097 0 --Vanity's Emptiness
-#Limited TCG					
-7902349 1 --Left Arm of the forbidden one						MAIN DECK MONSTERS
-44519536 1 --Left Leg of the forbidden one
-70903634 1 --Right Arm of the forbidden one
-8124921 1 --Right Leg of the forbidden one
-42790071 1 --Altergeist Multifaker
-61901281 1 --Black Dragon Collapserpent
-57143342 1 --Cir, Malebranche of the Burning Abyss
-33396948 1 --Exodia the Forbidden One
-64034255 1 --Genex Ally birdman
-20758643 1 --Graff, Malembrance of the Burning Abyss
-99177923 1 --Infernity Archfiend
-16226786 1 --Night Assailant
-88264978 1 --Red-Eyes Darkness Metal Dragon
-61740673 1 --Imperial Order
-89399912 1 --Tempest, Dragon Ruler of Storms
-26889158 1 --Salamangreat Gazelle
-81275020 1 --Speedroid Terrortop
-99234526 1 --White Dragon Wyverburster
-78872731 1 --Zoodiac Ratpier
-4474060 1 --SPYRAL Gear - Drone
-78080961 1 --SPYRAL Quik-Fix
-58984738 1 --Dinomight Knight, the True Dracofighter
-45222299 1 --Evigishki Gustkraken
-11877465 1 --Evigishki Mind Augus
-89463537 1 --Nekroz of Unicore
-33508719 1 --Morphing Jar
-28985331 1 --Armageddon Knight
-14536035 1 --Dark Grepher
-69015963 1 --Cyber Stein
-12958919 1 --Phantom Skyblaster
-70711847 1 --Danger! Nessie!
-82385847 1 --Dinowrestler Pankratops
-92559258 1 --Servant of Endymion
-30539496 1 --True King Lithosagym, the Disaster
-18239909 1 --Ignister Prominence, the Blasting Dracoslayer 		EXTRA DECK MONSTERS
-48063985 1 --Ritual Beast Ulti-Cannahawk
-39512984 1 --Gem-Knight Master Diamond
-70583986 1 --Dewloren, Tiger King of the Ice Barrier
-27552504 1 --Beatrice, Lady of Eternal
-581014 1 --Daigusto Emeral
-74586817 1 --Psy-Framelord Omega
-81674782 1 --Dimensional Fissure                                SPELL CARDS
-95308449 1 --Final Countdown
-81439173 1 --Foolish Burial
-66957584 1 --Infernity Launcher
-33782437 1 --One Day of Peace
-2295440 1 --One for One
-12580477 1 --Raigeki
-32807846 1 --Reinforcement of the Army
-52155219 1 --Salamangreat Circle
-24010609 1 --Sky Striker Mecha Modules - Multirole
-45305419 1 --Symbol of Heritage
-14733538 1 --Draco Face-off
-73468603 1 --Set Rotation
-73628505 1 --Terraforming
-35371948 1 --Trickstar Light Stage
-58577036 1 --Reasoning
-27970830 1 --Gateway of the Six
-70368879 1 --Upstart Goblin
-83764718 1 --Monster Reborn
-83764719 1 --Monster Reborn
-71344451 1 --Slash Draw
-75500286 1 --Gold Sarcophagus
-59750328 1 --Card of Demise
-93946239 1 --Into the Void
-67169062 1 --Pot of Avarice
-24940422 1 --Sekka's Light
-67723438 1 --Emergency Teleporter
-22842126 1 --Pantheism of the Monarchs
-15854426 1 --Divine Wind of the Mist Valley
-54631665 1 --SPYRAL Resort
-71650854 1 --Magical Mid-Breaker Field
-13035077 1 --Dragonic Diagram
-91623717 1 --Chain Strike
-8949584 1 --A Hero Lives
-72892473 1 --Card Destruction
-52340444 1 --Sky Striker Mecha - Hornet Drones
-73915051 1 --Scapegoat
-98338152 1 --Sky Striker Mecha - Widow Anchor
-32723153 1 --Magical Explosion			--TRAP CARDS
-35125879 1 --True King's Return
-82732705 1 --Skill Drain
-30241314 1 --Macro Cosmos
-89208725 1 --Metaverse
-17078030 1 --Wall of Revealing light
-23002292 1 --Red Reboot
-#Semi limited TCG
-10802915 2 --Tour Guide From the Underworld
-78868119 2 --Deep Sea Diva
-43694650 2 --Danger!? Jackalope?
-99745551 2 --Danger!? Tsuchinoko?
-28297833 2 --Necroface
-37520316 2 --Mind Control

--- a/lflist.conf
+++ b/lflist.conf
@@ -1128,7 +1128,8 @@
 62499965 0 --Z-ONE (Anime) (OCG Alias)
 511000333 0 --Quick Rush
 511000381 0 --Wonder Cloud
-511000429 0 --Gold Moon Coin
+511000429 0 --Gold Moon Coin (Anime)
+43528009 0 --Gold Moon Coin (Anime) (OCG Alias)
 511000471 0 --Drawber
 511000474 0 --Riryoku (Anime)
 34016756 0 --Riryoku (Anime) (OCG Alias)
@@ -1154,7 +1155,8 @@
 511001142 0 --Roll of Fate
 511001149 0 --Card of Demise (Anime)
 59750328 0 --Card of Demise (Anime) (OCG Alias)
-511001417 0 --Water of Life
+511001417 0 --Water of Life (Anime)
+7133305 0 --Water of Life (Anime) (OCG Alias)
 511001582 0 --Performance Mage Hurricane
 511001611 0 --Numbers Evaille
 511001627 0 --Galaxy Journey
@@ -1236,7 +1238,8 @@
 511002601 0 --Hand Destruction (Anime)
 74519184 0 --Hand Destruction (Anime) (OCG Alias)
 511002754 0 --Spirit Foresight
-513000011 0 --Burning Soul
+513000011 0 --Burning Soul (Anime)
+10723472 0 --Burning Soul (Anime) (OCG Alias)
 810000034 0 --Multiply (Anime)
 40703222 0 --Multiply (Anime) (OCG Alias)
 513000131 0 --Domain of the Dark Ruler
@@ -1259,7 +1262,8 @@
 511000773 0 --Traitor Fog
 511000907 0 --Compulsory Recoil Device
 511001119 0 --Deck Destruction Virus
-511002267 0 --Graveyard of Wandering Souls
+511002267 0 --Graveyard of Wandering Souls (Anime)
+98596596 0 --Graveyard of Wandering Souls (Anime) (OCG Alias)
 513000077 0 --Beast-borg Medal of the Crimson Chain
 513000111 0 --Final Attack Orders (Anime)
 52503575 0 --Final Attack Orders (Anime) (OCG Alias)
@@ -1340,13 +1344,15 @@
 511001642 1 --Synchro Alliance
 511003083 1 --Scrap-Iron Pitfall
 513000091 1 --Jurassic Impact (Anime)
-511000036 1 --Jurassic Impact (Anime) (OCG Alias)
+511000036 1 --Jurassic Impact (TF3)
+65430834 1 --Jurassic Impact (Anime) (OCG Alias)
 511001583 1 --Mage's Fortress
 511001802 1 --Fake Friendship Treaty
 #semi-limited anime
 344000000 2 --Garbage Lord (Anime)
 44682448 2 --Garbage Lord (Anime) (OCG Alias)
-511001945 2 --Battlewasp - Twinbow the Attacker
+511001945 2 --Battlewasp - Twinbow the Attacker (Anime)
+54772065 2 --Battlewasp - Twinbow the Attacker (Anime) (OCG Alias)
 511005044 2 --Giant Kra-Corn
 810000022 2 --Zeta Reticulant (Anime)
 64382839 2 --Zeta Reticulant (Anime) (OCG Alias)


### PR DESCRIPTION
Affected cards:
Gold Moon Coin
Water of Life
Burning Soul
Graveyard of Wandering Souls
Jurassic Impact
Battlewasp - Twinbow the Attacker