### PR TITLE
Updated "The Everglorious Golden Land"

### DIFF
--- a/script/c56984514.lua
+++ b/script/c56984514.lua
@@ -15,8 +15,11 @@ function s.initial_effect(c)
 	e1:SetOperation(s.activate)
 	c:RegisterEffect(e1)
 end
+function s.cfilter(c)
+	return c:IsFaceup() and c:IsSetCard(0x142)
+end
 function s.condition(e,tp,eg,ep,ev,re,r,rp)
-	return Duel.IsExistingMatchingCard(Card.IsSetCard,tp,LOCATION_ONFIELD,0,1,nil,0x142)
+	return Duel.IsExistingMatchingCard(s.cfilter,tp,LOCATION_MZONE,0,1,nil)
 		and (re:IsActiveType(TYPE_MONSTER) or re:IsHasType(EFFECT_TYPE_ACTIVATE)) and Duel.IsChainNegatable(ev)
 end
 function s.cost(e,tp,eg,ep,ev,re,r,rp,chk)


### PR DESCRIPTION
Should only be able to activate it if the player controls a face-up "Eldlich" monster.