### PR TITLE
Updated "Machina" union monsters

### DIFF
--- a/script/c42940404.lua
+++ b/script/c42940404.lua
@@ -1,7 +1,9 @@
 --マシンナーズ・ギアフレーム
+--Machina Gearframe
+
 local s,id=GetID()
 function s.initial_effect(c)
-	aux.AddUnionProcedure(c,aux.FilterBoolFunction(Card.IsRace,RACE_MACHINE),true,false)
+	aux.AddUnionProcedure(c,aux.FilterBoolFunction(Card.IsRace,RACE_MACHINE),false)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,2))

--- a/script/c78349103.lua
+++ b/script/c78349103.lua
@@ -1,7 +1,9 @@
 --マシンナーズ・ピースキーパー
+--Machina Peacekeeper
+
 local s,id=GetID()
 function s.initial_effect(c)
-	aux.AddUnionProcedure(c,aux.FilterBoolFunction(Card.IsRace,RACE_MACHINE),true,false)
+	aux.AddUnionProcedure(c,aux.FilterBoolFunction(Card.IsRace,RACE_MACHINE),false)
 	--search
 	local e1=Effect.CreateEffect(c)
 	e1:SetDescription(aux.Stringid(id,2))


### PR DESCRIPTION
Updated the following cards from SR10 with the current union monster text (monsters aren't restricted to 1 union monster at a time).
* Machina Peacekeeper
* Machina Gearframe