### PR TITLE
Updated "Eldlich the Golden Lord"

### DIFF
--- a/script/c100414027.lua
+++ b/script/c100414027.lua
@@ -60,7 +60,6 @@ end
 function s.thtg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return e:GetHandler():IsAbleToHand() end
 	Duel.SetOperationInfo(0,CATEGORY_TOHAND,e:GetHandler(),1,0,0)
-	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,nil,1,tp,LOCATION_HAND)
 end
 function s.spfilter(c,e,tp)
 	return c:IsRace(RACE_ZOMBIE) and c:IsCanBeSpecialSummoned(e,0,tp,false,false)


### PR DESCRIPTION
Second effect was being marked as though the player had special summoned monster (if even they didn't). Matters for interactions like Summon Limit, Pot of Duality, etc.