### PR TITLE
Fix "Shaddoll Ruq"

### DIFF
--- a/script/c101101076.lua
+++ b/script/c101101076.lua
@@ -37,6 +37,10 @@ function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
 		s.sptg(e,tp,eg,ep,ev,re,r,rp,1)
 		if not GhostBelleTable then GhostBelleTable={} end
 		table.insert(GhostBelleTable,e)
+	else
+		e:SetCategory(0)
+		e:SetOperation(nil)
+		if GhostBelleTable then table.remove(GhostBelleTable,e) end
 	end
 end
 function s.spcon(e,tp,eg,ep,ev,re,r,rp)


### PR DESCRIPTION
Previously the effect to Fusion Summon when you activated the card was "saved" to the effect that activates (and you choose to use it), which let it be able to have the player try to Fusion Summon at inappropriate times, or even if there is nothing to Fusion Summon for.