### PR TITLE
Fix "Tailor of the Fickle"

### DIFF
--- a/script/c43641473.lua
+++ b/script/c43641473.lua
@@ -1,0 +1,44 @@
+--移り気な仕立屋
+--Tailor of the Fickle
+local s,id=GetID()
+function s.initial_effect(c)
+	--effect
+	local e1=Effect.CreateEffect(c)
+	e1:SetCategory(CATEGORY_EQUIP)
+	e1:SetType(EFFECT_TYPE_ACTIVATE)
+	e1:SetProperty(EFFECT_FLAG_CARD_TARGET)
+	e1:SetHintTiming(0,TIMING_EQUIP)
+	e1:SetCode(EVENT_FREE_CHAIN)
+	e1:SetTarget(s.target)
+	e1:SetOperation(s.operation)
+	c:RegisterEffect(e1)
+end
+function s.tcfilter(tc,ec)
+	return tc:IsFaceup() and ec:CheckEquipTarget(tc)
+end
+function s.ecfilter(c)
+	return c:IsType(TYPE_EQUIP) and (not c:IsOriginalType(TYPE_MONSTER) or c:IsOriginalType(TYPE_UNION)) and c:GetEquipTarget()~=nil and Duel.IsExistingTarget(s.tcfilter,0,LOCATION_MZONE,LOCATION_MZONE,1,c:GetEquipTarget(),c)
+end
+function s.target(e,tp,eg,ep,ev,re,r,rp,chk,chkc)
+	if chkc then return false end
+	if chk==0 then return Duel.IsExistingTarget(s.ecfilter,tp,LOCATION_SZONE,LOCATION_SZONE,1,nil) end
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(id,0))
+	local g=Duel.SelectTarget(tp,s.ecfilter,tp,LOCATION_SZONE,LOCATION_SZONE,1,1,nil)
+	local ec=g:GetFirst()
+	e:SetLabelObject(ec)
+	Duel.Hint(HINT_SELECTMSG,tp,aux.Stringid(id,1))
+	local tc=Duel.SelectTarget(tp,s.tcfilter,tp,LOCATION_MZONE,LOCATION_MZONE,1,1,ec:GetEquipTarget(),ec)
+end
+function s.operation(e,tp,eg,ep,ev,re,r,rp)
+	local ec=e:GetLabelObject()
+	local g=Duel.GetChainInfo(0,CHAININFO_TARGET_CARDS)
+	local tc=g:GetFirst()
+	if tc==ec then tc=g:GetNext() end
+	if ec:IsFaceup() and ec:IsRelateToEffect(e) then 
+		if tc:IsFaceup() and tc:IsRelateToEffect(e) then
+			Duel.Equip(tp,ec,tc)
+		else 
+			Duel.SendtoGrave(ec,REASON_EFFECT) 
+		end
+	end
+end


### PR DESCRIPTION
Tailor of the Fickle shouldn't be able to change the equip target of a monster treated as an equip card except if the monster is a union monster