### PR TITLE
Fix "Dragunity Knight - Luin"

### DIFF
--- a/script/c12496261.lua
+++ b/script/c12496261.lua
@@ -1,5 +1,5 @@
 --ドラグニティナイト－ハールーン
---Dragunity Knight – Harloon 
+--Dragunity Knight – Luin
 local s,id=GetID()
 function s.initial_effect(c)
 	--synchro summon
@@ -80,7 +80,7 @@ function s.eqop2(e,tp,eg,ep,ev,re,r,rp)
 		e1:SetType(EFFECT_TYPE_SINGLE)
 		e1:SetCode(EFFECT_EQUIP_LIMIT)
 		e1:SetProperty(EFFECT_FLAG_CANNOT_DISABLE)
-		e1:SetValue(s.eqlimit2)
+		e1:SetValue(true)
 		e1:SetReset(RESET_EVENT+RESETS_STANDARD)
 		c:RegisterEffect(e1)
 		--equip effect
@@ -95,8 +95,3 @@ function s.eqop2(e,tp,eg,ep,ev,re,r,rp)
 		c:RegisterEffect(e3)
 	end
 end
-function s.eqlimit2(e,c)
-	local tp=e:GetHandlerPlayer()
-	return c:IsControler(tp)
-end
-


### PR DESCRIPTION
When the Equipped monster switch control, the Dragunity Knight - Luin should stay equipped.