### PR TITLE
Small fix "Guardian Dreadscythe"

### DIFF
--- a/script/c18175965.lua
+++ b/script/c18175965.lua
@@ -101,7 +101,7 @@ function s.spcon2(e,tp,eg,ep,ev,re,r,rp)
 	return e:GetHandler():IsPreviousLocation(LOCATION_ONFIELD)
 end
 function s.sptg2(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return e:GetHandler():IsStatus(STATUS_PROC_COMPLETE) end
+	if chk==0 then return true end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_HANDES,0,0,tp,1)
 end
@@ -109,7 +109,7 @@ function s.spop2(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
 	if Duel.DiscardHand(tp,nil,1,1,REASON_EFFECT)~=0 then
 		local ct=Duel.GetOperatedGroup():FilterCount(Card.IsLocation,nil,LOCATION_GRAVE)
-		if ct>0 and c:IsRelateToEffect(e) then
+		if ct>0 and c:IsRelateToEffect(e) and c:IsStatus(STATUS_PROC_COMPLETE) then
 			Duel.SpecialSummon(c,0,tp,tp,true,true,POS_FACEUP)
 		end
 	end


### PR DESCRIPTION
Now the last (mandatory) trigger effect activates even if the card cannot be Special Summoned.